### PR TITLE
fix: Restore selected shared folder path on app restart

### DIFF
--- a/lib/server_service.dart
+++ b/lib/server_service.dart
@@ -1257,6 +1257,29 @@ class ServerService {
       print('Loaded persisted SAF Directory URI: $_safDirectoryUri');
       // ここでネイティブ側にもURIを渡し、アクセス権を再確認させるなどの処理が必要になる可能性
     }
+
+    // iOS/Desktop: 永続化されたディレクトリパスを読み込む
+    if (!Platform.isAndroid) {
+      final savedPath = prefs.getString('selected_directory_path');
+      if (savedPath != null) {
+        final dir = Directory(savedPath);
+        if (await dir.exists()) {
+          _fallbackStoragePath = savedPath;
+          if (Platform.isIOS) {
+            final packageInfo = await PackageInfo.fromPlatform();
+            final docDir = await getApplicationDocumentsDirectory();
+            _displayPath = _getIosDisplayPath(savedPath, packageInfo.appName, docDir.path);
+          } else {
+            _displayPath = savedPath;
+          }
+          print('Loaded persisted directory path: $savedPath');
+        } else {
+          // 保存されたフォルダが存在しない場合は設定をクリア
+          await prefs.remove('selected_directory_path');
+          print('Persisted directory no longer exists, reverted to default: $savedPath');
+        }
+      }
+    }
   }
 
   /// フォルダを開く


### PR DESCRIPTION
## Summary
- 選択した共有フォルダのパスがアプリ再起動後にデフォルト（Documents/localnode）に戻る不具合を修正
- `loadPersistedSafUri()` を拡張し、iOS/Desktop で保存済みの `selected_directory_path` を起動時に読み込むようにした
- 保存されたフォルダが削除されていた場合はデフォルトにフォールバック

Closes #51

## Test plan
- [ ] Android/Windows でフォルダを選択 → アプリ再起動 → 選択したフォルダが維持されていること
- [ ] 保存されたフォルダを削除した場合、デフォルトにフォールバックすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)