### PR TITLE
v1.3.0: HTTPS/TLS support, SAN-aware selector, CLI improvements, and bug fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,6 +118,9 @@ jobs:
       - name: Build Windows
         run: flutter build windows --release
 
+      - name: Build localnode-cli.exe (standalone CLI binary)
+        run: dart compile exe bin/localnode_cli.dart -o build\windows\x64\runner\Release\localnode-cli.exe
+
       - name: Create zip archive
         run: Compress-Archive -Path build\windows\x64\runner\Release\* -DestinationPath localnode-windows-x64.zip
 

--- a/README.md
+++ b/README.md
@@ -4,15 +4,17 @@ A Flutter application that transforms your phone or computer into a secure, pers
 
 ## Features
 
-*   **Cross-Platform Server:** Turn your iOS, Android, Windows, macOS, or Linux device into a local HTTP file server.
+*   **Cross-Platform Server:** Turn your iOS, Android, Windows, macOS, or Linux device into a local HTTP/HTTPS file server.
 *   **Web Browser Access:** Access and manage your files from any device with a web browser on the same network. No special client app required.
 *   **Clipboard Sharing:** Sync text between devices via the clipboard sharing feature. Tag items with labels for easy identification.
 *   **Secure File Sharing:** Upload, download, and manage files with PIN-based authentication.
+*   **HTTPS/TLS Support:** Enable secure connections using your own TLS certificate and private key (e.g., from Tailscale). The SAN-aware selector automatically matches certificate entries to your device's IP addresses.
 *   **Access Control:** Configure download-only mode or disable PIN authentication for trusted networks.
 *   **Easy Connection:** Connect quickly using a QR code or by manually entering the displayed IP address.
 *   **IP Address Selection:** Choose which network interface (e.g., Wi-Fi, Tailscale) to use for serving files.
 *   **Custom Server Name:** Set a custom name displayed in the browser tab and page title.
 *   **Custom Shared Folder:** Select any folder on your device as the shared directory.
+*   **Settings Reset:** Reset all saved settings to defaults with a single button.
 *   **CLI Mode:** Run as a headless server from the command line on desktop platforms with full option support.
 *   **Client-only Web App:** The web version of LocalNode functions as a client to access servers running on other platforms.
 
@@ -55,7 +57,21 @@ A Flutter application that transforms your phone or computer into a secure, pers
 
 ### CLI Mode
 
-Run LocalNode as a headless server from the command line (Windows, macOS, Linux):
+Run LocalNode as a headless server from the command line.
+
+**Windows / Linux:**
+
+Use the standalone `localnode-cli` binary included in the release archive:
+
+```bash
+# Windows
+localnode-cli.exe [options]
+
+# Linux
+./localnode-cli [options]
+```
+
+**macOS:**
 
 ```bash
 localnode --cli [options]
@@ -80,6 +96,8 @@ localnode --cli [options]
 | `--pin` | Fixed PIN (random if not specified) |
 | `--dir`, `-d` | Shared directory path |
 | `--mode`, `-m` | Operation mode: `normal` or `download-only` |
+| `--https-cert` | Path to TLS certificate file (cert.pem) |
+| `--https-key` | Path to TLS private key file (key.pem) |
 | `--no-pin` | Disable PIN authentication |
 | `--no-clipboard` | Hide clipboard content from console output |
 | `--verbose`, `-v` | Enable verbose request logging |
@@ -89,25 +107,26 @@ localnode --cli [options]
 
 ```bash
 # Start with defaults (port 8080, random PIN, current directory)
-localnode --cli
+localnode-cli
 
 # Specify port, PIN, and shared directory
-localnode --cli -p 3000 --pin 1234 -d /home/user/share
+localnode-cli -p 3000 --pin 1234 -d /home/user/share
 
 # Specify IP address (useful for WSL, VPN, multi-NIC)
-localnode --cli -d /path/to/share --ip 192.168.1.100
+localnode-cli -d /path/to/share --ip 192.168.1.100
 
 # Set a custom server name
-localnode --cli --name "My Server"
+localnode-cli --name "My Server"
 
 # Download-only mode without PIN
