### PR TITLE
version/1.4.0: fix .ps1 script execution on Windows

### DIFF
--- a/bin/localnode_cli.dart
+++ b/bin/localnode_cli.dart
@@ -1134,8 +1134,8 @@ class _CliServer {
     if (Platform.isWindows) {
       if (script.toLowerCase().endsWith('.ps1')) {
         return (
-          'powershell.exe',
-          ['-ExecutionPolicy', 'Bypass', '-File', script, ...extraArgs]
+          'cmd',
+          ['/c', 'powershell.exe', '-ExecutionPolicy', 'Bypass', '-File', script, ...extraArgs]
         );
       }
       return ('cmd', ['/c', script, ...extraArgs]);


### PR DESCRIPTION
## Summary

- Fix `.ps1` scripts not running silently via `--post-action` / `--mention-action` on Windows
- Root cause: `powershell.exe` launched directly with `runInShell: false` is unreliable; now wrapped as `cmd /c powershell.exe -ExecutionPolicy Bypass -File script.ps1`

## Test plan

- [ ] Windows: `--post-action "*.ps1=./test.ps1"` fires on upload
- [ ] Windows: `--mention-action run=./test.ps1` fires on `@run run` via clipboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)