### PR TITLE
feat: SAN-aware IP/hostname selector for HTTPS (#154, #155)

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:io' show File, InternetAddress, Platform, stderr;
+import 'package:basic_utils/basic_utils.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -32,6 +33,7 @@ class ServerState {
     this.httpsCertPath,
     this.httpsKeyPath,
     this.httpsHostname,
+    this.certSanCandidates = const [],
   });
 
   final ServerStatus status;
@@ -49,6 +51,7 @@ class ServerState {
   final String? httpsCertPath;
   final String? httpsKeyPath;
   final String? httpsHostname;
+  final List<String> certSanCandidates;
 
   bool get httpsMode =>
       httpsCertPath != null &&
@@ -72,12 +75,14 @@ class ServerState {
     String? httpsCertPath,
     String? httpsKeyPath,
     String? httpsHostname,
+    List<String>? certSanCandidates,
     bool clearPin = false,
     bool clearErrorMessage = false,
     bool clearFixedPin = false,
     bool clearHttpsCertPath = false,
     bool clearHttpsKeyPath = false,
     bool clearHttpsHostname = false,
+    bool clearCertSanCandidates = false,
   }) {
     return ServerState(
       status: status ?? this.status,
@@ -99,6 +104,9 @@ class ServerState {
           clearHttpsKeyPath ? null : (httpsKeyPath ?? this.httpsKeyPath),
       httpsHostname:
           clearHttpsHostname ? null : (httpsHostname ?? this.httpsHostname),
+      certSanCandidates: clearCertSanCandidates
+          ? const []
+          : (certSanCandidates ?? this.certSanCandidates),
     );
   }
 }
