### PR TITLE
version/1.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ localnode --cli [options]
 | `--https-cert` | Path to TLS certificate file (cert.pem) |
 | `--https-key` | Path to TLS private key file (key.pem) |
 | `--post-action` | Script to execute after each upload (repeatable) |
+| `--mention-action` | Register clipboard mention command: `alias=script` (repeatable) |
 | `--token` | Fixed upload token for Bearer auth (random if not specified) |
 | `--no-token` | Disable token-based upload authentication |
 | `--no-pin` | Disable PIN authentication |
@@ -126,6 +127,12 @@ localnode-cli --mode download-only --no-pin
 
 # Enable HTTPS with a Tailscale certificate
 localnode-cli --https-cert /path/to/cert.pem --https-key /path/to/key.pem
+
+# Run a script after each upload
+localnode-cli --post-action ./notify.sh
+
+# Trigger scripts via clipboard mention commands
+localnode-cli --mention-action backup=./backup.sh --mention-action notify=./notify.sh
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ localnode --cli [options]
 | `--mode`, `-m` | Operation mode: `normal` or `download-only` |
 | `--https-cert` | Path to TLS certificate file (cert.pem) |
 | `--https-key` | Path to TLS private key file (key.pem) |
+| `--post-action` | Script to execute after each upload (repeatable) |
+| `--token` | Fixed upload token for Bearer auth (random if not specified) |
+| `--no-token` | Disable token-based upload authentication |
 | `--no-pin` | Disable PIN authentication |
 | `--no-clipboard` | Hide clipboard content from console output |
 | `--verbose`, `-v` | Enable verbose request logging |

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ localnode --cli [options]
 | `--mode`, `-m` | Operation mode: `normal` or `download-only` |
 | `--https-cert` | Path to TLS certificate file (cert.pem) |
 | `--https-key` | Path to TLS private key file (key.pem) |
-| `--post-action` | Script to execute after each upload (repeatable) |
+| `--post-action` | Script to execute on matching uploads: `pattern=script` (repeatable, glob pattern) |
 | `--mention-action` | Register clipboard mention command: `alias=script` (repeatable) |
 | `--token` | Fixed upload token for Bearer auth (random if not specified) |
 | `--no-token` | Disable token-based upload authentication |
@@ -128,8 +128,11 @@ localnode-cli --mode download-only --no-pin
 # Enable HTTPS with a Tailscale certificate
 localnode-cli --https-cert /path/to/cert.pem --https-key /path/to/key.pem
 
-# Run a script after each upload
-localnode-cli --post-action ./notify.sh
+# Run scripts based on uploaded file type
+localnode-cli --post-action "*.png=./move-pic.sh" --post-action "*.zip=./unzip.sh"
+
+# Run a script for all uploads
+localnode-cli --post-action "*=./notify.sh"
 
 # Trigger scripts via clipboard mention commands
 localnode-cli --mention-action backup=./backup.sh --mention-action notify=./notify.sh

--- a/assets/web/index.html
+++ b/assets/web/index.html
@@ -385,6 +385,221 @@
         .breadcrumb-current { color: #333; font-weight: 500; }
         .folder-row { cursor: pointer; }
         .folder-row:hover td { background-color: #f0f7ff; }
+
+        /* ソート・ビューワーコントロール */
+        .list-controls {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.5rem;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+        }
+        .sort-controls {
+            display: flex;
+            align-items: center;
+            gap: 0.25rem;
+            font-size: 0.85rem;
+            color: #666;
+        }
+        .sort-controls button {
+            padding: 0.25rem 0.6rem;
+            border: 1px solid #ccc;
+            border-radius: 4px;
+            background: white;
+            cursor: pointer;
+            font-size: 0.8rem;
+        }
+        .sort-controls button.active {
+            background: #1a73e8;
+            color: white;
+            border-color: #1a73e8;
+        }
+        #viewerModeBtn {
+            padding: 0.35rem 0.8rem;
+            border: 1px solid #ccc;
+            border-radius: 4px;
+            background: white;
+            cursor: pointer;
+            font-size: 0.85rem;
+        }
+        #viewerModeBtn.active {
+            background: #1a73e8;
+            color: white;
+            border-color: #1a73e8;
+        }
+
+        /* 画像グリッド（ビューワーモード） */
+        .viewer-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));
+            gap: 0.75rem;
+            margin-top: 0.5rem;
+        }
+        .viewer-item {
+            border: 2px solid transparent;
+            border-radius: 8px;
+            overflow: hidden;
+            cursor: pointer;
+            background: #f8f9fa;
+            text-align: center;
+            padding: 0.5rem;
+            transition: border-color 0.15s;
+        }
+        .viewer-item:hover { border-color: #1a73e8; }
+        .viewer-item.selected { border-color: #ea4335; }
+        .viewer-item img {
+            width: 100%;
+            height: 100px;
+            object-fit: cover;
+            border-radius: 4px;
+        }
+        .viewer-item .viewer-name {
+            font-size: 0.75rem;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            margin-top: 0.4rem;
+            color: #333;
+        }
+        .viewer-item .viewer-icon {
+            font-size: 2.5rem;
+            line-height: 100px;
+        }
+        .viewer-compare-btn {
+            font-size: 0.7rem;
+            padding: 0.15rem 0.4rem;
+            margin-top: 0.3rem;
+            border: 1px solid #ccc;
+            border-radius: 3px;
+            background: white;
+            cursor: pointer;
+        }
+        .viewer-compare-btn.selected { background: #ea4335; color: white; border-color: #ea4335; }
+
+        /* ライトボックス */
+        #lightbox {
+            display: none;
+            position: fixed;
+            inset: 0;
+            background: rgba(0,0,0,0.85);
+            z-index: 200;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+        }
+        #lightbox.open { display: flex; }
+        #lightbox-img-wrap {
+            position: relative;
+            overflow: hidden;
+            max-width: 90vw;
+            max-height: 75vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+        #lightbox-img {
+            max-width: 90vw;
+            max-height: 75vh;
+            object-fit: contain;
+            transform-origin: center center;
+            transition: transform 0.1s;
+            user-select: none;
+        }
+        #lightbox-meta {
+            color: white;
+            font-size: 0.85rem;
+            margin-top: 0.75rem;
+            text-align: center;
+            opacity: 0.85;
+        }
+        .lightbox-nav {
+            position: fixed;
+            top: 50%;
+            transform: translateY(-50%);
+            background: rgba(255,255,255,0.15);
+            border: none;
+            color: white;
+            font-size: 2rem;
+            padding: 0.5rem 1rem;
+            cursor: pointer;
+            border-radius: 4px;
+        }
+        #lightbox-prev { left: 1rem; }
+        #lightbox-next { right: 1rem; }
+        #lightbox-close {
+            position: fixed;
+            top: 1rem;
+            right: 1rem;
+            background: rgba(255,255,255,0.2);
+            border: none;
+            color: white;
+            font-size: 1.5rem;
+            padding: 0.3rem 0.7rem;
+            cursor: pointer;
+            border-radius: 4px;
+        }
+        #lightbox-zoom-hint {
+            position: fixed;
+            bottom: 1rem;
+            left: 50%;
+            transform: translateX(-50%);
+            color: rgba(255,255,255,0.5);
+            font-size: 0.75rem;
+        }
+
+        /* 比較ビュー */
+        #comparison-view {
+            display: none;
+            position: fixed;
+            inset: 0;
+            background: #111;
+            z-index: 200;
+            flex-direction: column;
+        }
+        #comparison-view.open { display: flex; }
+        #comparison-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 0.5rem 1rem;
+            background: #222;
+            color: white;
+        }
+        #comparison-header button {
+            background: rgba(255,255,255,0.2);
+            border: none;
+            color: white;
+            padding: 0.3rem 0.8rem;
+            cursor: pointer;
+            border-radius: 4px;
+        }
+        .comparison-panes {
+            display: flex;
+            flex: 1;
+            overflow: hidden;
+        }
+        .comparison-pane {
+            flex: 1;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            padding: 0.5rem;
+            border-right: 1px solid #444;
+        }
+        .comparison-pane:last-child { border-right: none; }
+        .comparison-pane img {
+            max-width: 100%;
+            max-height: 80vh;
+            object-fit: contain;
+        }
+        .comparison-pane .comp-meta {
+            color: rgba(255,255,255,0.7);
+            font-size: 0.8rem;
+            margin-top: 0.5rem;
+            text-align: center;
+        }
     </style>
 </head>
 <body>
@@ -439,18 +654,17 @@
 
                 <div id="breadcrumb"></div>
 
-                <div id="file-list">
-                    <table>
-                        <thead>
-                            <tr>
-                                <th class="preview-col"></th>
-                                <th class="fileinfo-col">ファイル名</th>
-                                <th class="actions">操作</th>
-                            </tr>
-                        </thead>
-                        <tbody></tbody>
-                    </table>
+                <div class="list-controls">
+                    <div class="sort-controls">
+                        <span>並び替え:</span>
+                        <button id="sortNameBtn" class="active">名前</button>
+                        <button id="sortSizeBtn">サイズ</button>
+                        <button id="sortOrderBtn" title="昇順/降順">↑</button>
+                    </div>
+                    <button id="viewerModeBtn">🖼 グリッド</button>
                 </div>
+
+                <div id="file-list"></div>
             </div>
 
             <!-- クリップボードタブ -->
@@ -476,6 +690,36 @@
         </div>
     </div>
 
