### PR TITLE
fix: Preserve selected folder across server stop/start on Android

### DIFF
--- a/lib/server_service.dart
+++ b/lib/server_service.dart
@@ -1194,7 +1194,6 @@ class ServerService {
     _ipAddress = null;
     _port = null;
     _pin = null;
-    _displayPath = null;
     _sessions.clear();
     _failedAttempts.clear();
     _lockoutUntil.clear();


### PR DESCRIPTION
## Summary
- `stopServer()` で `_displayPath` を null にリセットしていたため、Android でサーバー停止後にフォルダ選択が消える問題を修正
- Android は SAF を使うため `_fallbackStoragePath` ではなく `_displayPath` にのみ選択結果が保持されていた

Closes #51

## Test plan
- [ ] Android でフォルダ選択 → サーバー起動 → 停止 → 選択フォルダが維持されていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)