### PR TITLE
fix(cli): always drain stdin on Windows regardless of hasTerminal (#128)

### DIFF
--- a/lib/cli_runner.dart
+++ b/lib/cli_runner.dart
@@ -301,8 +301,10 @@ class CliRunner {
   }
 
   /// Drain stdin silently to prevent buffered input from leaking to the parent
-  /// shell after exit. Only drains when running in an interactive TTY to avoid
-  /// consuming piped input streams unnecessarily.
+  /// shell after exit. On Windows, stdin is always drained because
+  /// [stdin.hasTerminal] is unreliable there (note: this may consume piped
+  /// input on Windows). On other platforms, draining is skipped for
+  /// non-interactive (piped) stdin to avoid unnecessary CPU usage.
   /// Ctrl+C (SIGINT) is handled by the signal handler and is unaffected.
   Future<void> _waitForQuit() async {
     // Always drain on Windows (hasTerminal is unreliable there).


### PR DESCRIPTION
## Summary
- `stdin.hasTerminal` が Windows では信頼できないため、Windows では無条件に stdin をdrainするよう修正
- これにより、サーバー終了後にタイプした文字（'q' など）が親シェルに漏れてエラーになる問題を修正
- 非Windows環境では引き続き `hasTerminal` チェックを維持

## Test plan
- [ ] Windows CLI で `--cli` 起動後、'q' をタイプしてからCtrl+Cで終了
- [ ] PowerShell に 'q' が漏れてエラーにならないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)