### PR TITLE
fix: Show folder path dialog on Android instead of file manager

### DIFF
--- a/lib/server_service.dart
+++ b/lib/server_service.dart
@@ -1321,13 +1321,9 @@ class ServerService {
         // Linux: xdg-openで開く
         await Process.run('xdg-open', [storagePath]);
         return true;
-      } else if (Platform.isAndroid) {
-        // Android: MethodChannel経由でファイルマネージャーを開く
-        final String? uriToOpen = _safDirectoryUri ?? storagePath;
-        await _folderPlatform.invokeMethod('openFolder', {'path': uriToOpen});
-        return true;
-      } else if (Platform.isIOS) {
-        // iOS: 制限があるため、falseを返してダイアログ表示を促す
+      } else if (Platform.isAndroid || Platform.isIOS) {
+        // Android/iOS: SAFやサンドボックスの制限により直接フォルダを開けないため、
+        // falseを返してダイアログ表示を促す
         return false;
       }
     } on PlatformException catch (e) {


### PR DESCRIPTION
## Summary
- Android の「フォルダを開く」でファイルマネージャーが起動するが、SAF URI の制限で対象フォルダを開けない問題に対応
- iOS と同様にダイアログでパスを表示する方式に統一

Relates to #37

## Test plan
- [ ] Android でフォルダを開くボタン → ダイアログでパスが表示されること
- [ ] iOS の動作に影響がないこと
- [ ] Windows/Linux/macOS では引き続きファイルマネージャーが開くこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)