@@ -356,7 +364,7 @@ class ServerNotifier extends Notifier<ServerState> {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool('https_enabled', enabled);
     if (!enabled) {
-      // 無効化時は cert/key/hostname を state と prefs からクリアする
+      // 無効化時は cert/key/hostname/SANs を state と prefs からクリアする
       await prefs.remove('https_cert_path');
       await prefs.remove('https_key_path');
       await prefs.remove('https_hostname');
@@ -365,6 +373,7 @@ class ServerNotifier extends Notifier<ServerState> {
         clearHttpsCertPath: true,
         clearHttpsKeyPath: true,
         clearHttpsHostname: true,
+        clearCertSanCandidates: true,
       );
     } else {
       state = state.copyWith(httpsEnabled: true);
@@ -375,10 +384,40 @@ class ServerNotifier extends Notifier<ServerState> {
     final prefs = await SharedPreferences.getInstance();
     if (path == null || path.isEmpty) {
       await prefs.remove('https_cert_path');
-      state = state.copyWith(clearHttpsCertPath: true);
+      state = state.copyWith(
+        clearHttpsCertPath: true,
+        clearHttpsHostname: true,
+        clearCertSanCandidates: true,
+      );
     } else {
       await prefs.setString('https_cert_path', path);
-      state = state.copyWith(httpsCertPath: path);
+      // cert選択時にSANを解析してデバイスIPと照合 (#154)
+      final candidates = await _parseCertSanCandidates(path);
+      state = state.copyWith(httpsCertPath: path, certSanCandidates: candidates);
+      // 候補が1つなら自動選択
+      if (candidates.length == 1) {
+        await setHttpsHostname(candidates.first);
+      } else {
+        await prefs.remove('https_hostname');
+        state = state.copyWith(clearHttpsHostname: true);
+      }
+    }
+  }
+
+  /// cert.pem の SAN を解析し、デバイス保有IPと照合して候補リストを返す (#154)
+  Future<List<String>> _parseCertSanCandidates(String certPath) async {
+    try {
+      final pem = await File(certPath).readAsString();
+      final certData = X509Utils.x509CertificateFromPem(pem);
+      final sans = certData.subjectAlternativNames ?? [];
+      final deviceIps = state.availableIpAddresses.toSet();
+      final ipPattern = RegExp(r'^\d+\.\d+\.\d+\.\d+$');
+      return sans.where((san) {
+        if (ipPattern.hasMatch(san)) return deviceIps.contains(san);
+        return true; // ホスト名はすべて候補に含める
+      }).toList();
+    } catch (_) {
+      return [];
     }
   }
 
@@ -426,6 +465,7 @@ class ServerNotifier extends Notifier<ServerState> {
       clearHttpsCertPath: true,
       clearHttpsKeyPath: true,
       clearHttpsHostname: true,
+      clearCertSanCandidates: true,
       storagePath: _serverService.displayPath ?? _serverService.documentsPath,
     );
   }
@@ -906,18 +946,31 @@ class _HomePageState extends ConsumerState<HomePage> {
               const SizedBox(height: 8),
               ConstrainedBox(
                 constraints: const BoxConstraints(maxWidth: 400),
-                child: TextField(
-                  controller: _hostnameController,
-                  decoration: const InputDecoration(
-                    labelText: 'ホスト名 (任意)',
-                    hintText: 'example.local',
-                    border: OutlineInputBorder(),
-                    isDense: true,
-                  ),
-                  onChanged: (value) {
-                    notifier.setHttpsHostname(value);
-                  },
-                ),
+                child: serverState.certSanCandidates.isEmpty
+                    ? const Text(
+                        '証明書にSANが含まれていないか、デバイスのIPと一致するエントリがありません',
+                        style: TextStyle(fontSize: 12, color: Colors.orange),
+                      )
+                    : DropdownButtonFormField<String>(
+                        value: serverState.certSanCandidates
+                                .contains(serverState.httpsHostname)
+                            ? serverState.httpsHostname
+                            : null,
+                        decoration: const InputDecoration(
+                          labelText: '接続先 (SAN)',
+                          border: OutlineInputBorder(),
+                          isDense: true,
+                        ),
+                        items: serverState.certSanCandidates
+                            .map((s) => DropdownMenuItem(
+                                  value: s,
+                                  child: Text(s, style: const TextStyle(fontSize: 13)),
+                                ))
+                            .toList(),
+                        onChanged: (value) {
+                          if (value != null) notifier.setHttpsHostname(value);
+                        },
+                      ),
               ),
             ],
           ],

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -407,8 +407,11 @@ class ServerNotifier extends Notifier<ServerState> {
   /// cert.pem の SAN を解析し、デバイス保有IPと照合して候補リストを返す (#154)
   Future<List<String>> _parseCertSanCandidates(String certPath) async {
     try {
-      final pem = await File(certPath).readAsString();
-      final certData = X509Utils.x509CertificateFromPem(pem);
+      final raw = await File(certPath).readAsString();
+      // チェーン証明書の場合は最初のブロックだけ使う
+      final firstPem = _extractFirstPemBlock(raw);
+      if (firstPem == null) return [];
+      final certData = X509Utils.x509CertificateFromPem(firstPem);
       final sans = certData.subjectAlternativNames ?? [];
       final deviceIps = state.availableIpAddresses.toSet();
       final ipPattern = RegExp(r'^\d+\.\d+\.\d+\.\d+$');
@@ -419,6 +422,17 @@ class ServerNotifier extends Notifier<ServerState> {
     } catch (_) {
       return [];
     }
+  }
+
+  /// PEMファイルから最初の CERTIFICATE ブロックを抽出する
+  String? _extractFirstPemBlock(String pem) {
+    final begin = '-----BEGIN CERTIFICATE-----';
+    final end = '-----END CERTIFICATE-----';
+    final startIdx = pem.indexOf(begin);
+    if (startIdx == -1) return null;
+    final endIdx = pem.indexOf(end, startIdx);
+    if (endIdx == -1) return null;
+    return pem.substring(startIdx, endIdx + end.length);
   }
 
   Future<void> setHttpsKeyPath(String? path) async {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -41,6 +41,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.13.0"
+  basic_utils:
+    dependency: "direct main"
+    description:
+      name: basic_utils
+      sha256: "548047bef0b3b697be19fa62f46de54d99c9019a69fb7db92c69e19d87f633c7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -600,6 +608,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.8"
+  pointycastle:
+    dependency: transitive
+    description:
+      name: pointycastle
+      sha256: "92aa3841d083cc4b0f4709b5c74fd6409a3e6ba833ffc7dc6a8fee096366acf5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.0"
   pool:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -56,6 +56,7 @@ dependencies:
   args: ^2.4.2
   qr: ^3.0.1
   path: ^1.9.0
+  basic_utils: ^5.8.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Changes

cert.pem 選択時に証明書の SAN を解析し、デバイス保有 IP と照合して接続先候補を絞り込む。

- `basic_utils` パッケージで X.509 SAN を解析
- IP Address SAN: デバイスが保持する IP のみ候補に表示
- DNS Name SAN: すべて候補に追加
- 候補が1つなら自動選択、複数ならドロップダウンで選択
- SAN なし / 一致なし の場合は警告メッセージを表示
- cert クリア / HTTPS 無効化 / 設定リセット時に候補もクリア

Closes #154, #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)