-localnode --cli --mode download-only --no-pin
+localnode-cli --mode download-only --no-pin
+
+# Enable HTTPS with a Tailscale certificate
+localnode-cli --https-cert /path/to/cert.pem --https-key /path/to/key.pem
 
 ```
 
 To stop the server: **Ctrl+C**.
-
-> **Note (Windows):** On Windows, only Ctrl+C is supported to stop the server.
 
 ## Platform Support
 

--- a/bin/localnode_cli.dart
+++ b/bin/localnode_cli.dart
@@ -64,10 +64,21 @@ Future<void> main(List<String> args) async {
   final noPin = results['no-pin'] as bool;
   final fixedPin = results['pin'] as String?;
   final serverName = results['name'] as String;
-  // TODO(v1.3.0): HTTPS support (#98)
-  const String? httpsCertPath = null;
-  const String? httpsKeyPath = null;
-  const bool httpsMode = false;
+  final httpsCertPath = results['https-cert'] as String?;
+  final httpsKeyPath = results['https-key'] as String?;
+  if ((httpsCertPath == null) != (httpsKeyPath == null)) {
+    stderr.writeln('Error: --https-cert and --https-key must be specified together.');
+    exit(1);
+  }
+  if (httpsCertPath != null && !File(httpsCertPath).existsSync()) {
+    stderr.writeln('Error: Certificate file does not exist: $httpsCertPath');
+    exit(1);
+  }
+  if (httpsKeyPath != null && !File(httpsKeyPath).existsSync()) {
+    stderr.writeln('Error: Key file does not exist: $httpsKeyPath');
+    exit(1);
+  }
+  final bool httpsMode = httpsCertPath != null && httpsKeyPath != null;
 
   final authMode = noPin
       ? _AuthMode.noPin
@@ -155,7 +166,8 @@ ArgParser _buildParser() {
         abbr: 'v', help: 'Enable verbose request logging', negatable: false)
     ..addOption('name',
         abbr: 'n', help: 'Server name shown in browser tab title', defaultsTo: 'LocalNode')
-    // TODO(v1.3.0): --https-cert / --https-key (#98)
+    ..addOption('https-cert', help: 'Path to TLS certificate file (cert.pem)')
+    ..addOption('https-key', help: 'Path to TLS private key file (key.pem)')
     ..addFlag('help', abbr: 'h', help: 'Show this help', negatable: false);
 }
 
@@ -174,6 +186,7 @@ void _printUsage(ArgParser parser) {
   stdout.writeln('  localnode-cli --mode download-only --no-pin');
   stdout.writeln('  localnode-cli --no-clipboard --verbose');
   stdout.writeln('  localnode-cli --name "MyServer"');
+  stdout.writeln('  localnode-cli --https-cert /path/to/cert.pem --https-key /path/to/key.pem');
   stdout.writeln('');
   stdout.writeln('To stop: Ctrl+C');
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:io' show File, InternetAddress, Platform, stderr;
+import 'package:basic_utils/basic_utils.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -32,6 +33,7 @@ class ServerState {
     this.httpsCertPath,
     this.httpsKeyPath,
     this.httpsHostname,
+    this.certSanCandidates = const [],
   });
 
   final ServerStatus status;
@@ -49,6 +51,7 @@ class ServerState {
   final String? httpsCertPath;
   final String? httpsKeyPath;
   final String? httpsHostname;
+  final List<String> certSanCandidates;
 
   bool get httpsMode =>
       httpsCertPath != null &&
@@ -72,12 +75,14 @@ class ServerState {
     String? httpsCertPath,
     String? httpsKeyPath,
     String? httpsHostname,
+    List<String>? certSanCandidates,
     bool clearPin = false,
     bool clearErrorMessage = false,
     bool clearFixedPin = false,
     bool clearHttpsCertPath = false,
     bool clearHttpsKeyPath = false,
     bool clearHttpsHostname = false,
+    bool clearCertSanCandidates = false,
   }) {
     return ServerState(
       status: status ?? this.status,
@@ -99,6 +104,9 @@ class ServerState {
           clearHttpsKeyPath ? null : (httpsKeyPath ?? this.httpsKeyPath),
       httpsHostname:
           clearHttpsHostname ? null : (httpsHostname ?? this.httpsHostname),
+      certSanCandidates: clearCertSanCandidates
+          ? const []
+          : (certSanCandidates ?? this.certSanCandidates),
     );
   }
 }
@@ -356,7 +364,7 @@ class ServerNotifier extends Notifier<ServerState> {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool('https_enabled', enabled);
     if (!enabled) {
-      // 無効化時は cert/key/hostname を state と prefs からクリアする
+      // 無効化時は cert/key/hostname/SANs を state と prefs からクリアする
       await prefs.remove('https_cert_path');
       await prefs.remove('https_key_path');
       await prefs.remove('https_hostname');
@@ -365,6 +373,7 @@ class ServerNotifier extends Notifier<ServerState> {
         clearHttpsCertPath: true,
         clearHttpsKeyPath: true,
         clearHttpsHostname: true,
+        clearCertSanCandidates: true,
       );
     } else {
       state = state.copyWith(httpsEnabled: true);
@@ -375,10 +384,40 @@ class ServerNotifier extends Notifier<ServerState> {
     final prefs = await SharedPreferences.getInstance();
     if (path == null || path.isEmpty) {
       await prefs.remove('https_cert_path');
-      state = state.copyWith(clearHttpsCertPath: true);
+      state = state.copyWith(
+        clearHttpsCertPath: true,
+        clearHttpsHostname: true,
+        clearCertSanCandidates: true,
+      );
     } else {
       await prefs.setString('https_cert_path', path);
-      state = state.copyWith(httpsCertPath: path);
+      // cert選択時にSANを解析してデバイスIPと照合 (#154)
+      final candidates = await _parseCertSanCandidates(path);
+      state = state.copyWith(httpsCertPath: path, certSanCandidates: candidates);
+      // 候補が1つなら自動選択
+      if (candidates.length == 1) {
+        await setHttpsHostname(candidates.first);
+      } else {
+        await prefs.remove('https_hostname');
+        state = state.copyWith(clearHttpsHostname: true);
+      }
+    }
+  }
+
+  /// cert.pem の SAN を解析し、デバイス保有IPと照合して候補リストを返す (#154)
+  Future<List<String>> _parseCertSanCandidates(String certPath) async {
+    try {
+      final pem = await File(certPath).readAsString();
+      final certData = X509Utils.x509CertificateFromPem(pem);
+      final sans = certData.subjectAlternativNames ?? [];
+      final deviceIps = state.availableIpAddresses.toSet();
+      final ipPattern = RegExp(r'^\d+\.\d+\.\d+\.\d+$');
+      return sans.where((san) {
+        if (ipPattern.hasMatch(san)) return deviceIps.contains(san);
+        return true; // ホスト名はすべて候補に含める
+      }).toList();
+    } catch (_) {
+      return [];
     }
   }
 
@@ -426,6 +465,7 @@ class ServerNotifier extends Notifier<ServerState> {
       clearHttpsCertPath: true,
       clearHttpsKeyPath: true,
       clearHttpsHostname: true,
+      clearCertSanCandidates: true,
       storagePath: _serverService.displayPath ?? _serverService.documentsPath,
     );
   }
@@ -906,18 +946,31 @@ class _HomePageState extends ConsumerState<HomePage> {
               const SizedBox(height: 8),
               ConstrainedBox(
                 constraints: const BoxConstraints(maxWidth: 400),
-                child: TextField(
-                  controller: _hostnameController,
-                  decoration: const InputDecoration(
-                    labelText: 'ホスト名 (任意)',
-                    hintText: 'example.local',
-                    border: OutlineInputBorder(),
-                    isDense: true,
-                  ),
-                  onChanged: (value) {
-                    notifier.setHttpsHostname(value);
-                  },
-                ),
+                child: serverState.certSanCandidates.isEmpty
+                    ? const Text(
+                        '証明書にSANが含まれていないか、デバイスのIPと一致するエントリがありません',
+                        style: TextStyle(fontSize: 12, color: Colors.orange),
+                      )
+                    : DropdownButtonFormField<String>(
+                        value: serverState.certSanCandidates
+                                .contains(serverState.httpsHostname)
+                            ? serverState.httpsHostname
+                            : null,
+                        decoration: const InputDecoration(
+                          labelText: '接続先 (SAN)',
+                          border: OutlineInputBorder(),
+                          isDense: true,
+                        ),
+                        items: serverState.certSanCandidates
+                            .map((s) => DropdownMenuItem(
+                                  value: s,
+                                  child: Text(s, style: const TextStyle(fontSize: 13)),
+                                ))
+                            .toList(),
+                        onChanged: (value) {
+                          if (value != null) notifier.setHttpsHostname(value);
+                        },
+                      ),
               ),
             ],
           ],

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,5 @@
 import 'dart:async';
-import 'dart:io' show File, InternetAddress, Platform;
+import 'dart:io' show File, InternetAddress, Platform, stderr;
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -512,6 +512,15 @@ void main(List<String> args) async {
 
   // CLIモードかチェック
   if (CliRunner.isCliMode(args)) {
+    // Windows では GUI サブシステムの exe のため stdin を正しく制御できない。
+    // localnode-cli.exe (コンソールサブシステム) の使用を促す。
+    if (Platform.isWindows) {
+      stderr.writeln(
+          'Note: On Windows, please use localnode-cli.exe for CLI mode.');
+      stderr.writeln(
+          '      localnode-cli.exe --help');
+      stderr.writeln('');
+    }
     // CLIモードではFlutter UIを使わずにサーバーを起動
     final runner = CliRunner(args);
     await runner.run();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -34,6 +34,7 @@ class ServerState {
     this.httpsKeyPath,
     this.httpsHostname,
     this.certSanCandidates = const [],
+    this.resolvedHttpsIp,
   });
 
   final ServerStatus status;
@@ -52,6 +53,8 @@ class ServerState {
   final String? httpsKeyPath;
   final String? httpsHostname;
   final List<String> certSanCandidates;
+  // ホスト名をデバイスIPに解決した結果（非nullならIPドロップダウンをロック）(#985)
+  final String? resolvedHttpsIp;
 
   bool get httpsMode =>
       httpsCertPath != null &&
@@ -76,6 +79,7 @@ class ServerState {
     String? httpsKeyPath,
     String? httpsHostname,
     List<String>? certSanCandidates,
+    String? resolvedHttpsIp,
     bool clearPin = false,
     bool clearErrorMessage = false,
     bool clearFixedPin = false,
@@ -83,6 +87,7 @@ class ServerState {
     bool clearHttpsKeyPath = false,
     bool clearHttpsHostname = false,
     bool clearCertSanCandidates = false,
+    bool clearResolvedHttpsIp = false,
   }) {
     return ServerState(
       status: status ?? this.status,
@@ -107,6 +112,8 @@ class ServerState {
       certSanCandidates: clearCertSanCandidates
           ? const []
           : (certSanCandidates ?? this.certSanCandidates),
+      resolvedHttpsIp:
+          clearResolvedHttpsIp ? null : (resolvedHttpsIp ?? this.resolvedHttpsIp),
     );
   }
 }
@@ -223,10 +230,34 @@ class ServerNotifier extends Notifier<ServerState> {
       httpsHostname: savedHttpsHostname,
     );
 
-    // 起動後にSAN候補を復元 (#55)
+    // 起動後にSAN候補を復元し、保存済みホスト名と照合 (#55)
     if (savedHttpsCertPath != null) {
       final candidates = await _parseCertSanCandidates(savedHttpsCertPath);
-      state = state.copyWith(certSanCandidates: candidates);
+      final prefs2 = await SharedPreferences.getInstance();
+      final hostname = state.httpsHostname;
+      if (hostname != null && !candidates.contains(hostname)) {
+        // デバイスIP変更等で候補にないホスト名はクリア
+        await prefs2.remove('https_hostname');
+        state = state.copyWith(
+          certSanCandidates: candidates,
+          clearHttpsHostname: true,
+          clearResolvedHttpsIp: true,
+        );
+      } else if (hostname != null) {
+        // 有効なホスト名ならIP解決して resolvedHttpsIp をセット
+        final resolvedIp = await _resolveHostnameToDeviceIp(hostname);
+        state = state.copyWith(
+          certSanCandidates: candidates,
+          resolvedHttpsIp: resolvedIp,
+          selectedIpAddress: resolvedIp ?? state.selectedIpAddress,
+        );
+      } else if (candidates.length == 1) {
+        // 候補が1つなら自動選択
+        await setHttpsHostname(candidates.first);
+        state = state.copyWith(certSanCandidates: candidates);
+      } else {
+        state = state.copyWith(certSanCandidates: candidates);
+      }
     }
   }
 
@@ -385,6 +416,7 @@ class ServerNotifier extends Notifier<ServerState> {
         clearHttpsKeyPath: true,
         clearHttpsHostname: true,
         clearCertSanCandidates: true,
+        clearResolvedHttpsIp: true,
       );
     } else {
       state = state.copyWith(httpsEnabled: true);
@@ -396,11 +428,14 @@ class ServerNotifier extends Notifier<ServerState> {
     if (path == null || path.isEmpty) {
       _currentCertPath = null;
       await prefs.remove('https_cert_path');
+      await prefs.remove('https_key_path');
       await prefs.remove('https_hostname');
       state = state.copyWith(
         clearHttpsCertPath: true,
+        clearHttpsKeyPath: true,
         clearHttpsHostname: true,
         clearCertSanCandidates: true,
+        clearResolvedHttpsIp: true,
       );
     } else {
       await prefs.setString('https_cert_path', path);
@@ -431,9 +466,13 @@ class ServerNotifier extends Notifier<ServerState> {
       final sans = certData.subjectAlternativNames ?? [];
       // state.availableIpAddresses は未初期化の可能性があるため直接取得 (#421)
       final deviceIps = (await _serverService.getAvailableIpAddresses()).toSet();
+      // IP検出失敗時のフォールバック '0.0.0.0' のみの場合はIPフィルタをスキップ (#Copilot)
+      final skipIpFilter = deviceIps.length == 1 && deviceIps.contains('0.0.0.0');
       return sans.where((san) {
         // IPv4/IPv6 両対応 (#419)
-        if (InternetAddress.tryParse(san) != null) return deviceIps.contains(san);
+        if (InternetAddress.tryParse(san) != null) {
+          return skipIpFilter || deviceIps.contains(san);
+        }
         return true; // ホスト名はすべて候補に含める
       }).toList();
     } catch (_) {
@@ -467,7 +506,7 @@ class ServerNotifier extends Notifier<ServerState> {
     final prefs = await SharedPreferences.getInstance();
     if (hostname.isEmpty) {
       await prefs.remove('https_hostname');
-      state = state.copyWith(clearHttpsHostname: true);
+      state = state.copyWith(clearHttpsHostname: true, clearResolvedHttpsIp: true);
     } else {
       await prefs.setString('https_hostname', hostname);
       // ホスト名に対応するIPを解決して selectedIpAddress にセット (#155)
@@ -475,6 +514,7 @@ class ServerNotifier extends Notifier<ServerState> {
       state = state.copyWith(
         httpsHostname: hostname,
         selectedIpAddress: resolvedIp ?? state.selectedIpAddress,
+        resolvedHttpsIp: resolvedIp, // 解決成功時のみ非null → IPドロップダウンロック (#Copilot)
       );
     }
   }
@@ -518,6 +558,7 @@ class ServerNotifier extends Notifier<ServerState> {
       clearHttpsKeyPath: true,
       clearHttpsHostname: true,
       clearCertSanCandidates: true,
+      clearResolvedHttpsIp: true,
       storagePath: _serverService.displayPath ?? _serverService.documentsPath,
     );
   }
@@ -905,9 +946,8 @@ class _HomePageState extends ConsumerState<HomePage> {
                 .map((ip) => DropdownMenuItem(value: ip, child: Text(ip)))
                 .toList(),
             onChanged: (serverState.httpsMode &&
-                    serverState.httpsHostname != null &&
-                    serverState.httpsHostname!.isNotEmpty)
-                ? null // HTTPSホスト名設定時はIP変更不可
+                    serverState.resolvedHttpsIp != null)
+                ? null // ホスト名がデバイスIPに解決できた場合のみIPロック
                 : (ip) {
                     if (ip != null) {
                       notifier.selectIpAddress(ip);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1736,12 +1736,44 @@ class _CertPathField extends StatelessWidget {
           const SizedBox(width: 8),
           OutlinedButton(
             onPressed: () async {
-              final result = await FilePicker.platform.pickFiles(
-                type: FileType.any,
-                dialogTitle: '$label を選択',
-              );
-              if (result != null && result.files.single.path != null) {
-                onChanged(result.files.single.path);
+              try {
+                final result = await FilePicker.platform.pickFiles(
+                  type: FileType.any,
+                  dialogTitle: '$label を選択',
+                );
+                if (result != null && result.files.single.path != null) {
+                  onChanged(result.files.single.path);
+                }
+              } catch (_) {
+                // XDG Desktop Portal 未インストール環境（WSL等）でのフォールバック (#161)
+                if (!context.mounted) return;
+                final controller = TextEditingController(text: value ?? '');
+                final entered = await showDialog<String>(
+                  context: context,
+                  builder: (ctx) => AlertDialog(
+                    title: Text('$label のパスを入力'),
+                    content: TextField(
+                      controller: controller,
+                      decoration: const InputDecoration(
+                        hintText: '/path/to/file.pem',
+                      ),
+                      autofocus: true,
+                    ),
+                    actions: [
+                      TextButton(
+                        onPressed: () => Navigator.pop(ctx),
+                        child: const Text('キャンセル'),
+                      ),
+                      TextButton(
+                        onPressed: () => Navigator.pop(ctx, controller.text),
+                        child: const Text('OK'),
+                      ),
+                    ],
+                  ),
+                );
+                if (entered != null && entered.isNotEmpty) {
+                  onChanged(entered);
+                }
               }
             },
             child: Text('$label を選択'),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -169,6 +169,9 @@ class ServerNotifier extends Notifier<ServerState> {
   // _serverService を ref 経由で取得
   ServerService get _serverService => ref.read(serverServiceProvider);
 
+  // cert解析のレースコンディション防止用 (#403)
+  String? _currentCertPath;
+
   Future<void> loadIpAddresses() async {
     if (kIsWeb) return; // Webでは実行しない
     await _serverService.initializePaths();
@@ -219,6 +222,12 @@ class ServerNotifier extends Notifier<ServerState> {
       httpsKeyPath: savedHttpsKeyPath,
       httpsHostname: savedHttpsHostname,
     );
+
+    // 起動後にSAN候補を復元 (#55)
+    if (savedHttpsCertPath != null) {
+      final candidates = await _parseCertSanCandidates(savedHttpsCertPath);
+      state = state.copyWith(certSanCandidates: candidates);
+    }
   }
 
   /// サーバー名を設定して永続化
@@ -276,6 +285,8 @@ class ServerNotifier extends Notifier<ServerState> {
     state = state.copyWith(selectedIpAddress: ipAddress);
     // 逆引きDNSでホスト名を自動入力（HTTPSモード時、フィールドが空の時のみ）(#133)
     if (state.httpsHostname != null && state.httpsHostname!.isNotEmpty) return;
+    // SAN候補がある場合は逆引きDNS自動入力をスキップ（certSanCandidatesと競合するため）(#985)
+    if (state.certSanCandidates.isNotEmpty) return;
     try {
       final resolved = await InternetAddress(ipAddress).reverse();
       // DNS応答が返ってきた時点で選択IPが変わっていれば無視（競合防止）
@@ -383,7 +394,9 @@ class ServerNotifier extends Notifier<ServerState> {
   Future<void> setHttpsCertPath(String? path) async {
     final prefs = await SharedPreferences.getInstance();
     if (path == null || path.isEmpty) {
+      _currentCertPath = null;
       await prefs.remove('https_cert_path');
+      await prefs.remove('https_hostname');
       state = state.copyWith(
         clearHttpsCertPath: true,
         clearHttpsHostname: true,
@@ -392,7 +405,10 @@ class ServerNotifier extends Notifier<ServerState> {
     } else {
       await prefs.setString('https_cert_path', path);
       // cert選択時にSANを解析してデバイスIPと照合 (#154)
+      _currentCertPath = path;
       final candidates = await _parseCertSanCandidates(path);
+      // レースコンディション: 解析中に別のcertが選択された場合は無視 (#403)
+      if (_currentCertPath != path) return;
       state = state.copyWith(httpsCertPath: path, certSanCandidates: candidates);
       // 候補が1つなら自動選択
       if (candidates.length == 1) {
@@ -413,10 +429,11 @@ class ServerNotifier extends Notifier<ServerState> {
       if (firstPem == null) return [];
       final certData = X509Utils.x509CertificateFromPem(firstPem);
       final sans = certData.subjectAlternativNames ?? [];
-      final deviceIps = state.availableIpAddresses.toSet();
-      final ipPattern = RegExp(r'^\d+\.\d+\.\d+\.\d+$');
+      // state.availableIpAddresses は未初期化の可能性があるため直接取得 (#421)
+      final deviceIps = (await _serverService.getAvailableIpAddresses()).toSet();
       return sans.where((san) {
-        if (ipPattern.hasMatch(san)) return deviceIps.contains(san);
+        // IPv4/IPv6 両対応 (#419)
+        if (InternetAddress.tryParse(san) != null) return deviceIps.contains(san);
         return true; // ホスト名はすべて候補に含める
       }).toList();
     } catch (_) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -453,8 +453,29 @@ class ServerNotifier extends Notifier<ServerState> {
       state = state.copyWith(clearHttpsHostname: true);
     } else {
       await prefs.setString('https_hostname', hostname);
-      state = state.copyWith(httpsHostname: hostname);
+      // ホスト名に対応するIPを解決して selectedIpAddress にセット (#155)
+      final resolvedIp = await _resolveHostnameToDeviceIp(hostname);
+      state = state.copyWith(
+        httpsHostname: hostname,
+        selectedIpAddress: resolvedIp ?? state.selectedIpAddress,
+      );
     }
+  }
+
+  /// ホスト名をデバイス保有IPに解決する (#155)
+  /// IPアドレスならそのまま返す。DNS名なら解決してデバイスIPと照合する。
+  Future<String?> _resolveHostnameToDeviceIp(String hostname) async {
+    final deviceIps = state.availableIpAddresses.toSet();
+    // IPアドレスそのものならそのまま返す
+    if (deviceIps.contains(hostname)) return hostname;
+    // DNS名前解決
+    try {
+      final addresses = await InternetAddress.lookup(hostname);
+      for (final addr in addresses) {
+        if (deviceIps.contains(addr.address)) return addr.address;
+      }
+    } catch (_) {}
+    return null;
   }
 
   /// すべての保存済み設定を初期化する (#147)
@@ -858,6 +879,7 @@ class _HomePageState extends ConsumerState<HomePage> {
         const SizedBox(height: 20),
 
         // IPアドレス選択ドロップダウン
+        // HTTPSモードでホスト名が設定済みの場合はIPをロックする (#155)
         if (serverState.availableIpAddresses.isNotEmpty &&
             serverState.selectedIpAddress != null)
           DropdownButton<String>(
@@ -865,11 +887,15 @@ class _HomePageState extends ConsumerState<HomePage> {
             items: serverState.availableIpAddresses
                 .map((ip) => DropdownMenuItem(value: ip, child: Text(ip)))
                 .toList(),
-            onChanged: (ip) {
-              if (ip != null) {
-                notifier.selectIpAddress(ip); // Future は fire-and-forget で OK
-              }
-            },
+            onChanged: (serverState.httpsMode &&
+                    serverState.httpsHostname != null &&
+                    serverState.httpsHostname!.isNotEmpty)
+                ? null // HTTPSホスト名設定時はIP変更不可
+                : (ip) {
+                    if (ip != null) {
+                      notifier.selectIpAddress(ip);
+                    }
+                  },
           ),
         const SizedBox(height: 10),
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -407,8 +407,11 @@ class ServerNotifier extends Notifier<ServerState> {
   /// cert.pem の SAN を解析し、デバイス保有IPと照合して候補リストを返す (#154)
   Future<List<String>> _parseCertSanCandidates(String certPath) async {
     try {
-      final pem = await File(certPath).readAsString();
-      final certData = X509Utils.x509CertificateFromPem(pem);
+      final raw = await File(certPath).readAsString();
+      // チェーン証明書の場合は最初のブロックだけ使う
+      final firstPem = _extractFirstPemBlock(raw);
+      if (firstPem == null) return [];
+      final certData = X509Utils.x509CertificateFromPem(firstPem);
       final sans = certData.subjectAlternativNames ?? [];
       final deviceIps = state.availableIpAddresses.toSet();
       final ipPattern = RegExp(r'^\d+\.\d+\.\d+\.\d+$');
@@ -419,6 +422,17 @@ class ServerNotifier extends Notifier<ServerState> {
     } catch (_) {
       return [];
     }
+  }
+
+  /// PEMファイルから最初の CERTIFICATE ブロックを抽出する
+  String? _extractFirstPemBlock(String pem) {
+    final begin = '-----BEGIN CERTIFICATE-----';
+    final end = '-----END CERTIFICATE-----';
+    final startIdx = pem.indexOf(begin);
+    if (startIdx == -1) return null;
+    final endIdx = pem.indexOf(end, startIdx);
+    if (endIdx == -1) return null;
+    return pem.substring(startIdx, endIdx + end.length);
   }
 
   Future<void> setHttpsKeyPath(String? path) async {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -41,6 +41,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.13.0"
+  basic_utils:
+    dependency: "direct main"
+    description:
+      name: basic_utils
+      sha256: "548047bef0b3b697be19fa62f46de54d99c9019a69fb7db92c69e19d87f633c7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -600,6 +608,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.8"
+  pointycastle:
+    dependency: transitive
+    description:
+      name: pointycastle
+      sha256: "92aa3841d083cc4b0f4709b5c74fd6409a3e6ba833ffc7dc6a8fee096366acf5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.0"
   pool:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -56,6 +56,7 @@ dependencies:
   args: ^2.4.2
   qr: ^3.0.1
   path: ^1.9.0
+  basic_utils: ^5.8.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary

- **HTTPS/TLS support**: SSL/TLS toggle with cert.pem + key.pem selection; SAN-aware IP/hostname selector that filters certificate SANs against device IPs (e.g., Tailscale certs) (#133, #141, #145, #154, #155)
- **CLI HTTPS**: `--https-cert` / `--https-key` options added to `localnode-cli` (#98)
- **Windows CLI**: Separate `localnode-cli.exe` (console subsystem) to fix echo and exit issues (#158, #159)
- **Settings reset**: Reset all saved settings to defaults (#147, #156)
- **Bug fixes**: Site name in browser title (#127), Linux folder/cursor/background CLI fixes (#130, #131, #132), UI layout fixes (#142, #143, #144, #152, #153), settings reset state fix (#163)
- **Linux**: File picker DBus fallback for WSL environments (#161)
- **README**: Updated for v1.3.0

## Test plan

- [ ] HTTPS mode: select cert.pem + key.pem, verify SAN selector shows correct entries
- [ ] HTTPS with Tailscale cert: verify hostname auto-selects and IP locks
- [ ] CLI: `localnode-cli --https-cert cert.pem --https-key key.pem` starts HTTPS server
- [ ] Windows: `localnode-cli.exe` starts without echo, Ctrl+C stops cleanly
- [ ] Settings reset clears all fields including HTTPS cert/key/hostname
- [ ] Linux WSL: file picker fallback dialog appears on DBus error

🤖 Generated with [Claude Code](https://claude.com/claude-code)