+    <!-- ライトボックス -->
+    <div id="lightbox">
+        <button id="lightbox-close">✕</button>
+        <button class="lightbox-nav" id="lightbox-prev">‹</button>
+        <div id="lightbox-img-wrap">
+            <img id="lightbox-img" src="" alt="">
+        </div>
+        <button class="lightbox-nav" id="lightbox-next">›</button>
+        <div id="lightbox-meta"></div>
+        <div id="lightbox-zoom-hint">スクロールでズーム • 矢印キーで移動</div>
+    </div>
+
+    <!-- 比較ビュー -->
+    <div id="comparison-view">
+        <div id="comparison-header">
+            <span>画像比較</span>
+            <button id="comparison-close">✕ 閉じる</button>
+        </div>
+        <div class="comparison-panes">
+            <div class="comparison-pane">
+                <img id="comp-img-0" src="" alt="">
+                <div class="comp-meta" id="comp-meta-0"></div>
+            </div>
+            <div class="comparison-pane">
+                <img id="comp-img-1" src="" alt="">
+                <div class="comp-meta" id="comp-meta-1"></div>
+            </div>
+        </div>
+    </div>
+
     <script>
         document.addEventListener('DOMContentLoaded', () => {
             const pinModal = document.getElementById('pin-modal');
@@ -484,7 +728,6 @@
             const pinInput = document.getElementById('pinInput');
             const pinStatus = document.getElementById('pinStatus');
 
-            const fileListBody = document.querySelector('#file-list tbody');
             const uploadForm = document.getElementById('uploadForm');
             const fileInput = document.getElementById('fileInput');
             const uploadStatus = document.getElementById('uploadStatus');
@@ -495,6 +738,19 @@
             let serverInfo = {};
             // 現在表示中のフォルダパス（ルートは空文字）
             let currentPath = '';
+
+            // ビューワーモード・ソート状態
+            let sortBy = 'name';
+            let sortOrder = 'asc';
+            let isViewerMode = false;
+            let allItems = [];
+            let compareImages = [];
+            let lightboxImageList = [];
+            let lightboxIndex = 0;
+            let lightboxScale = 1;
+
+            const IMAGE_EXTS = new Set(['png','jpg','jpeg','gif','webp','bmp']);
+            const isImageFile = (name) => IMAGE_EXTS.has((name.split('.').pop() || '').toLowerCase());
 
             const renderBreadcrumb = () => {
                 const breadcrumb = document.getElementById('breadcrumb');
@@ -647,61 +903,21 @@
                     if (!response.ok) throw new Error('Failed to fetch files.');
                     const items = await response.json();
 
-                    fileListBody.innerHTML = '';
+                    allItems = items;
                     const hasFiles = items.some(i => i.type === 'file' || !i.type);
-                    const hasItems = items.length > 0;
-
-                    if (!hasItems) {
-                        fileListBody.innerHTML = '<tr><td colspan="3" style="text-align:center;">ファイルはありません。</td></tr>';
+                    const isDownloadOnly = serverInfo.operationMode === 'downloadOnly';
+                    if (items.length === 0) {
                         downloadAllBtn.style.display = 'none';
                         deleteAllBtn.style.display = 'none';
                     } else {
-                        const isDownloadOnly = serverInfo.operationMode === 'downloadOnly';
                         downloadAllBtn.style.display = hasFiles ? 'inline-block' : 'none';
                         deleteAllBtn.style.display = (hasFiles && !isDownloadOnly) ? 'inline-block' : 'none';
-
-                        items.forEach(item => {
-                            const row = document.createElement('tr');
-                            if (item.type === 'directory') {
-                                row.classList.add('folder-row');
-                                row.innerHTML = `
-                                    <td class="preview-col">📁</td>
-                                    <td class="fileinfo-col" title="${escapeHtml(item.name)}">
-                                        <div class="fileinfo-name">${escapeHtml(item.name)}</div>
-                                    </td>
-                                    <td class="actions">
-                                        <button class="btn-download" onclick="downloadFile('${item.id}', '${escapeHtml(item.name)}.zip')">DL</button>
-                                    </td>
-                                `;
-                                row.addEventListener('click', (e) => {
-                                    if (e.target.tagName === 'BUTTON') return;
-                                    const newPath = currentPath ? `${currentPath}/${item.name}` : item.name;
-                                    navigateTo(newPath);
-                                });
-                            } else {
-                                const sizeMB = (item.size / (1024 * 1024)).toFixed(2);
-                                const preview = getFilePreview(item);
-                                const deleteBtn = isDownloadOnly
-                                    ? ''
-                                    : `<button class="btn-delete" onclick="deleteFile('${item.id}', '${escapeHtml(item.name)}')">削除</button>`;
-                                row.innerHTML = `
-                                    <td class="preview-col">${preview}</td>
-                                    <td class="fileinfo-col" title="${escapeHtml(item.name)}">
-                                        <div class="fileinfo-name">${escapeHtml(item.name)}</div>
-                                        <div class="fileinfo-size">${sizeMB} MB</div>
-                                    </td>
-                                    <td class="actions">
-                                        <button class="btn-download" onclick="downloadFile('${item.id}', '${escapeHtml(item.name)}')">DL</button>
-                                        ${deleteBtn}
-                                    </td>
-                                `;
-                            }
-                            fileListBody.appendChild(row);
-                        });
                     }
+                    renderView();
                 } catch (error) {
                     if (error.message !== 'Authentication failed.') {
-                        fileListBody.innerHTML = `<tr><td colspan="3" style="text-align:center; color: red;">${error.message}</td></tr>`;
+                        document.getElementById('file-list').innerHTML =
+                            `<table><tbody><tr><td colspan="3" style="text-align:center; color: red;">${error.message}</td></tr></tbody></table>`;
                     }
                 }
             };
@@ -1015,6 +1231,249 @@
                 } catch (error) {
                     alert(error.message);
                 }
+            });
+
+            // === ソート・ビューワーモード ===
+
+            const sortItems = (items) => {
+                const dirs = items.filter(i => i.type === 'directory');
+                const files = items.filter(i => i.type !== 'directory');
+                const cmp = (a, b) => {
+                    let r = 0;
+                    if (sortBy === 'name') r = a.name.localeCompare(b.name, undefined, { numeric: true, sensitivity: 'base' });
+                    else if (sortBy === 'size') r = (a.size || 0) - (b.size || 0);
+                    return sortOrder === 'asc' ? r : -r;
+                };
+                return [...dirs.sort(cmp), ...files.sort(cmp)];
+            };
+
+            const renderView = () => {
+                const sorted = sortItems(allItems);
+                if (isViewerMode) renderGridView(sorted);
+                else renderTableView(sorted);
+            };
+
+            const renderTableView = (items) => {
+                const fileList = document.getElementById('file-list');
+                const isDownloadOnly = serverInfo.operationMode === 'downloadOnly';
+
+                if (items.length === 0) {
+                    fileList.innerHTML = '<table><tbody><tr><td colspan="3" style="text-align:center;">ファイルはありません。</td></tr></tbody></table>';
+                    return;
+                }
+
+                fileList.innerHTML = `
+                    <table>
+                        <thead>
+                            <tr>
+                                <th class="preview-col"></th>
+                                <th class="fileinfo-col">ファイル名</th>
+                                <th class="actions">操作</th>
+                            </tr>
+                        </thead>
+                        <tbody></tbody>
+                    </table>`;
+                const tbody = fileList.querySelector('tbody');
+
+                items.forEach(item => {
+                    const row = document.createElement('tr');
+                    if (item.type === 'directory') {
+                        row.classList.add('folder-row');
+                        row.innerHTML = `
+                            <td class="preview-col">📁</td>
+                            <td class="fileinfo-col" title="${escapeHtml(item.name)}">
+                                <div class="fileinfo-name">${escapeHtml(item.name)}</div>
+                            </td>
+                            <td class="actions">
+                                <button class="btn-download" onclick="downloadFile('${item.id}', '${escapeHtml(item.name)}.zip')">DL</button>
+                            </td>`;
+                        row.addEventListener('click', (e) => {
+                            if (e.target.tagName === 'BUTTON') return;
+                            navigateTo(currentPath ? `${currentPath}/${item.name}` : item.name);
+                        });
+                    } else {
+                        const sizeMB = (item.size / (1024 * 1024)).toFixed(2);
+                        const preview = getFilePreview(item);
+                        const deleteBtn = isDownloadOnly
+                            ? ''
+                            : `<button class="btn-delete" onclick="deleteFile('${item.id}', '${escapeHtml(item.name)}')">削除</button>`;
+                        row.innerHTML = `
+                            <td class="preview-col">${preview}</td>
+                            <td class="fileinfo-col" title="${escapeHtml(item.name)}">
+                                <div class="fileinfo-name">${escapeHtml(item.name)}</div>
+                                <div class="fileinfo-size">${sizeMB} MB</div>
+                            </td>
+                            <td class="actions">
+                                <button class="btn-download" onclick="downloadFile('${item.id}', '${escapeHtml(item.name)}')">DL</button>
+                                ${deleteBtn}
+                            </td>`;
+                    }
+                    tbody.appendChild(row);
+                });
+            };
+
+            const renderGridView = (items) => {
+                lightboxImageList = items.filter(i => i.type !== 'directory' && isImageFile(i.name));
+                const isDownloadOnly = serverInfo.operationMode === 'downloadOnly';
+                const fileList = document.getElementById('file-list');
+
+                if (items.length === 0) {
+                    fileList.innerHTML = '<p style="text-align:center; color:#666; padding:1rem;">ファイルはありません。</p>';
+                    return;
+                }
+
+                let header = '';
+                if (compareImages.length > 0) {
+                    const openBtn = compareImages.length === 2
+                        ? '<button id="compareOpenBtn" style="margin-left:0.5rem; padding:0.2rem 0.6rem; background:#1a73e8; color:white; border:none; border-radius:4px; cursor:pointer;">比較する</button>'
+                        : '';
+                    header = `<div style="text-align:right; margin-bottom:0.5rem; font-size:0.85rem; color:#666;">
+                        ${compareImages.length}/2 選択中${openBtn}
+                        <button id="compareClearBtn" style="margin-left:0.5rem; padding:0.2rem 0.6rem; background:#999; color:white; border:none; border-radius:4px; cursor:pointer;">クリア</button>
+                    </div>`;
+                }
+
+                let html = header + '<div class="viewer-grid">';
+                items.forEach(item => {
+                    if (item.type === 'directory') {
+                        const target = currentPath ? `${currentPath}/${item.name}` : item.name;
+                        html += `<div class="viewer-item" onclick="navigateTo('${escapeHtml(target)}')">
+                            <div class="viewer-icon">📁</div>
+                            <div class="viewer-name" title="${escapeHtml(item.name)}">${escapeHtml(item.name)}</div>
+                        </div>`;
+                    } else if (isImageFile(item.name)) {
+                        const imgIdx = lightboxImageList.findIndex(i => i.id === item.id);
+                        const sel = compareImages.some(c => c.id === item.id);
+                        html += `<div class="viewer-item${sel ? ' selected' : ''}">
+                            <img src="/api/thumbnail/${item.id}" alt="${escapeHtml(item.name)}" loading="lazy" onclick="openLightbox(${imgIdx})" style="cursor:pointer;">
+                            <div class="viewer-name" title="${escapeHtml(item.name)}">${escapeHtml(item.name)}</div>
+                            <button class="viewer-compare-btn${sel ? ' selected' : ''}" onclick="toggleCompare('${item.id}','${escapeHtml(item.name)}')">
+                                ${sel ? '✓ 選択済' : '比較選択'}
+                            </button>
+                        </div>`;
+                    } else {
+                        const preview = getFilePreview(item);
+                        html += `<div class="viewer-item" onclick="downloadFile('${item.id}','${escapeHtml(item.name)}')">
+                            <div class="viewer-icon">${preview}</div>
+                            <div class="viewer-name" title="${escapeHtml(item.name)}">${escapeHtml(item.name)}</div>
+                        </div>`;
+                    }
+                });
+                html += '</div>';
+                fileList.innerHTML = html;
+
+                const compareOpenBtn = document.getElementById('compareOpenBtn');
+                if (compareOpenBtn) compareOpenBtn.addEventListener('click', openComparison);
+                const compareClearBtn = document.getElementById('compareClearBtn');
+                if (compareClearBtn) compareClearBtn.addEventListener('click', () => { compareImages = []; renderView(); });
+            };
+
+            window.toggleCompare = (id, name) => {
+                const idx = compareImages.findIndex(c => c.id === id);
+                if (idx >= 0) {
+                    compareImages.splice(idx, 1);
+                } else {
+                    if (compareImages.length >= 2) { alert('比較できるのは2枚までです。'); return; }
+                    compareImages.push({ id, name });
+                }
+                renderView();
+            };
+
+            const openComparison = () => {
+                if (compareImages.length < 2) return;
+                document.getElementById('comp-img-0').src = `/api/download/${compareImages[0].id}`;
+                document.getElementById('comp-meta-0').textContent = compareImages[0].name;
+                document.getElementById('comp-img-1').src = `/api/download/${compareImages[1].id}`;
+                document.getElementById('comp-meta-1').textContent = compareImages[1].name;
+                document.getElementById('comparison-view').classList.add('open');
+            };
+
+            document.getElementById('comparison-close').addEventListener('click', () => {
+                document.getElementById('comparison-view').classList.remove('open');
+            });
+
+            // === ライトボックス ===
+            const lightboxEl = document.getElementById('lightbox');
+            const lightboxImg = document.getElementById('lightbox-img');
+            const lightboxMeta = document.getElementById('lightbox-meta');
+
+            window.openLightbox = (idx) => {
+                if (lightboxImageList.length === 0) return;
+                lightboxIndex = idx;
+                lightboxScale = 1;
+                lightboxImg.style.transform = 'scale(1)';
+                updateLightbox();
+                lightboxEl.classList.add('open');
+                document.body.style.overflow = 'hidden';
+            };
+
+            const updateLightbox = () => {
+                const item = lightboxImageList[lightboxIndex];
+                if (!item) return;
+                lightboxImg.src = `/api/download/${item.id}`;
+                lightboxImg.alt = item.name;
+                const sizeMB = item.size ? ` • ${(item.size / (1024 * 1024)).toFixed(2)} MB` : '';
+                lightboxMeta.textContent = `${item.name}${sizeMB} (${lightboxIndex + 1} / ${lightboxImageList.length})`;
+            };
+
+            const closeLightbox = () => {
+                lightboxEl.classList.remove('open');
+                document.body.style.overflow = '';
+                lightboxImg.src = '';
+            };
+
+            document.getElementById('lightbox-close').addEventListener('click', closeLightbox);
+            lightboxEl.addEventListener('click', (e) => { if (e.target === lightboxEl) closeLightbox(); });
+
+            document.getElementById('lightbox-prev').addEventListener('click', () => {
+                lightboxIndex = (lightboxIndex - 1 + lightboxImageList.length) % lightboxImageList.length;
+                lightboxScale = 1;
+                lightboxImg.style.transform = 'scale(1)';
+                updateLightbox();
+            });
+
+            document.getElementById('lightbox-next').addEventListener('click', () => {
+                lightboxIndex = (lightboxIndex + 1) % lightboxImageList.length;
+                lightboxScale = 1;
+                lightboxImg.style.transform = 'scale(1)';
+                updateLightbox();
+            });
+
+            document.getElementById('lightbox-img-wrap').addEventListener('wheel', (e) => {
+                e.preventDefault();
+                lightboxScale = Math.min(Math.max(lightboxScale * (e.deltaY > 0 ? 0.9 : 1.1), 0.5), 5);
+                lightboxImg.style.transform = `scale(${lightboxScale})`;
+            }, { passive: false });
+
+            document.addEventListener('keydown', (e) => {
+                if (!lightboxEl.classList.contains('open')) return;
+                if (e.key === 'ArrowLeft') document.getElementById('lightbox-prev').click();
+                else if (e.key === 'ArrowRight') document.getElementById('lightbox-next').click();
+                else if (e.key === 'Escape') closeLightbox();
+            });
+
+            // === ソートボタン ===
+            const updateSortButtons = () => {
+                document.getElementById('sortNameBtn').classList.toggle('active', sortBy === 'name');
+                document.getElementById('sortSizeBtn').classList.toggle('active', sortBy === 'size');
+                document.getElementById('sortOrderBtn').textContent = sortOrder === 'asc' ? '↑' : '↓';
+            };
+
+            document.getElementById('sortNameBtn').addEventListener('click', () => {
+                sortBy = 'name'; updateSortButtons(); renderView();
+            });
+            document.getElementById('sortSizeBtn').addEventListener('click', () => {
+                sortBy = 'size'; updateSortButtons(); renderView();
+            });
+            document.getElementById('sortOrderBtn').addEventListener('click', () => {
+                sortOrder = sortOrder === 'asc' ? 'desc' : 'asc'; updateSortButtons(); renderView();
+            });
+            document.getElementById('viewerModeBtn').addEventListener('click', () => {
+                isViewerMode = !isViewerMode;
+                const btn = document.getElementById('viewerModeBtn');
+                btn.classList.toggle('active', isViewerMode);
+                btn.textContent = isViewerMode ? '☰ リスト' : '🖼 グリッド';
+                renderView();
             });
 
             // 初期化処理：サーバー情報を取得し、認証モードに応じてPINモーダルを表示

