### PR TITLE
fix: ARM64 Flutter manual install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,12 +174,13 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y ninja-build libgtk-3-dev
 
-      - name: Set up Flutter
-        uses: subosito/flutter-action@v2
-        with:
-          flutter-version: '3.38.5'
-          channel: 'stable'
-          cache: true
+      - name: Set up Flutter (ARM64 manual install)
+        run: |
+          git clone https://github.com/flutter/flutter.git --depth 1 -b stable $HOME/flutter
+          echo "$HOME/flutter/bin" >> $GITHUB_PATH
+
+      - name: Flutter precache
+        run: flutter precache --linux
 
       - run: flutter pub get
 


### PR DESCRIPTION
## Summary
- ARM64 Linux ビルドで `subosito/flutter-action@v2` が Flutter SDK を解決できない問題を修正
- `git clone` による手動インストールに変更（macOS `ci_post_clone.sh` と同じアプローチ）

## Test plan
- [ ] ARM64 Linux ビルドが正常に完了すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)