### PR TITLE
fix: Fix unified ci_post_clone.sh for Xcode Cloud

### DIFF
--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+# エラーが発生したら即座に停止するように設定
+set -e
+
+# 1. Flutter SDKのクローン
+git clone https://github.com/flutter/flutter.git --depth 1 -b stable $HOME/flutter
+export PATH="$PATH:$HOME/flutter/bin"
+
+# 2. プロジェクトルートに戻る（ci_scripts/ から1階層上）
+cd ..
+
+# 3. Flutter設定
+flutter config --enable-macos-desktop
+flutter precache --ios --macos
+flutter pub get
+
+# 4. CocoaPodsのインストール
+if ! command -v pod &> /dev/null; then
+    sudo gem install cocoapods
+fi
+
+# 5. プラットフォーム別にpod install
+if [ -d "ios" ]; then
+    cd ios
+    pod install
+    cd ..
+fi
+
+if [ -d "macos" ]; then
+    cd macos
+    pod install
+    cd ..
+fi


### PR DESCRIPTION
## Summary
- プロジェクトルートに統合ci_scriptsを配置（Xcode Cloud仕様対応）
- `--enable-macos-desktop` のtypo修正
- `cd ..` のスペース欠落修正
- ci_scriptsからプロジェクトルートへの `cd ..` を追加

## Test plan
- [ ] Xcode Cloud iOS ワークフローでビルド成功を確認
- [ ] Xcode Cloud macOS ワークフローでビルド成功を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)