--- a/assets/web/index.html
+++ b/assets/web/index.html
@@ -365,6 +365,26 @@
         .clipboard-section {
             margin-top: 0;
         }
+        .breadcrumb {
+            display: flex;
+            align-items: center;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+            padding: 0.5rem 0;
+            font-size: 0.9rem;
+            margin-bottom: 0.5rem;
+            min-height: 2rem;
+        }
+        .breadcrumb-item {
+            color: #1a73e8;
+            cursor: pointer;
+            text-decoration: underline;
+        }
+        .breadcrumb-item:hover { color: #0d47a1; }
+        .breadcrumb-sep { color: #999; }
+        .breadcrumb-current { color: #333; font-weight: 500; }
+        .folder-row { cursor: pointer; }
+        .folder-row:hover td { background-color: #f0f7ff; }
     </style>
 </head>
 <body>
@@ -416,6 +436,8 @@
                     <button id="downloadAllBtn">すべてをzipでダウンロード</button>
                     <button id="deleteAllBtn">すべてを削除</button>
                 </div>
+
+                <div id="breadcrumb"></div>
 
                 <div id="file-list">
                     <table>
@@ -471,6 +493,36 @@
 
             // サーバー情報（モード等）
             let serverInfo = {};
+            // 現在表示中のフォルダパス（ルートは空文字）
+            let currentPath = '';
+
+            const renderBreadcrumb = () => {
+                const breadcrumb = document.getElementById('breadcrumb');
+                if (!currentPath) {
+                    breadcrumb.innerHTML = '<span class="breadcrumb-current">🏠 ホーム</span>';
+                    return;
+                }
+                const parts = currentPath.split('/');
+                let html = '<span class="breadcrumb-item" onclick="navigateTo(\'\')">🏠 ホーム</span>';
+                let accumulated = '';
+                parts.forEach((part, i) => {
+                    accumulated += (accumulated ? '/' : '') + part;
+                    html += '<span class="breadcrumb-sep"> / </span>';
+                    if (i === parts.length - 1) {
+                        html += `<span class="breadcrumb-current">${escapeHtml(part)}</span>`;
+                    } else {
+                        const path = accumulated;
+                        html += `<span class="breadcrumb-item" onclick="navigateTo('${escapeHtml(path)}')">${escapeHtml(part)}</span>`;
+                    }
+                });
+                breadcrumb.innerHTML = html;
+            };
+
+            window.navigateTo = (path) => {
+                currentPath = path;
+                renderBreadcrumb();
+                fetchFiles();
+            };
 
             // 401を検知してPINモーダルを表示する汎用fetchラッパー
             const safeFetch = async (url, options = {}) => {
@@ -586,55 +638,80 @@
                 return '📁'; // Default icon
             };
 
-            // ファイル一覧を取得して表示
+            // ファイル一覧を取得して表示（サブフォルダナビゲーション対応）
             const fetchFiles = async () => {
+                renderBreadcrumb();
                 try {
-                    const response = await safeFetch('/api/files');
+                    const url = currentPath ? `/api/files?path=${encodeURIComponent(currentPath)}` : '/api/files';
+                    const response = await safeFetch(url);
                     if (!response.ok) throw new Error('Failed to fetch files.');
-                    const files = await response.json();
+                    const items = await response.json();
 
                     fileListBody.innerHTML = '';
-                    if (files.length === 0) {
+                    const hasFiles = items.some(i => i.type === 'file' || !i.type);
+                    const hasItems = items.length > 0;
+
+                    if (!hasItems) {
                         fileListBody.innerHTML = '<tr><td colspan="3" style="text-align:center;">ファイルはありません。</td></tr>';
-                        downloadAllBtn.style.display = 'none'; // ファイルがなければボタンを隠す
-                        deleteAllBtn.style.display = 'none'; // ファイルがなければボタンを隠す
+                        downloadAllBtn.style.display = 'none';
+                        deleteAllBtn.style.display = 'none';
                     } else {
                         const isDownloadOnly = serverInfo.operationMode === 'downloadOnly';
-                        downloadAllBtn.style.display = 'inline-block'; // ファイルがあればボタンを表示
-                        deleteAllBtn.style.display = isDownloadOnly ? 'none' : 'inline-block';
-                        files.forEach(file => {
+                        downloadAllBtn.style.display = hasFiles ? 'inline-block' : 'none';
+                        deleteAllBtn.style.display = (hasFiles && !isDownloadOnly) ? 'inline-block' : 'none';
+
+                        items.forEach(item => {
                             const row = document.createElement('tr');
-                            const sizeMB = (file.size / (1024 * 1024)).toFixed(2);
-                            const preview = getFilePreview(file);
-
-                            const deleteBtn = isDownloadOnly
-                                ? ''
-                                : `<button class="btn-delete" onclick="deleteFile('${file.id}', '${escapeHtml(file.name)}')">削除</button>`;
-
-                            row.innerHTML = `
-                                <td class="preview-col">${preview}</td>
-                                <td class="fileinfo-col" title="${escapeHtml(file.name)}">
-                                    <div class="fileinfo-name">${escapeHtml(file.name)}</div>
-                                    <div class="fileinfo-size">${sizeMB} MB</div>
-                                </td>
-                                <td class="actions">
-                                    <button class="btn-download" onclick="downloadFile('${file.id}', '${escapeHtml(file.name)}')">DL</button>
-                                    ${deleteBtn}
-                                </td>
-                            `;
+                            if (item.type === 'directory') {
+                                row.classList.add('folder-row');
+                                row.innerHTML = `
+                                    <td class="preview-col">📁</td>
+                                    <td class="fileinfo-col" title="${escapeHtml(item.name)}">
+                                        <div class="fileinfo-name">${escapeHtml(item.name)}</div>
+                                    </td>
+                                    <td class="actions">
+                                        <button class="btn-download" onclick="downloadFile('${item.id}', '${escapeHtml(item.name)}.zip')">DL</button>
+                                    </td>
+                                `;
+                                row.addEventListener('click', (e) => {
+                                    if (e.target.tagName === 'BUTTON') return;
+                                    const newPath = currentPath ? `${currentPath}/${item.name}` : item.name;
+                                    navigateTo(newPath);
+                                });
+                            } else {
+                                const sizeMB = (item.size / (1024 * 1024)).toFixed(2);
+                                const preview = getFilePreview(item);
+                                const deleteBtn = isDownloadOnly
+                                    ? ''
+                                    : `<button class="btn-delete" onclick="deleteFile('${item.id}', '${escapeHtml(item.name)}')">削除</button>`;
+                                row.innerHTML = `
+                                    <td class="preview-col">${preview}</td>
+                                    <td class="fileinfo-col" title="${escapeHtml(item.name)}">
+                                        <div class="fileinfo-name">${escapeHtml(item.name)}</div>
+                                        <div class="fileinfo-size">${sizeMB} MB</div>
+                                    </td>
+                                    <td class="actions">
+                                        <button class="btn-download" onclick="downloadFile('${item.id}', '${escapeHtml(item.name)}')">DL</button>
+                                        ${deleteBtn}
+                                    </td>
+                                `;
+                            }
                             fileListBody.appendChild(row);
                         });
                     }
                 } catch (error) {
-                     if (error.message !== 'Authentication failed.') {
+                    if (error.message !== 'Authentication failed.') {
                         fileListBody.innerHTML = `<tr><td colspan="3" style="text-align:center; color: red;">${error.message}</td></tr>`;
-                     }
+                    }
                 }
             };
 
-            // 全ファイルダウンロード処理
+            // 全ファイルダウンロード処理（現在フォルダのみ）
             downloadAllBtn.addEventListener('click', () => {
-                window.location.href = '/api/download-all';
+                const url = currentPath
+                    ? `/api/download-all?path=${encodeURIComponent(currentPath)}`
+                    : '/api/download-all';
+                window.location.href = url;
             });
 
             // 全ファイル削除処理

--- a/assets/web/index.html
+++ b/assets/web/index.html
@@ -754,24 +754,34 @@
 
             const renderBreadcrumb = () => {
                 const breadcrumb = document.getElementById('breadcrumb');
+                breadcrumb.textContent = '';
+                const mkSpan = (cls, text) => {
+                    const s = document.createElement('span');
+                    s.className = cls;
+                    s.textContent = text;
+                    return s;
+                };
                 if (!currentPath) {
-                    breadcrumb.innerHTML = '<span class="breadcrumb-current">🏠 ホーム</span>';
+                    breadcrumb.appendChild(mkSpan('breadcrumb-current', '🏠 ホーム'));
                     return;
                 }
+                const home = mkSpan('breadcrumb-item', '🏠 ホーム');
+                home.addEventListener('click', () => navigateTo(''));
+                breadcrumb.appendChild(home);
                 const parts = currentPath.split('/');
-                let html = '<span class="breadcrumb-item" onclick="navigateTo(\'\')">🏠 ホーム</span>';
                 let accumulated = '';
                 parts.forEach((part, i) => {
                     accumulated += (accumulated ? '/' : '') + part;
-                    html += '<span class="breadcrumb-sep"> / </span>';
+                    breadcrumb.appendChild(mkSpan('breadcrumb-sep', ' / '));
                     if (i === parts.length - 1) {
-                        html += `<span class="breadcrumb-current">${escapeHtml(part)}</span>`;
+                        breadcrumb.appendChild(mkSpan('breadcrumb-current', part));
                     } else {
                         const path = accumulated;
-                        html += `<span class="breadcrumb-item" onclick="navigateTo('${escapeHtml(path)}')">${escapeHtml(part)}</span>`;
+                        const item = mkSpan('breadcrumb-item', part);
+                        item.addEventListener('click', () => navigateTo(path));
+                        breadcrumb.appendChild(item);
                     }
                 });
-                breadcrumb.innerHTML = html;
             };
 
             window.navigateTo = (path) => {
@@ -1279,34 +1289,58 @@
                     const row = document.createElement('tr');
                     if (item.type === 'directory') {
                         row.classList.add('folder-row');
-                        row.innerHTML = `
-                            <td class="preview-col">📁</td>
-                            <td class="fileinfo-col" title="${escapeHtml(item.name)}">
-                                <div class="fileinfo-name">${escapeHtml(item.name)}</div>
-                            </td>
-                            <td class="actions">
-                                <button class="btn-download" onclick="downloadFile('${item.id}', '${escapeHtml(item.name)}.zip')">DL</button>
-                            </td>`;
+                        const tdIcon = document.createElement('td');
+                        tdIcon.className = 'preview-col';
+                        tdIcon.textContent = '📁';
+                        const tdName = document.createElement('td');
+                        tdName.className = 'fileinfo-col';
+                        tdName.title = item.name;
+                        const nameDiv = document.createElement('div');
+                        nameDiv.className = 'fileinfo-name';
+                        nameDiv.textContent = item.name;
+                        tdName.appendChild(nameDiv);
+                        const tdActions = document.createElement('td');
+                        tdActions.className = 'actions';
+                        const dlBtn = document.createElement('button');
+                        dlBtn.className = 'btn-download';
+                        dlBtn.textContent = 'DL';
+                        dlBtn.addEventListener('click', () => downloadFile(item.id, item.name + '.zip'));
+                        tdActions.appendChild(dlBtn);
+                        row.append(tdIcon, tdName, tdActions);
                         row.addEventListener('click', (e) => {
                             if (e.target.tagName === 'BUTTON') return;
                             navigateTo(currentPath ? `${currentPath}/${item.name}` : item.name);
                         });
                     } else {
                         const sizeMB = (item.size / (1024 * 1024)).toFixed(2);
-                        const preview = getFilePreview(item);
-                        const deleteBtn = isDownloadOnly
-                            ? ''
-                            : `<button class="btn-delete" onclick="deleteFile('${item.id}', '${escapeHtml(item.name)}')">削除</button>`;
-                        row.innerHTML = `
-                            <td class="preview-col">${preview}</td>
-                            <td class="fileinfo-col" title="${escapeHtml(item.name)}">
-                                <div class="fileinfo-name">${escapeHtml(item.name)}</div>
-                                <div class="fileinfo-size">${sizeMB} MB</div>
-                            </td>
-                            <td class="actions">
-                                <button class="btn-download" onclick="downloadFile('${item.id}', '${escapeHtml(item.name)}')">DL</button>
-                                ${deleteBtn}
-                            </td>`;
+                        const tdIcon = document.createElement('td');
+                        tdIcon.className = 'preview-col';
+                        tdIcon.textContent = getFilePreview(item);
+                        const tdName = document.createElement('td');
+                        tdName.className = 'fileinfo-col';
+                        tdName.title = item.name;
+                        const nameDiv = document.createElement('div');
+                        nameDiv.className = 'fileinfo-name';
+                        nameDiv.textContent = item.name;
+                        const sizeDiv = document.createElement('div');
+                        sizeDiv.className = 'fileinfo-size';
+                        sizeDiv.textContent = `${sizeMB} MB`;
+                        tdName.append(nameDiv, sizeDiv);
+                        const tdActions = document.createElement('td');
+                        tdActions.className = 'actions';
+                        const dlBtn = document.createElement('button');
+                        dlBtn.className = 'btn-download';
+                        dlBtn.textContent = 'DL';
+                        dlBtn.addEventListener('click', () => downloadFile(item.id, item.name));
+                        tdActions.appendChild(dlBtn);
+                        if (!isDownloadOnly) {
+                            const delBtn = document.createElement('button');
+                            delBtn.className = 'btn-delete';
+                            delBtn.textContent = '削除';
+                            delBtn.addEventListener('click', () => deleteFile(item.id, item.name));
+                            tdActions.appendChild(delBtn);
+                        }
+                        row.append(tdIcon, tdName, tdActions);
                     }
                     tbody.appendChild(row);
                 });
@@ -1322,50 +1356,73 @@
                     return;
                 }
 
-                let header = '';
+                fileList.textContent = '';
+
                 if (compareImages.length > 0) {
-                    const openBtn = compareImages.length === 2
-                        ? '<button id="compareOpenBtn" style="margin-left:0.5rem; padding:0.2rem 0.6rem; background:#1a73e8; color:white; border:none; border-radius:4px; cursor:pointer;">比較する</button>'
-                        : '';
-                    header = `<div style="text-align:right; margin-bottom:0.5rem; font-size:0.85rem; color:#666;">
-                        ${compareImages.length}/2 選択中${openBtn}
-                        <button id="compareClearBtn" style="margin-left:0.5rem; padding:0.2rem 0.6rem; background:#999; color:white; border:none; border-radius:4px; cursor:pointer;">クリア</button>
-                    </div>`;
+                    const hdr = document.createElement('div');
+                    Object.assign(hdr.style, { textAlign: 'right', marginBottom: '0.5rem', fontSize: '0.85rem', color: '#666' });
+                    hdr.appendChild(document.createTextNode(`${compareImages.length}/2 選択中`));
+                    if (compareImages.length === 2) {
+                        const openBtn = document.createElement('button');
+                        openBtn.id = 'compareOpenBtn';
+                        Object.assign(openBtn.style, { marginLeft: '0.5rem', padding: '0.2rem 0.6rem', background: '#1a73e8', color: 'white', border: 'none', borderRadius: '4px', cursor: 'pointer' });
+                        openBtn.textContent = '比較する';
+                        openBtn.addEventListener('click', openComparison);
+                        hdr.appendChild(openBtn);
+                    }
+                    const clearBtn = document.createElement('button');
+                    clearBtn.id = 'compareClearBtn';
+                    Object.assign(clearBtn.style, { marginLeft: '0.5rem', padding: '0.2rem 0.6rem', background: '#999', color: 'white', border: 'none', borderRadius: '4px', cursor: 'pointer' });
+                    clearBtn.textContent = 'クリア';
+                    clearBtn.addEventListener('click', () => { compareImages = []; renderView(); });
+                    hdr.appendChild(clearBtn);
+                    fileList.appendChild(hdr);
                 }
 
-                let html = header + '<div class="viewer-grid">';
+                const grid = document.createElement('div');
+                grid.className = 'viewer-grid';
+
                 items.forEach(item => {
+                    const viewerItem = document.createElement('div');
+                    const nameDiv = document.createElement('div');
+                    nameDiv.className = 'viewer-name';
+                    nameDiv.title = item.name;
+                    nameDiv.textContent = item.name;
+
                     if (item.type === 'directory') {
+                        viewerItem.className = 'viewer-item';
+                        const iconDiv = document.createElement('div');
+                        iconDiv.className = 'viewer-icon';
+                        iconDiv.textContent = '📁';
+                        viewerItem.append(iconDiv, nameDiv);
                         const target = currentPath ? `${currentPath}/${item.name}` : item.name;
-                        html += `<div class="viewer-item" onclick="navigateTo('${escapeHtml(target)}')">
-                            <div class="viewer-icon">📁</div>
-                            <div class="viewer-name" title="${escapeHtml(item.name)}">${escapeHtml(item.name)}</div>
-                        </div>`;
+                        viewerItem.addEventListener('click', () => navigateTo(target));
                     } else if (isImageFile(item.name)) {
                         const imgIdx = lightboxImageList.findIndex(i => i.id === item.id);
                         const sel = compareImages.some(c => c.id === item.id);
-                        html += `<div class="viewer-item${sel ? ' selected' : ''}">
-                            <img src="/api/thumbnail/${item.id}" alt="${escapeHtml(item.name)}" loading="lazy" onclick="openLightbox(${imgIdx})" style="cursor:pointer;">
-                            <div class="viewer-name" title="${escapeHtml(item.name)}">${escapeHtml(item.name)}</div>
-                            <button class="viewer-compare-btn${sel ? ' selected' : ''}" onclick="toggleCompare('${item.id}','${escapeHtml(item.name)}')">
-                                ${sel ? '✓ 選択済' : '比較選択'}
-                            </button>
-                        </div>`;
+                        viewerItem.className = `viewer-item${sel ? ' selected' : ''}`;
+                        const img = document.createElement('img');
+                        img.src = `/api/thumbnail/${item.id}`;
+                        img.alt = item.name;
+                        img.loading = 'lazy';
+                        img.style.cursor = 'pointer';
+                        img.addEventListener('click', () => openLightbox(imgIdx));
+                        const cmpBtn = document.createElement('button');
+                        cmpBtn.className = `viewer-compare-btn${sel ? ' selected' : ''}`;
+                        cmpBtn.textContent = sel ? '✓ 選択済' : '比較選択';
+                        cmpBtn.addEventListener('click', () => toggleCompare(item.id, item.name));
+                        viewerItem.append(img, nameDiv, cmpBtn);
                     } else {
-                        const preview = getFilePreview(item);
-                        html += `<div class="viewer-item" onclick="downloadFile('${item.id}','${escapeHtml(item.name)}')">
-                            <div class="viewer-icon">${preview}</div>
-                            <div class="viewer-name" title="${escapeHtml(item.name)}">${escapeHtml(item.name)}</div>
-                        </div>`;
+                        viewerItem.className = 'viewer-item';
+                        const iconDiv = document.createElement('div');
+                        iconDiv.className = 'viewer-icon';
+                        iconDiv.textContent = getFilePreview(item);
+                        viewerItem.append(iconDiv, nameDiv);
+                        viewerItem.addEventListener('click', () => downloadFile(item.id, item.name));
                     }
+                    grid.appendChild(viewerItem);
                 });
-                html += '</div>';
-                fileList.innerHTML = html;
-
-                const compareOpenBtn = document.getElementById('compareOpenBtn');
-                if (compareOpenBtn) compareOpenBtn.addEventListener('click', openComparison);
-                const compareClearBtn = document.getElementById('compareClearBtn');
-                if (compareClearBtn) compareClearBtn.addEventListener('click', () => { compareImages = []; renderView(); });
+                fileList.appendChild(grid);
             };
 
             window.toggleCompare = (id, name) => {

--- a/bin/localnode_cli.dart
+++ b/bin/localnode_cli.dart
@@ -205,7 +205,10 @@ ArgParser _buildParser() {
     ..addOption('https-cert', help: 'Path to TLS certificate file (cert.pem)')
     ..addOption('https-key', help: 'Path to TLS private key file (key.pem)')
     ..addMultiOption('post-action',
-        help: 'Script to run after each upload (repeatable)',
+        help:
+            'Script to run after each upload (repeatable). Runs as the server process user. '
+            'Use only on trusted networks. If running as a systemd service, set User= to a '
+            'low-privilege account.',
         valueHelp: 'script')
     ..addOption('token', help: 'Fixed upload token (random if not specified)')
     ..addFlag('no-token',
@@ -229,6 +232,12 @@ void _printUsage(ArgParser parser) {
   stdout.writeln('  localnode-cli --no-clipboard --verbose');
   stdout.writeln('  localnode-cli --name "MyServer"');
   stdout.writeln('  localnode-cli --https-cert /path/to/cert.pem --https-key /path/to/key.pem');
+  stdout.writeln('  localnode-cli --post-action ./resize.sh --post-action ./notify.sh');
+  stdout.writeln('');
+  stdout.writeln('Security note (--post-action):');
+  stdout.writeln('  Scripts run with the same user privileges as the LocalNode process.');
+  stdout.writeln('  If running as a systemd service, set User= to a low-privilege account.');
+  stdout.writeln('  Use only on trusted networks.');
   stdout.writeln('');
   stdout.writeln('To stop: Ctrl+C');
 }

--- a/bin/localnode_cli.dart
+++ b/bin/localnode_cli.dart
@@ -68,6 +68,22 @@ Future<void> main(List<String> args) async {
   final noToken = results['no-token'] as bool;
   final fixedToken = results['token'] as String?;
   final postActions = results['post-action'] as List<String>;
+  final mentionActionRaw = results['mention-action'] as List<String>;
+  final mentionActions = <String, String>{};
+  for (final entry in mentionActionRaw) {
+    final eq = entry.indexOf('=');
+    if (eq <= 0) {
+      stderr.writeln('Error: --mention-action must be in <alias>=<script> format: $entry');
+      exit(1);
+    }
+    final alias = entry.substring(0, eq).trim();
+    final script = entry.substring(eq + 1).trim();
+    if (alias.isEmpty || script.isEmpty) {
+      stderr.writeln('Error: --mention-action alias and script must not be empty: $entry');
+      exit(1);
+    }
+    mentionActions[alias] = script;
+  }
   final httpsCertPath = results['https-cert'] as String?;
   final httpsKeyPath = results['https-key'] as String?;
   if ((httpsCertPath == null) != (httpsKeyPath == null)) {
@@ -128,6 +144,7 @@ Future<void> main(List<String> args) async {
       httpsKeyPath: httpsKeyPath,
       uploadToken: uploadToken,
       postActions: postActions,
+      mentionActions: mentionActions,
     );
   } catch (e) {
     stderr.writeln('Error: Failed to start server: $e');
@@ -151,6 +168,12 @@ Future<void> main(List<String> args) async {
     stdout.writeln('  Post-action(s):');
     for (final s in postActions) {
       stdout.writeln('    $s');
+    }
+  }
+  if (mentionActions.isNotEmpty) {
+    stdout.writeln('  Mention action(s):');
+    for (final entry in mentionActions.entries) {
+      stdout.writeln('    @run ${entry.key} -> ${entry.value}');
     }
   }
   if (uploadToken != null) {
@@ -210,6 +233,12 @@ ArgParser _buildParser() {
             'Use only on trusted networks. If running as a systemd service, set User= to a '
             'low-privilege account.',
         valueHelp: 'script')
+    ..addMultiOption('mention-action',
+        help:
+            'Register a clipboard mention command: <alias>=<script>. '
+            'Send "@run <alias>" via clipboard to trigger the script (repeatable). '
+            'Runs as the server process user.',
+        valueHelp: 'alias=script')
     ..addOption('token', help: 'Fixed upload token (random if not specified)')
     ..addFlag('no-token',
         help: 'Disable token-based upload authentication', negatable: false)
@@ -233,8 +262,9 @@ void _printUsage(ArgParser parser) {
   stdout.writeln('  localnode-cli --name "MyServer"');
   stdout.writeln('  localnode-cli --https-cert /path/to/cert.pem --https-key /path/to/key.pem');
   stdout.writeln('  localnode-cli --post-action ./resize.sh --post-action ./notify.sh');
+  stdout.writeln('  localnode-cli --mention-action backup=./backup.sh --mention-action notify=./notify.sh');
   stdout.writeln('');
-  stdout.writeln('Security note (--post-action):');
+  stdout.writeln('Security note (--post-action / --mention-action):');
   stdout.writeln('  Scripts run with the same user privileges as the LocalNode process.');
   stdout.writeln('  If running as a systemd service, set User= to a low-privilege account.');
   stdout.writeln('  Use only on trusted networks.');
@@ -656,6 +686,7 @@ class _CliServer {
   final Map<String, DateTime> _lockoutUntil = {};
   String? _uploadToken;
   List<String> _postActions = [];
+  Map<String, String> _mentionActions = {};
 
   late final Router _router;
 
@@ -700,11 +731,13 @@ class _CliServer {
     String? httpsKeyPath,
     String? uploadToken,
     List<String> postActions = const [],
+    Map<String, String> mentionActions = const {},
   }) async {
     _authMode = authMode;
     _downloadOnly = downloadOnly;
     _uploadToken = uploadToken;
     _postActions = postActions;
+    _mentionActions = mentionActions;
     _clipboardEnabled = clipboardEnabled;
     _serverName = serverName;
     _startedAt = DateTime.now().millisecondsSinceEpoch;
@@ -1079,6 +1112,38 @@ class _CliServer {
     }
   }
 
+  void _runMentionAction(String alias, String script) {
+    () async {
+      try {
+        final result = await Process.run(
+          Platform.isWindows ? 'cmd' : script,
+          Platform.isWindows ? ['/c', script] : [],
+          runInShell: !Platform.isWindows,
+        );
+        final resultText = result.exitCode == 0
+            ? '@run $alias: OK'
+            : '@run $alias: FAILED (exit ${result.exitCode})';
+        if (result.exitCode != 0 && (result.stderr as String).isNotEmpty) {
+          stderr.writeln('[mention-action] "$alias" stderr: ${result.stderr}');
+        }
+        final resultItem = _ClipboardItem(
+          id: _generateId(),
+          text: resultText,
+          tag: 'mention-result',
+          createdAt: DateTime.now(),
+        );
+        _clipboardItems.insert(0, resultItem);
+        while (_clipboardItems.length > _maxClipboardItems) {
+          _clipboardItems.removeLast();
+        }
+        _clipboardLastModified = DateTime.now().millisecondsSinceEpoch;
+        _log('[mention-action] "$alias" -> $resultText');
+      } catch (e) {
+        stderr.writeln('[mention-action] Failed to run "$alias": $e');
+      }
+    }();
+  }
+
   Future<Response> _downloadHandler(Request req, String id) async {
     try {
       final filePath = utf8.decode(base64Url.decode(id));
@@ -1229,6 +1294,19 @@ class _CliServer {
         _clipboardItems.removeLast();
       }
       _clipboardLastModified = DateTime.now().millisecondsSinceEpoch;
+
+      // #174: @run <alias> メンション検出
+      if (_mentionActions.isNotEmpty) {
+        final match = RegExp(r'^@run\s+(\S+)$').firstMatch(text);
+        if (match != null) {
+          final alias = match.group(1)!;
+          final script = _mentionActions[alias];
+          if (script != null) {
+            _runMentionAction(alias, script);
+          }
+        }
+      }
+
       return Response.ok(json.encode(item.toJson()),
           headers: {'Content-Type': 'application/json'});
     } catch (_) {

--- a/bin/localnode_cli.dart
+++ b/bin/localnode_cli.dart
@@ -777,6 +777,7 @@ class _CliServer {
         json.encode({
           'version': '1.1.2',
           'name': _serverName,
+          'serverName': _serverName,
           'operationMode': _downloadOnly ? 'downloadOnly' : 'normal',
           'authMode': _authMode == _AuthMode.fixedPin
               ? 'fixedPin'

--- a/bin/localnode_cli.dart
+++ b/bin/localnode_cli.dart
@@ -82,6 +82,10 @@ Future<void> main(List<String> args) async {
       stderr.writeln('Error: --mention-action alias and script must not be empty: $entry');
       exit(1);
     }
+    if (alias == 'list') {
+      stderr.writeln('Error: "list" is a reserved mention name and cannot be used as an alias.');
+      exit(1);
+    }
     mentionActions[alias] = script;
   }
   final httpsCertPath = results['https-cert'] as String?;
@@ -1112,6 +1116,30 @@ class _CliServer {
     }
   }
 
+  String _buildMentionList() {
+    if (_mentionActions.isEmpty) {
+      return 'No mention actions registered.\nBuilt-in: @list';
+    }
+    final lines = ['Available mention commands:']
+      ..add('  @list — show this list')
+      ..addAll(_mentionActions.keys.map((a) => '  @run $a'));
+    return lines.join('\n');
+  }
+
+  void _replyToClipboard(String text) {
+    final item = _ClipboardItem(
+      id: _generateId(),
+      text: text,
+      tag: 'mention-result',
+      createdAt: DateTime.now(),
+    );
+    _clipboardItems.insert(0, item);
+    while (_clipboardItems.length > _maxClipboardItems) {
+      _clipboardItems.removeLast();
+    }
+    _clipboardLastModified = DateTime.now().millisecondsSinceEpoch;
+  }
+
   void _runMentionAction(String alias, String script) {
     () async {
       try {
@@ -1126,17 +1154,7 @@ class _CliServer {
         if (result.exitCode != 0 && (result.stderr as String).isNotEmpty) {
           stderr.writeln('[mention-action] "$alias" stderr: ${result.stderr}');
         }
-        final resultItem = _ClipboardItem(
-          id: _generateId(),
-          text: resultText,
-          tag: 'mention-result',
-          createdAt: DateTime.now(),
-        );
-        _clipboardItems.insert(0, resultItem);
-        while (_clipboardItems.length > _maxClipboardItems) {
-          _clipboardItems.removeLast();
-        }
-        _clipboardLastModified = DateTime.now().millisecondsSinceEpoch;
+        _replyToClipboard(resultText);
         _log('[mention-action] "$alias" -> $resultText');
       } catch (e) {
         stderr.writeln('[mention-action] Failed to run "$alias": $e');
@@ -1295,8 +1313,10 @@ class _CliServer {
       }
       _clipboardLastModified = DateTime.now().millisecondsSinceEpoch;
 
-      // #174: @run <alias> メンション検出
-      if (_mentionActions.isNotEmpty) {
+      // #174: メンションコマンド検出
+      if (text == '@list') {
+        _replyToClipboard(_buildMentionList());
+      } else {
         final match = RegExp(r'^@run\s+(\S+)$').firstMatch(text);
         if (match != null) {
           final alias = match.group(1)!;

--- a/bin/localnode_cli.dart
+++ b/bin/localnode_cli.dart
@@ -67,6 +67,7 @@ Future<void> main(List<String> args) async {
   final serverName = results['name'] as String;
   final noToken = results['no-token'] as bool;
   final fixedToken = results['token'] as String?;
+  final postActions = results['post-action'] as List<String>;
   final httpsCertPath = results['https-cert'] as String?;
   final httpsKeyPath = results['https-key'] as String?;
   if ((httpsCertPath == null) != (httpsKeyPath == null)) {
@@ -126,6 +127,7 @@ Future<void> main(List<String> args) async {
       httpsCertPath: httpsCertPath,
       httpsKeyPath: httpsKeyPath,
       uploadToken: uploadToken,
+      postActions: postActions,
     );
   } catch (e) {
     stderr.writeln('Error: Failed to start server: $e');
@@ -145,6 +147,12 @@ Future<void> main(List<String> args) async {
   }
   stdout.writeln('  Name: $serverName');
   stdout.writeln('  Mode: ${downloadOnly ? "download-only" : "normal"}');
+  if (postActions.isNotEmpty) {
+    stdout.writeln('  Post-action(s):');
+    for (final s in postActions) {
+      stdout.writeln('    $s');
+    }
+  }
   if (uploadToken != null) {
     stdout.writeln('  Upload Token: $uploadToken');
     stdout.writeln('');
@@ -196,6 +204,9 @@ ArgParser _buildParser() {
         abbr: 'n', help: 'Server name shown in browser tab title', defaultsTo: 'LocalNode')
     ..addOption('https-cert', help: 'Path to TLS certificate file (cert.pem)')
     ..addOption('https-key', help: 'Path to TLS private key file (key.pem)')
+    ..addMultiOption('post-action',
+        help: 'Script to run after each upload (repeatable)',
+        valueHelp: 'script')
     ..addOption('token', help: 'Fixed upload token (random if not specified)')
     ..addFlag('no-token',
         help: 'Disable token-based upload authentication', negatable: false)
@@ -635,6 +646,7 @@ class _CliServer {
   final Map<String, int> _failedAttempts = {};
   final Map<String, DateTime> _lockoutUntil = {};
   String? _uploadToken;
+  List<String> _postActions = [];
 
   late final Router _router;
 
@@ -678,10 +690,12 @@ class _CliServer {
     String? httpsCertPath,
     String? httpsKeyPath,
     String? uploadToken,
+    List<String> postActions = const [],
   }) async {
     _authMode = authMode;
     _downloadOnly = downloadOnly;
     _uploadToken = uploadToken;
+    _postActions = postActions;
     _clipboardEnabled = clipboardEnabled;
     _serverName = serverName;
     _startedAt = DateTime.now().millisecondsSinceEpoch;
@@ -1022,10 +1036,37 @@ class _CliServer {
         sink.add(chunk);
       }
       await sink.close();
+      if (_postActions.isNotEmpty) {
+        _runPostActions(file.path);
+      }
       return Response.ok('File uploaded: ${p.basename(file.path)}');
     } catch (e) {
       await sink.close();
       return Response.internalServerError(body: 'Upload failed: $e');
+    }
+  }
+
+  void _runPostActions(String filePath) {
+    for (final script in _postActions) {
+      () async {
+        try {
+          final result = await Process.run(
+            Platform.isWindows ? 'cmd' : script,
+            Platform.isWindows ? ['/c', script, filePath] : [filePath],
+            runInShell: !Platform.isWindows,
+          );
+          if (result.exitCode != 0) {
+            stderr.writeln('[post-action] "$script" exited ${result.exitCode}');
+            if ((result.stderr as String).isNotEmpty) {
+              stderr.writeln(result.stderr);
+            }
+          } else {
+            _log('[post-action] "$script" completed for ${p.basename(filePath)}');
+          }
+        } catch (e) {
+          stderr.writeln('[post-action] Failed to run "$script": $e');
+        }
+      }();
     }
   }
 

--- a/bin/localnode_cli.dart
+++ b/bin/localnode_cli.dart
@@ -1147,12 +1147,24 @@ class _CliServer {
   }
 
   String _buildMentionList() {
+    final lines = <String>[];
+
+    lines.add('Mention commands:');
+    lines.add('  @list — show this list');
     if (_mentionActions.isEmpty) {
-      return 'No mention actions registered.\nBuilt-in: @list';
+      lines.add('  (no @run actions registered)');
+    } else {
+      lines.addAll(_mentionActions.keys.map((a) => '  @run $a'));
     }
-    final lines = ['Available mention commands:']
-      ..add('  @list — show this list')
-      ..addAll(_mentionActions.keys.map((a) => '  @run $a'));
+
+    if (_postActions.isNotEmpty) {
+      lines.add('');
+      lines.add('Post-upload actions:');
+      for (final a in _postActions) {
+        lines.add('  ${a.pattern} -> ${a.script}');
+      }
+    }
+
     return lines.join('\n');
   }
 

--- a/bin/localnode_cli.dart
+++ b/bin/localnode_cli.dart
@@ -65,6 +65,8 @@ Future<void> main(List<String> args) async {
   final noPin = results['no-pin'] as bool;
   final fixedPin = results['pin'] as String?;
   final serverName = results['name'] as String;
+  final noToken = results['no-token'] as bool;
+  final fixedToken = results['token'] as String?;
   final httpsCertPath = results['https-cert'] as String?;
   final httpsKeyPath = results['https-key'] as String?;
   if ((httpsCertPath == null) != (httpsKeyPath == null)) {
@@ -104,6 +106,11 @@ Future<void> main(List<String> args) async {
   stdout.writeln('LocalNode CLI Server');
   stdout.writeln('=' * 40);
 
+  // #173: アップロードトークンの決定（download-only モードでは不要）
+  final String? uploadToken = (!noToken && !downloadOnly)
+      ? (fixedToken ?? _generateUploadToken())
+      : null;
+
   final server = _CliServer(verbose: verbose);
 
   try {
@@ -118,6 +125,7 @@ Future<void> main(List<String> args) async {
       clipboardEnabled: !noClipboard,
       httpsCertPath: httpsCertPath,
       httpsKeyPath: httpsKeyPath,
+      uploadToken: uploadToken,
     );
   } catch (e) {
     stderr.writeln('Error: Failed to start server: $e');
@@ -137,6 +145,14 @@ Future<void> main(List<String> args) async {
   }
   stdout.writeln('  Name: $serverName');
   stdout.writeln('  Mode: ${downloadOnly ? "download-only" : "normal"}');
+  if (uploadToken != null) {
+    stdout.writeln('  Upload Token: $uploadToken');
+    stdout.writeln('');
+    stdout.writeln('  curl example:');
+    stdout.writeln('    curl -H "Authorization: Bearer $uploadToken" \\');
+    stdout.writeln('         -F "file=@/path/to/file" \\');
+    stdout.writeln('         $serverUrl/api/upload');
+  }
   stdout.writeln('');
   stdout.writeln('QR Code:');
   _printQrCode(serverUrl);
@@ -180,6 +196,9 @@ ArgParser _buildParser() {
         abbr: 'n', help: 'Server name shown in browser tab title', defaultsTo: 'LocalNode')
     ..addOption('https-cert', help: 'Path to TLS certificate file (cert.pem)')
     ..addOption('https-key', help: 'Path to TLS private key file (key.pem)')
+    ..addOption('token', help: 'Fixed upload token (random if not specified)')
+    ..addFlag('no-token',
+        help: 'Disable token-based upload authentication', negatable: false)
     ..addFlag('help', abbr: 'h', help: 'Show this help', negatable: false);
 }
 
@@ -507,6 +526,14 @@ Future<_HttpsHostResult> _resolveHttpsHost({
   return _HttpsHostResult(bindIp: c.ip, advertisedHost: c.host);
 }
 
+/// ランダムなアップロードトークンを生成する（32文字の16進数）
+String _generateUploadToken() {
+  final r = Random.secure();
+  return List.generate(16, (_) => r.nextInt(256))
+      .map((b) => b.toRadixString(16).padLeft(2, '0'))
+      .join();
+}
+
 void _flushWindowsInput() {
   if (!Platform.isWindows) return;
   try {
@@ -607,6 +634,7 @@ class _CliServer {
   final Set<String> _sessions = {};
   final Map<String, int> _failedAttempts = {};
   final Map<String, DateTime> _lockoutUntil = {};
+  String? _uploadToken;
 
   late final Router _router;
 
@@ -649,9 +677,11 @@ class _CliServer {
     bool clipboardEnabled = true,
     String? httpsCertPath,
     String? httpsKeyPath,
+    String? uploadToken,
   }) async {
     _authMode = authMode;
     _downloadOnly = downloadOnly;
+    _uploadToken = uploadToken;
     _clipboardEnabled = clipboardEnabled;
     _serverName = serverName;
     _startedAt = DateTime.now().millisecondsSinceEpoch;
@@ -854,6 +884,15 @@ class _CliServer {
             }
           }
           if (token != null && _sessions.contains(token)) return inner(req);
+
+          // #173: Bearer トークンによるアップロード認証
+          if (_uploadToken != null &&
+              req.method == 'POST' &&
+              path == 'api/upload') {
+            final authHeader = req.headers['authorization'] ?? '';
+            if (authHeader == 'Bearer $_uploadToken') return inner(req);
+          }
+
           return Response.unauthorized(
             json.encode({'error': 'Authentication required.'}),
             headers: {'Content-Type': 'application/json'},

--- a/bin/localnode_cli.dart
+++ b/bin/localnode_cli.dart
@@ -14,6 +14,7 @@ import 'dart:typed_data';
 
 import 'package:archive/archive.dart';
 import 'package:args/args.dart';
+import 'package:basic_utils/basic_utils.dart';
 import 'package:image/image.dart' as img;
 import 'package:path/path.dart' as p;
 import 'package:qr/qr.dart';
@@ -86,7 +87,18 @@ Future<void> main(List<String> args) async {
           ? _AuthMode.fixedPin
           : _AuthMode.randomPin;
 
-  final ipAddress = specifiedIp ?? await _selectIpAddress();
+  // #177/#169: HTTPS モードで SAN→ホスト名→IP 解決フロー
+  String ipAddress;
+  String advertisedHost; // QR/URL に使うホスト名またはIP
+  if (httpsMode) {
+    final sanResult = await _resolveHttpsHost(
+        certPath: httpsCertPath!, specifiedIp: specifiedIp);
+    ipAddress = sanResult.bindIp;
+    advertisedHost = sanResult.advertisedHost;
+  } else {
+    ipAddress = specifiedIp ?? await _selectIpAddress();
+    advertisedHost = ipAddress;
+  }
 
   stdout.writeln('');
   stdout.writeln('LocalNode CLI Server');
@@ -113,7 +125,7 @@ Future<void> main(List<String> args) async {
   }
 
   final scheme = httpsMode ? 'https' : 'http';
-  final serverUrl = '$scheme://$ipAddress:$port';
+  final serverUrl = '$scheme://$advertisedHost:$port';
 
   stdout.writeln('Server started.');
   stdout.writeln('');
@@ -356,6 +368,143 @@ bool _isInteractiveForeground() {
   } catch (_) {
     return true;
   }
+}
+
+// =============================================================================
+// HTTPS: SAN → ホスト名 → IP 解決 (#177, #169)
+// =============================================================================
+
+class _HttpsHostResult {
+  final String bindIp;
+  final String advertisedHost;
+  _HttpsHostResult({required this.bindIp, required this.advertisedHost});
+}
+
+/// cert の SAN を解析し、バインド IP と広告ホストを決定する。
+/// - SANのホスト名をデバイスIPに解決して候補を絞り込む
+/// - 候補が1つなら自動決定、複数なら対話選択
+/// - 一致しない場合はエラー終了 (#169)
+Future<_HttpsHostResult> _resolveHttpsHost({
+  required String certPath,
+  String? specifiedIp,
+}) async {
+  // SAN を解析
+  List<String> sans = [];
+  try {
+    final raw = await File(certPath).readAsString();
+    final begin = '-----BEGIN CERTIFICATE-----';
+    final end = '-----END CERTIFICATE-----';
+    final startIdx = raw.indexOf(begin);
+    final endIdx = startIdx >= 0 ? raw.indexOf(end, startIdx) : -1;
+    if (startIdx >= 0 && endIdx >= 0) {
+      final pem = raw.substring(startIdx, endIdx + end.length);
+      final cert = X509Utils.x509CertificateFromPem(pem);
+      sans = cert.subjectAlternativNames ?? [];
+    }
+  } catch (e) {
+    stderr.writeln('Warning: Failed to parse certificate SANs: $e');
+  }
+
+  if (sans.isEmpty) {
+    stderr.writeln('Error: No SANs found in certificate. Cannot determine HTTPS hostname.');
+    exit(1);
+  }
+
+  // デバイスの IP 一覧を取得
+  final deviceIps = <String>{};
+  try {
+    for (final iface in await NetworkInterface.list()) {
+      for (final addr in iface.addresses) {
+        deviceIps.add(addr.address);
+      }
+    }
+  } catch (_) {}
+
+  // --ip 指定時はその IP が SAN に含まれるか検証 (#169)
+  if (specifiedIp != null) {
+    bool covered = sans.contains(specifiedIp);
+    if (!covered) {
+      // ホスト名 SAN を DNS 解決して照合
+      for (final san in sans) {
+        if (InternetAddress.tryParse(san) == null) {
+          try {
+            final addrs = await InternetAddress.lookup(san);
+            if (addrs.any((a) => a.address == specifiedIp)) {
+              covered = true;
+              break;
+            }
+          } catch (_) {}
+        }
+      }
+    }
+    if (!covered) {
+      stderr.writeln(
+          'Error: The certificate does not cover the specified IP "$specifiedIp".');
+      stderr.writeln('  Certificate SANs: ${sans.join(', ')}');
+      exit(1);
+    }
+    return _HttpsHostResult(bindIp: specifiedIp, advertisedHost: specifiedIp);
+  }
+
+  // SAN のホスト名をデバイス IP に解決して候補を抽出
+  final candidates = <({String host, String ip})>[];
+  for (final san in sans) {
+    if (InternetAddress.tryParse(san) != null) {
+      // IP SAN: デバイス IP と一致するか確認
+      if (deviceIps.contains(san)) {
+        candidates.add((host: san, ip: san));
+      }
+    } else {
+      // ホスト名 SAN: DNS 解決してデバイス IP と照合
+      try {
+        final addrs = await InternetAddress.lookup(san);
+        for (final addr in addrs) {
+          if (deviceIps.contains(addr.address)) {
+            candidates.add((host: san, ip: addr.address));
+            break;
+          }
+        }
+      } catch (_) {}
+    }
+  }
+
+  if (candidates.isEmpty) {
+    stderr.writeln(
+        'Error: Certificate SANs do not match any device IP address. Cannot start HTTPS server.');
+    stderr.writeln('  Certificate SANs: ${sans.join(', ')}');
+    stderr.writeln('  Device IPs: ${deviceIps.join(', ')}');
+    stderr.writeln('  Use --ip <address> to override, or fix the certificate.');
+    exit(1);
+  }
+
+  if (candidates.length == 1) {
+    final c = candidates.first;
+    stdout.writeln('HTTPS: Using "${c.host}" (resolved to ${c.ip})');
+    return _HttpsHostResult(bindIp: c.ip, advertisedHost: c.host);
+  }
+
+  // 複数候補 → 対話選択
+  if (stdin.hasTerminal && _isInteractiveForeground()) {
+    stdout.writeln('Multiple HTTPS hostname candidates detected:');
+    for (int i = 0; i < candidates.length; i++) {
+      final c = candidates[i];
+      stdout.writeln('  [${i + 1}] ${c.host} (${c.ip})');
+    }
+    stdout.write('Select [1-${candidates.length}] (default: 1): ');
+    try {
+      final input = stdin.readLineSync()?.trim();
+      if (input != null && input.isNotEmpty) {
+        final idx = int.tryParse(input);
+        if (idx != null && idx >= 1 && idx <= candidates.length) {
+          final c = candidates[idx - 1];
+          return _HttpsHostResult(bindIp: c.ip, advertisedHost: c.host);
+        }
+      }
+    } catch (_) {}
+  }
+  final c = candidates.first;
+  stdout.writeln('HTTPS: Auto-selecting "${c.host}" (${c.ip})');
+  return _HttpsHostResult(bindIp: c.ip, advertisedHost: c.host);
 }
 
 void _flushWindowsInput() {

--- a/bin/localnode_cli.dart
+++ b/bin/localnode_cli.dart
@@ -67,7 +67,22 @@ Future<void> main(List<String> args) async {
   final serverName = results['name'] as String;
   final noToken = results['no-token'] as bool;
   final fixedToken = results['token'] as String?;
-  final postActions = results['post-action'] as List<String>;
+  final postActionRaw = results['post-action'] as List<String>;
+  final postActions = <({String pattern, String script})>[];
+  for (final entry in postActionRaw) {
+    final eq = entry.indexOf('=');
+    if (eq <= 0) {
+      stderr.writeln('Error: --post-action must be in <pattern>=<script> format: $entry');
+      exit(1);
+    }
+    final pattern = entry.substring(0, eq).trim();
+    final script = entry.substring(eq + 1).trim();
+    if (pattern.isEmpty || script.isEmpty) {
+      stderr.writeln('Error: --post-action pattern and script must not be empty: $entry');
+      exit(1);
+    }
+    postActions.add((pattern: pattern, script: script));
+  }
   final mentionActionRaw = results['mention-action'] as List<String>;
   final mentionActions = <String, String>{};
   for (final entry in mentionActionRaw) {
@@ -170,8 +185,8 @@ Future<void> main(List<String> args) async {
   stdout.writeln('  Mode: ${downloadOnly ? "download-only" : "normal"}');
   if (postActions.isNotEmpty) {
     stdout.writeln('  Post-action(s):');
-    for (final s in postActions) {
-      stdout.writeln('    $s');
+    for (final a in postActions) {
+      stdout.writeln('    ${a.pattern} -> ${a.script}');
     }
   }
   if (mentionActions.isNotEmpty) {
@@ -233,10 +248,12 @@ ArgParser _buildParser() {
     ..addOption('https-key', help: 'Path to TLS private key file (key.pem)')
     ..addMultiOption('post-action',
         help:
-            'Script to run after each upload (repeatable). Runs as the server process user. '
+            'Script to run after matching uploads: <pattern>=<script> (repeatable). '
+            'Pattern is a glob matched against the filename (e.g. *.zip, *.png, *). '
+            'Runs as the server process user. '
             'Use only on trusted networks. If running as a systemd service, set User= to a '
             'low-privilege account.',
-        valueHelp: 'script')
+        valueHelp: 'pattern=script')
     ..addMultiOption('mention-action',
         help:
             'Register a clipboard mention command: <alias>=<script>. '
@@ -265,7 +282,7 @@ void _printUsage(ArgParser parser) {
   stdout.writeln('  localnode-cli --no-clipboard --verbose');
   stdout.writeln('  localnode-cli --name "MyServer"');
   stdout.writeln('  localnode-cli --https-cert /path/to/cert.pem --https-key /path/to/key.pem');
-  stdout.writeln('  localnode-cli --post-action ./resize.sh --post-action ./notify.sh');
+  stdout.writeln('  localnode-cli --post-action "*.png=./resize.sh" --post-action "*.zip=./unzip.sh"');
   stdout.writeln('  localnode-cli --mention-action backup=./backup.sh --mention-action notify=./notify.sh');
   stdout.writeln('');
   stdout.writeln('Security note (--post-action / --mention-action):');
@@ -689,7 +706,7 @@ class _CliServer {
   final Map<String, int> _failedAttempts = {};
   final Map<String, DateTime> _lockoutUntil = {};
   String? _uploadToken;
-  List<String> _postActions = [];
+  List<({String pattern, String script})> _postActions = [];
   Map<String, String> _mentionActions = {};
 
   late final Router _router;
@@ -734,7 +751,7 @@ class _CliServer {
     String? httpsCertPath,
     String? httpsKeyPath,
     String? uploadToken,
-    List<String> postActions = const [],
+    List<({String pattern, String script})> postActions = const [],
     Map<String, String> mentionActions = const {},
   }) async {
     _authMode = authMode;
@@ -1092,25 +1109,38 @@ class _CliServer {
     }
   }
 
+  bool _globMatch(String pattern, String filename) {
+    final regexStr = RegExp.escape(pattern)
+        .replaceAll(r'\*', '.*')
+        .replaceAll(r'\?', '.');
+    return RegExp('^$regexStr\$', caseSensitive: !Platform.isWindows)
+        .hasMatch(filename);
+  }
+
   void _runPostActions(String filePath) {
-    for (final script in _postActions) {
+    final filename = p.basename(filePath);
+    for (final action in _postActions) {
+      if (!_globMatch(action.pattern, filename)) continue;
       () async {
         try {
           final result = await Process.run(
-            Platform.isWindows ? 'cmd' : script,
-            Platform.isWindows ? ['/c', script, filePath] : [filePath],
+            Platform.isWindows ? 'cmd' : action.script,
+            Platform.isWindows
+                ? ['/c', action.script, filePath]
+                : [filePath],
             runInShell: !Platform.isWindows,
           );
           if (result.exitCode != 0) {
-            stderr.writeln('[post-action] "$script" exited ${result.exitCode}');
+            stderr.writeln(
+                '[post-action] "${action.script}" exited ${result.exitCode}');
             if ((result.stderr as String).isNotEmpty) {
               stderr.writeln(result.stderr);
             }
           } else {
-            _log('[post-action] "$script" completed for ${p.basename(filePath)}');
+            _log('[post-action] "${action.script}" completed for $filename');
           }
         } catch (e) {
-          stderr.writeln('[post-action] Failed to run "$script": $e');
+          stderr.writeln('[post-action] Failed to run "${action.script}": $e');
         }
       }();
     }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,5 @@
 import 'dart:async';
-import 'dart:io' show File, InternetAddress, Platform, stderr;
+import 'dart:io' show File, InternetAddress, Platform, exit, stderr;
 import 'package:basic_utils/basic_utils.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/foundation.dart';
@@ -647,12 +647,14 @@ void main(List<String> args) async {
   if (CliRunner.isCliMode(args)) {
     // Windows では GUI サブシステムの exe のため stdin を正しく制御できない。
     // localnode-cli.exe (コンソールサブシステム) の使用を促す。
+    // CliRunner を起動せず即終了することで stdin への 'q' 漏れを防ぐ (#170)。
     if (Platform.isWindows) {
       stderr.writeln(
           'Note: On Windows, please use localnode-cli.exe for CLI mode.');
       stderr.writeln(
           '      localnode-cli.exe --help');
       stderr.writeln('');
+      exit(0);
     }
     // CLIモードではFlutter UIを使わずにサーバーを起動
     final runner = CliRunner(args);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -475,7 +475,9 @@ class ServerNotifier extends Notifier<ServerState> {
         }
         return true; // ホスト名はすべて候補に含める
       }).toList();
-    } catch (_) {
+    } catch (e, st) {
+      stderr.writeln('Warning: SAN parsing failed for "$certPath": $e');
+      stderr.writeln(st);
       return [];
     }
   }
@@ -1016,28 +1018,34 @@ class _HomePageState extends ConsumerState<HomePage> {
           ),
           if (serverState.httpsEnabled) ...[
             const SizedBox(height: 4),
-            Row(
-              children: [
-                const SizedBox(width: 8),
-                const Text('証明書 (cert.pem):', style: TextStyle(fontSize: 13)),
-              ],
+            ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 400),
+              child: const Row(
+                children: [
+                  SizedBox(width: 8),
+                  Text('証明書ファイル:', style: TextStyle(fontSize: 13)),
+                ],
+              ),
             ),
             const SizedBox(height: 4),
             _CertPathField(
-              label: 'cert.pem',
+              label: '証明書ファイル',
               value: serverState.httpsCertPath,
               onChanged: (path) => notifier.setHttpsCertPath(path),
             ),
             const SizedBox(height: 8),
-            Row(
-              children: [
-                const SizedBox(width: 8),
-                const Text('秘密鍵 (key.pem):', style: TextStyle(fontSize: 13)),
-              ],
+            ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 400),
+              child: const Row(
+                children: [
+                  SizedBox(width: 8),
+                  Text('秘密鍵ファイル:', style: TextStyle(fontSize: 13)),
+                ],
+              ),
             ),
             const SizedBox(height: 4),
             _CertPathField(
-              label: 'key.pem',
+              label: '秘密鍵ファイル',
               value: serverState.httpsKeyPath,
               onChanged: (path) => notifier.setHttpsKeyPath(path),
             ),
@@ -1496,6 +1504,19 @@ class _HomePageState extends ConsumerState<HomePage> {
               SnackBar(
                 content: Text('秘密鍵ファイルが見つかりません: ${serverState.httpsKeyPath}'),
                 backgroundColor: Colors.red,
+              ),
+            );
+            return;
+          }
+          // #168: HTTPS モードで SAN がデバイス IP と一致しない場合は起動をブロック
+          if (serverState.httpsMode && serverState.certSanCandidates.isEmpty) {
+            if (!context.mounted) return;
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(
+                content: Text(
+                    '証明書のSANにデバイスのIPと一致するエントリがありません。接続できないため起動を中断しました。'),
+                backgroundColor: Colors.red,
+                duration: Duration(seconds: 6),
               ),
             );
             return;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,6 +10,7 @@ import 'package:localnode/server_service.dart';
 import 'package:qr_flutter/qr_flutter.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:window_manager/window_manager.dart';
 
 // サーバーの状態を表すenum
 enum ServerStatus { stopped, running, error }
@@ -664,6 +665,24 @@ void main(List<String> args) async {
 
   // 通常のFlutter UIモード
   WidgetsFlutterBinding.ensureInitialized();
+
+  // デスクトップはウィンドウサイズを設定 (#135)
+  if (!kIsWeb && (Platform.isWindows || Platform.isLinux || Platform.isMacOS)) {
+    await windowManager.ensureInitialized();
+    await windowManager.waitUntilReadyToShow(
+      const WindowOptions(
+        size: Size(520, 820),
+        minimumSize: Size(420, 600),
+        center: true,
+        titleBarStyle: TitleBarStyle.normal,
+      ),
+      () async {
+        await windowManager.show();
+        await windowManager.focus();
+      },
+    );
+  }
+
   runApp(const ProviderScope(child: MyApp()));
 }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -475,7 +475,9 @@ class ServerNotifier extends Notifier<ServerState> {
         }
         return true; // ホスト名はすべて候補に含める
       }).toList();
-    } catch (_) {
+    } catch (e, st) {
+      stderr.writeln('Warning: SAN parsing failed for "$certPath": $e');
+      stderr.writeln(st);
       return [];
     }
   }
@@ -1496,6 +1498,19 @@ class _HomePageState extends ConsumerState<HomePage> {
               SnackBar(
                 content: Text('秘密鍵ファイルが見つかりません: ${serverState.httpsKeyPath}'),
                 backgroundColor: Colors.red,
+              ),
+            );
+            return;
+          }
+          // #168: HTTPS モードで SAN がデバイス IP と一致しない場合は起動をブロック
+          if (serverState.httpsMode && serverState.certSanCandidates.isEmpty) {
+            if (!context.mounted) return;
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(
+                content: Text(
+                    '証明書のSANにデバイスのIPと一致するエントリがありません。接続できないため起動を中断しました。'),
+                backgroundColor: Colors.red,
+                duration: Duration(seconds: 6),
               ),
             );
             return;

--- a/lib/server_service.dart
+++ b/lib/server_service.dart
@@ -430,16 +430,19 @@ class ServerService {
       if (!await rootDir.exists()) {
         return Response.internalServerError(body: 'Documents directory not found.');
       }
-      // パストラバーサル防止
-      final targetPath = p.normalize(p.join(storagePath, relPath));
-      if (!targetPath.startsWith(p.normalize(storagePath))) {
-        return Response.forbidden('Access denied');
-      }
+      // パストラバーサル防止: シンボリックリンク解決後のパスで検証
+      final canonicalRoot = await rootDir.resolveSymbolicLinks();
+      final targetPath = p.normalize(p.join(canonicalRoot, relPath));
       final directory = Directory(targetPath);
       if (!await directory.exists()) {
         return Response.notFound('Directory not found.');
       }
-      final items = await directory.list().toList();
+      final canonicalTarget = await directory.resolveSymbolicLinks();
+      if (canonicalTarget != canonicalRoot &&
+          !p.isWithin(canonicalRoot, canonicalTarget)) {
+        return Response.forbidden('Access denied');
+      }
+      final items = await directory.list(followLinks: false).toList();
       final itemList = items.map((item) async {
         final isDir = item is Directory;
         final id = base64Url.encode(utf8.encode(item.path));
@@ -591,18 +594,26 @@ class ServerService {
       // 他のプラットフォーム、またはSAFが設定されていないAndroidの場合
       else {
         final filePath = decoded;
-        // パストラバーサル防止
-        final rootPath = p.normalize(storagePath);
-        if (!p.normalize(filePath).startsWith(rootPath)) {
+        // パストラバーサル防止: シンボリックリンク解決後のパスで検証
+        final canonicalRoot =
+            await Directory(storagePath).resolveSymbolicLinks();
+        final canonicalFile =
+            await File(filePath).resolveSymbolicLinks().catchError((_) async {
+          return Directory(filePath).resolveSymbolicLinks();
+        });
+        if (canonicalFile != canonicalRoot &&
+            !p.isWithin(canonicalRoot, canonicalFile)) {
           return Response.forbidden('Access denied');
         }
         // フォルダの場合はZIPで返す (#179)
         if (await FileSystemEntity.isDirectory(filePath)) {
-          final dirName = p.basename(filePath);
+          final dirName = Uri.encodeComponent(p.basename(filePath))
+              .replaceAll("'", '%27');
           final encoder = ZipEncoder();
           final archive = Archive();
           final dir = Directory(filePath);
-          final files = dir.listSync(recursive: true).whereType<File>();
+          final files =
+              dir.listSync(recursive: true, followLinks: false).whereType<File>();
           for (final file in files) {
             final bytes = await file.readAsBytes();
             final rel = p.relative(file.path, from: filePath);
@@ -614,7 +625,8 @@ class ServerService {
           }
           return Response.ok(zipData, headers: {
             'Content-Type': 'application/zip',
-            'Content-Disposition': 'attachment; filename="$dirName.zip"',
+            'Content-Disposition':
+                "attachment; filename*=UTF-8''$dirName.zip",
           });
         }
         final file = File(filePath);
@@ -904,16 +916,19 @@ class ServerService {
     else {
       // ?path= で現在フォルダを指定し、そのフォルダのファイルのみをZIP (#179)
       final relPath = request.url.queryParameters['path'] ?? '';
-      final targetPath = p.normalize(p.join(storagePath, relPath));
-      if (!targetPath.startsWith(p.normalize(storagePath))) {
-        return Response.forbidden('Access denied');
-      }
+      final canonicalRoot = await Directory(storagePath).resolveSymbolicLinks();
+      final targetPath = p.normalize(p.join(canonicalRoot, relPath));
       final directory = Directory(targetPath);
       if (!await directory.exists()) {
         return Response.internalServerError(body: 'Documents directory not found.');
       }
+      final canonicalTarget = await directory.resolveSymbolicLinks();
+      if (canonicalTarget != canonicalRoot &&
+          !p.isWithin(canonicalRoot, canonicalTarget)) {
+        return Response.forbidden('Access denied');
+      }
       // 現在フォルダの直下ファイルのみ（再帰なし）
-      final files = directory.listSync().whereType<File>();
+      final files = directory.listSync(followLinks: false).whereType<File>();
       for (final file in files) {
         final bytes = await file.readAsBytes();
         final filename = p.basename(file.path);

--- a/lib/server_service.dart
+++ b/lib/server_service.dart
@@ -424,24 +424,49 @@ class ServerService {
     }
     // 他のプラットフォーム、またはSAFが設定されていないAndroidの場合は、従来のdart:ioを使用
     else {
-      final directory = Directory(storagePath);
-      if (!await directory.exists()) {
+      // ?path= パラメータで相対パスを受け取りサブフォルダナビゲーションに対応 (#178, #179)
+      final relPath = request.url.queryParameters['path'] ?? '';
+      final rootDir = Directory(storagePath);
+      if (!await rootDir.exists()) {
         return Response.internalServerError(body: 'Documents directory not found.');
       }
-      final files = await directory.list().where((item) => item is File).cast<File>().toList();
-      final fileList = files.map((file) async {
-        final stat = await file.stat();
-        // パスをBase64エンコードしてIDとして追加
-        final id = base64Url.encode(utf8.encode(file.path));
-        return {
-          'name': p.basename(file.path),
-          'size': stat.size,
-          'modified': stat.modified.toIso8601String(),
-          'id': id,
-        };
+      // パストラバーサル防止
+      final targetPath = p.normalize(p.join(storagePath, relPath));
+      if (!targetPath.startsWith(p.normalize(storagePath))) {
+        return Response.forbidden('Access denied');
+      }
+      final directory = Directory(targetPath);
+      if (!await directory.exists()) {
+        return Response.notFound('Directory not found.');
+      }
+      final items = await directory.list().toList();
+      final itemList = items.map((item) async {
+        final isDir = item is Directory;
+        final id = base64Url.encode(utf8.encode(item.path));
+        if (isDir) {
+          return {
+            'name': p.basename(item.path),
+            'type': 'directory',
+            'id': id,
+          };
+        } else {
+          final stat = await item.stat();
+          return {
+            'name': p.basename(item.path),
+            'type': 'file',
+            'size': stat.size,
+            'modified': stat.modified.toIso8601String(),
+            'id': id,
+          };
+        }
       }).toList();
 
-      final results = await Future.wait(fileList);
+      final results = await Future.wait(itemList);
+      // フォルダ先頭、名前順でソート
+      results.sort((a, b) {
+        if (a['type'] != b['type']) return a['type'] == 'directory' ? -1 : 1;
+        return (a['name'] as String).compareTo(b['name'] as String);
+      });
       return Response.ok(jsonEncode(results), headers: {'Content-Type': 'application/json'});
     }
   }
@@ -566,6 +591,32 @@ class ServerService {
       // 他のプラットフォーム、またはSAFが設定されていないAndroidの場合
       else {
         final filePath = decoded;
+        // パストラバーサル防止
+        final rootPath = p.normalize(storagePath);
+        if (!p.normalize(filePath).startsWith(rootPath)) {
+          return Response.forbidden('Access denied');
+        }
+        // フォルダの場合はZIPで返す (#179)
+        if (await FileSystemEntity.isDirectory(filePath)) {
+          final dirName = p.basename(filePath);
+          final encoder = ZipEncoder();
+          final archive = Archive();
+          final dir = Directory(filePath);
+          final files = dir.listSync(recursive: true).whereType<File>();
+          for (final file in files) {
+            final bytes = await file.readAsBytes();
+            final rel = p.relative(file.path, from: filePath);
+            archive.addFile(ArchiveFile(rel, bytes.length, bytes));
+          }
+          final zipData = encoder.encode(archive);
+          if (zipData == null) {
+            return Response.internalServerError(body: 'Failed to create zip.');
+          }
+          return Response.ok(zipData, headers: {
+            'Content-Type': 'application/zip',
+            'Content-Disposition': 'attachment; filename="$dirName.zip"',
+          });
+        }
         final file = File(filePath);
         if (!await file.exists()) {
           return Response.notFound('File not found: $filePath');
@@ -851,14 +902,21 @@ class ServerService {
     }
     // 他のプラットフォーム、またはSAFが設定されていないAndroidの場合
     else {
-      final directory = Directory(storagePath);
+      // ?path= で現在フォルダを指定し、そのフォルダのファイルのみをZIP (#179)
+      final relPath = request.url.queryParameters['path'] ?? '';
+      final targetPath = p.normalize(p.join(storagePath, relPath));
+      if (!targetPath.startsWith(p.normalize(storagePath))) {
+        return Response.forbidden('Access denied');
+      }
+      final directory = Directory(targetPath);
       if (!await directory.exists()) {
         return Response.internalServerError(body: 'Documents directory not found.');
       }
-      final files = directory.listSync(recursive: true).whereType<File>();
+      // 現在フォルダの直下ファイルのみ（再帰なし）
+      final files = directory.listSync().whereType<File>();
       for (final file in files) {
         final bytes = await file.readAsBytes();
-        final filename = p.relative(file.path, from: directory.path);
+        final filename = p.basename(file.path);
         archive.addFile(ArchiveFile(filename, bytes.length, bytes));
       }
     }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -664,6 +664,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
+  screen_retriever:
+    dependency: transitive
+    description:
+      name: screen_retriever
+      sha256: "570dbc8e4f70bac451e0efc9c9bb19fa2d6799a11e6ef04f946d7886d2e23d0c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
+  screen_retriever_linux:
+    dependency: transitive
+    description:
+      name: screen_retriever_linux
+      sha256: f7f8120c92ef0784e58491ab664d01efda79a922b025ff286e29aa123ea3dd18
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
+  screen_retriever_macos:
+    dependency: transitive
+    description:
+      name: screen_retriever_macos
+      sha256: "71f956e65c97315dd661d71f828708bd97b6d358e776f1a30d5aa7d22d78a149"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
+  screen_retriever_platform_interface:
+    dependency: transitive
+    description:
+      name: screen_retriever_platform_interface
+      sha256: ee197f4581ff0d5608587819af40490748e1e39e648d7680ecf95c05197240c0
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
+  screen_retriever_windows:
+    dependency: transitive
+    description:
+      name: screen_retriever_windows
+      sha256: "449ee257f03ca98a57288ee526a301a430a344a161f9202b4fcc38576716fe13"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
   shared_preferences:
     dependency: "direct main"
     description:
@@ -957,6 +997,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
+  window_manager:
+    dependency: "direct main"
+    description:
+      name: window_manager
+      sha256: "732896e1416297c63c9e3fb95aea72d0355f61390263982a47fd519169dc5059"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.3"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.3.0+1
+version: 1.4.0+1
 
 environment:
   sdk: '>=3.4.3 <4.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -57,6 +57,7 @@ dependencies:
   qr: ^3.0.1
   path: ^1.9.0
   basic_utils: ^5.8.2
+  window_manager: ^0.4.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary

- feat(web): Explorer-style folder navigation with breadcrumb (#178, #179)
- fix(web): zip download scope limited to current folder only (#179)
- feat(web): image viewer mode — grid, lightbox with zoom, comparison (#178)
- fix(windows): exit immediately on `--cli` to prevent `q` leaking into shell (#170)
- fix(cli): `--name` now reflected in browser tab/page title (#171)

## Test plan

- [ ] Explorer navigation: browse subfolders, breadcrumb, folder zip download
- [ ] Viewer mode: grid toggle, lightbox zoom, image comparison, download from lightbox
- [ ] Windows: `LocalNode.exe --cli` shows advisory and exits cleanly (no `q` leak)
- [ ] CLI `--name "My Server"`: browser tab and h1 show correct name

🤖 Generated with [Claude Code](https://claude.com/claude-code)