### PR TITLE
fix: build localnode-cli.exe for Windows (#158, #159)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,6 +118,9 @@ jobs:
       - name: Build Windows
         run: flutter build windows --release
 
+      - name: Build localnode-cli.exe (standalone CLI binary)
+        run: dart compile exe bin/localnode_cli.dart -o build\windows\x64\runner\Release\localnode-cli.exe
+
       - name: Create zip archive
         run: Compress-Archive -Path build\windows\x64\runner\Release\* -DestinationPath localnode-windows-x64.zip
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,5 @@
 import 'dart:async';
-import 'dart:io' show File, InternetAddress, Platform;
+import 'dart:io' show File, InternetAddress, Platform, stderr;
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -512,6 +512,15 @@ void main(List<String> args) async {
 
   // CLIモードかチェック
   if (CliRunner.isCliMode(args)) {
+    // Windows では GUI サブシステムの exe のため stdin を正しく制御できない。
+    // localnode-cli.exe (コンソールサブシステム) の使用を促す。
+    if (Platform.isWindows) {
+      stderr.writeln(
+          'Note: On Windows, please use localnode-cli.exe for CLI mode.');
+      stderr.writeln(
+          '      localnode-cli.exe --help');
+      stderr.writeln('');
+    }
     // CLIモードではFlutter UIを使わずにサーバーを起動
     final runner = CliRunner(args);
     await runner.run();


### PR DESCRIPTION
## 問題

`flutter build windows` はGUIサブシステムの `.exe` を生成するため、PowerShell がstdinを保持し続ける。
その結果:
- `SetConsoleMode` がstdinに効かない
- 入力文字がPowerShellにエコーされコマンドとして解釈される (#159)
- プロセスはバックグラウンド扱いになる (#158)

## 修正

Linuxと同様に `dart compile exe bin/localnode_cli.dart` でコンソールサブシステムの `localnode-cli.exe` をビルドし、Windows リリースに含める。
コンソールサブシステムのexeはプロセスがstdinを正しく所有するため、`SetConsoleMode` が機能する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)