### PR TITLE
fix: Generate ephemeral xcfilelist for macOS build

### DIFF
--- a/macos/ci_scripts/ci_post_clone.sh
+++ b/macos/ci_scripts/ci_post_clone.sh
@@ -19,6 +19,9 @@ flutter config --enable-macos-desktop
 flutter precache --macos
 flutter pub get
 
+# ephemeral ファイル（FlutterInputs.xcfilelist等）を生成
+flutter build macos --config-only
+
 # 3. CocoaPodsのインストール
 if ! command -v pod &> /dev/null; then
     sudo gem install cocoapods


### PR DESCRIPTION
## Summary
- macOS CIスクリプトに `flutter build macos --config-only` を追加
- `FlutterInputs.xcfilelist` / `FlutterOutputs.xcfilelist` は `.gitignore` 対象で `flutter pub get` では生成されないため、明示的に生成が必要

## Test plan
- [ ] Xcode Cloud macOS ビルドで ephemeral ファイルのエラーが解消されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)