### PR TITLE
fix: Add CocoaPods config and CI script logging

### DIFF
--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -3,6 +3,11 @@
 # エラーが発生したら即座に停止するように設定
 set -e
 
+echo "=========================================="
+echo "[CI_SCRIPTS] ROOT ci_scripts/ci_post_clone.sh"
+echo "[CI_SCRIPTS] PWD: $(pwd)"
+echo "=========================================="
+
 # 1. Flutter SDKのクローン
 git clone https://github.com/flutter/flutter.git --depth 1 -b stable $HOME/flutter
 export PATH="$PATH:$HOME/flutter/bin"

--- a/ios/ci_scripts/ci_post_clone.sh
+++ b/ios/ci_scripts/ci_post_clone.sh
@@ -3,6 +3,11 @@
 # エラーが発生したら即座に停止するように設定
 set -e
 
+echo "=========================================="
+echo "[CI_SCRIPTS] ios/ci_scripts/ci_post_clone.sh"
+echo "[CI_SCRIPTS] PWD: $(pwd)"
+echo "=========================================="
+
 # 1. Flutter SDKのクローン
 git clone https://github.com/flutter/flutter.git --depth 1 -b stable $HOME/flutter
 export PATH="$PATH:$HOME/flutter/bin"

--- a/macos/Runner/Configs/AppInfo.xcconfig
+++ b/macos/Runner/Configs/AppInfo.xcconfig
@@ -4,6 +4,11 @@
 // future. If not, the values below would default to using the project name when this becomes a
 // 'flutter create' template.
 
+// CocoaPods configuration
+#include? "../../Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
+#include? "../../Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
+#include? "../../Pods/Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"
+
 // The application's name. By default this is also the title of the Flutter window.
 PRODUCT_NAME = LocalNode
 

--- a/macos/ci_scripts/ci_post_clone.sh
+++ b/macos/ci_scripts/ci_post_clone.sh
@@ -3,6 +3,11 @@
 # エラーが発生したら即座に停止するように設定
 set -e
 
+echo "=========================================="
+echo "[CI_SCRIPTS] macos/ci_scripts/ci_post_clone.sh"
+echo "[CI_SCRIPTS] PWD: $(pwd)"
+echo "=========================================="
+
 # 1. Flutter SDKのクローン
 git clone https://github.com/flutter/flutter.git --depth 1 -b stable $HOME/flutter
 export PATH="$PATH:$HOME/flutter/bin"


### PR DESCRIPTION
## Summary
- macOS `AppInfo.xcconfig` に Pods の xcconfig を include して CocoaPods base configuration 警告を解消
- 3つの `ci_post_clone.sh` にログ出力を追加し、Xcode Cloud でどのスクリプトが実行されるか特定可能に

## Test plan
- [ ] Xcode Cloud iOS ビルドのログで `[CI_SCRIPTS]` を確認
- [ ] Xcode Cloud macOS ビルドのログで `[CI_SCRIPTS]` を確認
- [ ] CocoaPods の base configuration 警告が消えていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)