### PR TITLE
version/1.4.0: device test bugfixes and security fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,12 @@ localnode-cli --mention-action backup=./backup.sh --mention-action notify=./noti
 
 ```
 
+> **Note (`--post-action` / `--mention-action`):** The `script` value must be a path to an executable file only — passing arguments inline (e.g. `script=./notify.sh arg1`) is not supported. For `--post-action`, the uploaded file path is automatically passed as the first argument to the script.
+
+```bash
+
+```
+
 To stop the server: **Ctrl+C**.
 
 ## Platform Support

--- a/README.md
+++ b/README.md
@@ -140,10 +140,14 @@ localnode-cli --mention-action backup=./backup.sh --mention-action notify=./noti
 ```
 
 > **Note (`--post-action` / `--mention-action`):** The `script` value must be a path to an executable file only — passing arguments inline (e.g. `script=./notify.sh arg1`) is not supported. For `--post-action`, the uploaded file path is automatically passed as the first argument to the script.
-
-```bash
-
-```
+>
+> ```bash
+> # Valid: executable path only; the uploaded file path is passed automatically
+> localnode-cli --post-action "*.jpg=./process-image.sh"
+>
+> # Valid: mention action with an executable path only
+> localnode-cli --mention-action backup=./backup.sh
+> ```
 
 To stop the server: **Ctrl+C**.
 

--- a/assets/web/index.html
+++ b/assets/web/index.html
@@ -539,6 +539,19 @@
             cursor: pointer;
             border-radius: 4px;
         }
+        #lightbox-save {
+            position: fixed;
+            bottom: 2.5rem;
+            left: 50%;
+            transform: translateX(-50%);
+            background: rgba(255,255,255,0.2);
+            border: none;
+            color: white;
+            font-size: 0.9rem;
+            padding: 0.3rem 0.8rem;
+            cursor: pointer;
+            border-radius: 4px;
+        }
         #lightbox-zoom-hint {
             position: fixed;
             bottom: 1rem;
@@ -699,6 +712,7 @@
         </div>
         <button class="lightbox-nav" id="lightbox-next">›</button>
         <div id="lightbox-meta"></div>
+        <button id="lightbox-save">⬇ 保存</button>
         <div id="lightbox-zoom-hint">スクロールでズーム • 矢印キーで移動</div>
     </div>
 
@@ -901,7 +915,7 @@
                 if (videoExtensions.includes(ext)) return '🎬';
                 if (audioExtensions.includes(ext)) return '🎵';
                 if (ext === 'pdf') return '📄';
-                return '📁'; // Default icon
+                return '📎';
             };
 
             // ファイル一覧を取得して表示（サブフォルダナビゲーション対応）
@@ -1315,7 +1329,16 @@
                         const sizeMB = (item.size / (1024 * 1024)).toFixed(2);
                         const tdIcon = document.createElement('td');
                         tdIcon.className = 'preview-col';
-                        tdIcon.textContent = getFilePreview(item);
+                        const preview = getFilePreview(item);
+                        if (preview.startsWith('<img')) {
+                            const img = document.createElement('img');
+                            img.src = `/api/thumbnail/${item.id}`;
+                            img.alt = item.name;
+                            img.loading = 'lazy';
+                            tdIcon.appendChild(img);
+                        } else {
+                            tdIcon.textContent = preview;
+                        }
                         const tdName = document.createElement('td');
                         tdName.className = 'fileinfo-col';
                         tdName.title = item.name;
@@ -1481,6 +1504,10 @@
 
             document.getElementById('lightbox-close').addEventListener('click', closeLightbox);
             lightboxEl.addEventListener('click', (e) => { if (e.target === lightboxEl) closeLightbox(); });
