### PR TITLE
fix: Copilot review fixes from PR #109

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -187,6 +187,8 @@ class ServerNotifier extends Notifier<ServerState> {
     state = state.copyWith(serverName: trimmed);
   }
 
+  /// state を更新し、SharedPreferences に永続化する。
+  /// TextField の onSubmitted から呼び出す。
   Future<void> setServerName(String name) async {
     final prefs = await SharedPreferences.getInstance();
     final trimmed = name.trim().isEmpty ? 'LocalNode' : name.trim();

--- a/lib/tls_manager.dart
+++ b/lib/tls_manager.dart
@@ -233,11 +233,7 @@ class TlsManager {
   /// [fingerprint] は CA 証明書の SHA-256 フィンガープリント（任意）。
   static String buildSetupHtml(String ipAddress, int httpsPort, {String fingerprint = ''}) {
     final httpsUrl = 'https://$ipAddress:$httpsPort/';
-    final escapedFingerprint = fingerprint
-        .replaceAll('&', '&amp;')
-        .replaceAll('<', '&lt;')
-        .replaceAll('>', '&gt;')
-        .replaceAll('"', '&quot;');
+    final escapedFingerprint = const HtmlEscape().convert(fingerprint);
     return '''<!DOCTYPE html>
 <html lang="ja">
 <head>


### PR DESCRIPTION
## Summary

PR #109 の Copilot コードレビューで指摘された3件を修正します。

- `caCertFingerprint()` の `Process.run` を try/catch で囲み、openssl 起動失敗時も空文字を返すよう修正
- セットアップページに埋め込む `fingerprint` を HTML エスケープ
- サーバー名フィールドを `onChanged`（メモリ更新）+ `onSubmitted`（SharedPreferences保存）に分離し、Enter を押さずにサーバー起動しても最新の名前が使われるよう修正

## Test plan

- [ ] HTTPS モードでサーバー起動し、セットアップページにフィンガープリントが表示される
- [ ] サーバー名を変更して Enter を押さずにサーバー起動 → 変更後の名前が使われる
- [ ] サーバー名を変更して Enter を押す → 次回起動後も名前が保持される

🤖 Generated with [Claude Code](https://claude.com/claude-code)