### PR TITLE
fix: Update display path on Android SAF folder selection

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -129,7 +129,7 @@ class ServerNotifier extends Notifier<ServerState> {
     state = state.copyWith(
       availableIpAddresses: ips,
       selectedIpAddress: ips.isNotEmpty ? ips.first : null,
-      storagePath: _serverService.documentsPath,
+      storagePath: _serverService.displayPath ?? _serverService.documentsPath,
     );
   }
 
@@ -192,7 +192,7 @@ class ServerNotifier extends Notifier<ServerState> {
   Future<void> selectSafDirectory() async {
     if (kIsWeb) return;
     await _serverService.selectSafDirectory();
-    state = state.copyWith(storagePath: _serverService.documentsPath);
+    state = state.copyWith(storagePath: _serverService.displayPath ?? _serverService.documentsPath);
   }
 
   Future<void> start(int port) async {


### PR DESCRIPTION
## Summary
- Android SAF でフォルダ選択時に表示パスが更新されない問題を修正
- SAF URI から人間が読めるパスを生成する `_getAndroidSafDisplayPath()` を追加
- アプリ再起動時にも Android の表示パスを復元するようにした
- `main.dart` の `storagePath` 参照を `displayPath` 優先に変更

Closes #51

## Test plan
- [ ] Android でフォルダを選択 → UIに選択したフォルダパスが表示されること
- [ ] Android でアプリ再起動 → 選択したフォルダが維持されていること
- [ ] Windows/iOS で既存動作に影響がないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)