### PR TITLE
fix: Add build number offset for Google Play version code

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
           ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
         run: |
           flutter build appbundle --release \
-            --build-number=${{ github.run_number }}
+            --build-number=$(( ${{ github.run_number }} + 28 ))
 
       - name: Upload AAB artifact
         uses: actions/upload-artifact@v4
@@ -87,7 +87,7 @@ jobs:
           ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
         run: |
           flutter build apk --release \
-            --build-number=${{ github.run_number }}
+            --build-number=$(( ${{ github.run_number }} + 28 ))
 
       - name: Rename APK
         run: mv build/app/outputs/flutter-apk/app-release.apk build/app/outputs/flutter-apk/localnode-android.apk


### PR DESCRIPTION
## Summary
- ワークフローファイル名変更(`android-release.yml` → `release.yml`)により `github.run_number` が1にリセットされ、Google Playで version code 重複エラーが発生していた
- 旧ワークフローの最終 run_number(28)をオフセットとして加算し、version code の連続性を維持

## Test plan
- [ ] GitHub Actions で release ワークフローが正常に実行されること
- [ ] Google Play への AAB アップロードが version code エラーなく成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)