+            document.getElementById('lightbox-save').addEventListener('click', () => {
+                const item = lightboxImageList[lightboxIndex];
+                if (item) downloadFile(item.id, item.name);
+            });
 
             document.getElementById('lightbox-prev').addEventListener('click', () => {
                 lightboxIndex = (lightboxIndex - 1 + lightboxImageList.length) % lightboxImageList.length;

--- a/assets/web/index.html
+++ b/assets/web/index.html
@@ -1329,15 +1329,14 @@
                         const sizeMB = (item.size / (1024 * 1024)).toFixed(2);
                         const tdIcon = document.createElement('td');
                         tdIcon.className = 'preview-col';
-                        const preview = getFilePreview(item);
-                        if (preview.startsWith('<img')) {
+                        if (isImageFile(item.name)) {
                             const img = document.createElement('img');
                             img.src = `/api/thumbnail/${item.id}`;
                             img.alt = item.name;
                             img.loading = 'lazy';
                             tdIcon.appendChild(img);
                         } else {
-                            tdIcon.textContent = preview;
+                            tdIcon.textContent = getFilePreview(item);
                         }
                         const tdName = document.createElement('td');
                         tdName.className = 'fileinfo-col';

--- a/bin/localnode_cli.dart
+++ b/bin/localnode_cli.dart
@@ -200,7 +200,8 @@ Future<void> main(List<String> args) async {
     stdout.writeln('');
     stdout.writeln('  curl example:');
     stdout.writeln('    curl -H "Authorization: Bearer $uploadToken" \\');
-    stdout.writeln('         -F "file=@/path/to/file" \\');
+    stdout.writeln('         -H "x-filename: myfile.txt" \\');
+    stdout.writeln('         --data-binary @/path/to/myfile.txt \\');
     stdout.writeln('         $serverUrl/api/upload');
   }
   stdout.writeln('');
@@ -1055,25 +1056,43 @@ class _CliServer {
         headers: {'Content-Type': 'application/json'},
       );
 
-  Future<Response> _getFilesHandler(Request _) async {
-    final dir = Directory(_storagePath!);
-    if (!await dir.exists()) {
+  Future<Response> _getFilesHandler(Request req) async {
+    final root = Directory(_storagePath!);
+    if (!await root.exists()) {
       return Response.internalServerError(body: 'Storage directory not found.');
     }
-    final files = await dir
-        .list()
-        .where((e) => e is File)
-        .cast<File>()
-        .toList();
-    final list = await Future.wait(files.map((f) async {
-      final stat = await f.stat();
+    final relPath = req.url.queryParameters['path'] ?? '';
+    final canonicalRoot = await root.resolveSymbolicLinks();
+    final targetPath = p.normalize(p.join(canonicalRoot, relPath));
+    final dir = Directory(targetPath);
+    if (!await dir.exists()) {
+      return Response.notFound('Directory not found.');
+    }
+    final canonicalTarget = await dir.resolveSymbolicLinks();
+    if (canonicalTarget != canonicalRoot &&
+        !p.isWithin(canonicalRoot, canonicalTarget)) {
+      return Response.forbidden('Access denied');
+    }
+    final entries = await dir.list(followLinks: false).toList();
+    final list = await Future.wait(entries.map((e) async {
+      final isDir = e is Directory;
+      final id = base64Url.encode(utf8.encode(e.path));
+      if (isDir) {
+        return {'name': p.basename(e.path), 'type': 'directory', 'id': id};
+      }
+      final stat = await e.stat();
       return {
-        'name': p.basename(f.path),
+        'name': p.basename(e.path),
+        'type': 'file',
         'size': stat.size,
         'modified': stat.modified.toIso8601String(),
-        'id': base64Url.encode(utf8.encode(f.path)),
+        'id': id,
       };
     }));
+    list.sort((a, b) {
+      if (a['type'] != b['type']) return a['type'] == 'directory' ? -1 : 1;
+      return (a['name'] as String).compareTo(b['name'] as String);
+    });
     return Response.ok(jsonEncode(list),
         headers: {'Content-Type': 'application/json'});
   }
@@ -1109,6 +1128,21 @@ class _CliServer {
     }
   }
 
+  // Windows で .ps1 は powershell.exe 経由で実行
+  (String executable, List<String> args) _buildCommand(
+      String script, List<String> extraArgs) {
+    if (Platform.isWindows) {
+      if (script.toLowerCase().endsWith('.ps1')) {
+        return (
+          'powershell.exe',
+          ['-ExecutionPolicy', 'Bypass', '-File', script, ...extraArgs]
+        );
+      }
+      return ('cmd', ['/c', script, ...extraArgs]);
+    }
+    return (script, extraArgs);
+  }
+
   bool _globMatch(String pattern, String filename) {
     final regexStr = RegExp.escape(pattern)
         .replaceAll(r'\*', '.*')
@@ -1123,11 +1157,9 @@ class _CliServer {
       if (!_globMatch(action.pattern, filename)) continue;
       () async {
         try {
+          final cmd = _buildCommand(action.script, [filePath]);
           final result = await Process.run(
-            Platform.isWindows ? 'cmd' : action.script,
-            Platform.isWindows
-                ? ['/c', action.script, filePath]
-                : [filePath],
+            cmd.$1, cmd.$2,
             runInShell: !Platform.isWindows,
           );
           if (result.exitCode != 0) {
@@ -1185,9 +1217,9 @@ class _CliServer {
   void _runMentionAction(String alias, String script) {
     () async {
       try {
+        final cmd = _buildCommand(script, []);
         final result = await Process.run(
-          Platform.isWindows ? 'cmd' : script,
-          Platform.isWindows ? ['/c', script] : [],
+          cmd.$1, cmd.$2,
           runInShell: !Platform.isWindows,
         );
         final resultText = result.exitCode == 0
@@ -1247,17 +1279,28 @@ class _CliServer {
     }
   }
 
-  Future<Response> _downloadAllHandler(Request _) async {
-    final dir = Directory(_storagePath!);
-    if (!await dir.exists()) {
+  Future<Response> _downloadAllHandler(Request req) async {
+    final root = Directory(_storagePath!);
+    if (!await root.exists()) {
       return Response.internalServerError(body: 'Storage directory not found.');
     }
+    final relPath = req.url.queryParameters['path'] ?? '';
+    final canonicalRoot = await root.resolveSymbolicLinks();
+    final targetPath = p.normalize(p.join(canonicalRoot, relPath));
+    final dir = Directory(targetPath);
+    if (!await dir.exists()) {
+      return Response.internalServerError(body: 'Directory not found.');
+    }
+    final canonicalTarget = await dir.resolveSymbolicLinks();
+    if (canonicalTarget != canonicalRoot &&
+        !p.isWithin(canonicalRoot, canonicalTarget)) {
+      return Response.forbidden('Access denied');
+    }
     final archive = Archive();
-    final files = dir.listSync(recursive: true).whereType<File>();
+    final files = dir.listSync(followLinks: false).whereType<File>();
     for (final f in files) {
       final bytes = await f.readAsBytes();
-      archive.addFile(ArchiveFile(
-          p.relative(f.path, from: dir.path), bytes.length, bytes));
+      archive.addFile(ArchiveFile(p.basename(f.path), bytes.length, bytes));
     }
     final zip = ZipEncoder().encode(archive);
     if (zip == null) {


### PR DESCRIPTION
## Summary

Post-device-test bugfixes and Copilot review security fixes on top of the v1.4.0 feature set.

- CLI folder navigation (`?path=` support, directory listing with `type` field)
- Lightbox save button restored
- Table view thumbnail rendering fixed
- Windows `.ps1` support for post-action / mention-action
- curl upload example corrected (`--data-binary` + `x-filename` header)
- Path traversal / symlink / XSS fixes from Copilot review

## Test plan

- [ ] Web UI: folder navigation works in CLI mode
- [ ] Web UI: thumbnails render correctly in table view
- [ ] Web UI: lightbox save button downloads image
- [ ] CLI: `.ps1` post-action fires on Windows
- [ ] CLI: curl upload example works as shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)