### PR TITLE
version/1.5.0: bugfixes and UX improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ localnode --cli [options]
 | `--https-key` | Path to TLS private key file (key.pem) |
 | `--post-action` | Script to execute on matching uploads: `pattern=script` (repeatable, glob pattern) |
 | `--mention-action` | Register clipboard mention command: `alias=script` (repeatable) |
-| `--token` | Fixed upload token for Bearer auth (random if not specified) |
-| `--no-token` | Disable token-based upload authentication |
+| `--token` | Fixed Bearer token for upload and clipboard POST (random if not specified) |
+| `--no-token` | Disable token-based authentication for upload and clipboard POST |
 | `--no-pin` | Disable PIN authentication |
 | `--no-clipboard` | Hide clipboard content from console output |
 | `--verbose`, `-v` | Enable verbose request logging |

--- a/assets/web/index.html
+++ b/assets/web/index.html
@@ -249,6 +249,28 @@
             white-space: pre-wrap;
             margin: 0 0 0.5rem 0;
         }
+        .clipboard-file-thumb {
+            max-width: 80px;
+            max-height: 80px;
+            border-radius: 4px;
+            cursor: pointer;
+            vertical-align: middle;
+            margin: 0 0.2rem;
+            border: 1px solid #b2dfdb;
+        }
+        .clipboard-file-thumb:hover { border-color: #00796b; }
+        .clipboard-file-chip {
+            display: inline-block;
+            padding: 0.1rem 0.5rem;
+            margin: 0 0.2rem;
+            background: #b2dfdb;
+            color: #00695c;
+            border-radius: 3px;
+            font-size: 0.85rem;
+            cursor: pointer;
+            vertical-align: middle;
+        }
+        .clipboard-file-chip:hover { background: #80cbc4; }
         .clipboard-item-meta {
             display: flex;
             align-items: center;
@@ -1193,7 +1215,7 @@
                 clipboardList.innerHTML = items.map(item => `
                     <div class="clipboard-item" data-id="${escapeHtml(item.id)}">
                         <div class="clipboard-item-content">
-                            <p class="clipboard-item-text">${escapeHtml(item.text)}</p>
+                            <p class="clipboard-item-text">${renderClipboardText(item.text)}</p>
                             <div class="clipboard-item-meta">
                                 ${item.tag ? `<span class="clipboard-item-tag">${escapeHtml(item.tag)}</span>` : ''}
                                 <span class="clipboard-item-time">${formatTime(item.createdAt)}</span>
@@ -1206,6 +1228,58 @@
                     </div>
                 `).join('');
             };
+
+            // #198: @file:<relpath> をサムネイル/チップに変換（メッセージあたり最大5個）
+            const renderClipboardText = (text) => {
+                const MAX_FILES = 5;
+                const IMAGE_EXTS_FOR_FILE = new Set(['png','jpg','jpeg','gif','webp','bmp']);
+                let fileCount = 0;
+                const parts = [];
+                let lastIndex = 0;
+                const re = /@file:(\S+)/g;
+                let m;
+                while ((m = re.exec(text)) !== null) {
+                    if (m.index > lastIndex) {
+                        parts.push(escapeHtml(text.substring(lastIndex, m.index)));
+                    }
+                    const path = m[1];
+                    const invalid = path.includes('..') ||
+                        path.startsWith('/') ||
+                        path.startsWith('\\') ||
+                        path.includes(':');
+                    if (invalid || fileCount >= MAX_FILES) {
+                        parts.push(escapeHtml(m[0]));
+                    } else {
+                        fileCount++;
+                        const slash = path.lastIndexOf('/');
+                        const folder = slash >= 0 ? path.substring(0, slash) : '';
+                        const filename = slash >= 0 ? path.substring(slash + 1) : path;
+                        const ext = (filename.split('.').pop() || '').toLowerCase();
+                        const isImage = IMAGE_EXTS_FOR_FILE.has(ext);
+                        const folderAttr = escapeHtml(folder);
+                        const pathParam = encodeURIComponent(path);
+                        if (isImage) {
+                            parts.push(`<img class="clipboard-file-thumb" src="/api/thumbnail-by-path?path=${pathParam}" data-folder="${folderAttr}" title="${escapeHtml(filename)}" loading="lazy">`);
+                        } else {
+                            parts.push(`<span class="clipboard-file-chip" data-folder="${folderAttr}" title="${escapeHtml(path)}">📎 ${escapeHtml(filename)}</span>`);
+                        }
+                    }
+                    lastIndex = re.lastIndex;
+                }
+                if (lastIndex < text.length) {
+                    parts.push(escapeHtml(text.substring(lastIndex)));
+                }
+                return parts.join('');
+            };
+
+            // @file リファレンスをクリックしたらファイル一覧でそのフォルダに移動
+            document.getElementById('clipboardList').addEventListener('click', (e) => {
+                const target = e.target.closest('[data-folder]');
+                if (!target) return;
+                const folder = target.dataset.folder || '';
+                navigateTo(folder);
+                document.getElementById('file-list').scrollIntoView({ behavior: 'smooth', block: 'start' });
+            });
 
             const formatTime = (isoString) => {
                 const date = new Date(isoString);
@@ -1259,7 +1333,9 @@
                 const item = document.querySelector(`[data-id="${id}"]`);
                 if (!item) return;
 
-                const text = item.querySelector('.clipboard-item-text').textContent;
+                // 原文 (@file: マーカーを含む) を currentClipboardItems から取得
+                const original = currentClipboardItems.find(i => i.id === id);
+                const text = original ? original.text : item.querySelector('.clipboard-item-text').textContent;
 
                 try {
                     await navigator.clipboard.writeText(text);

--- a/assets/web/index.html
+++ b/assets/web/index.html
@@ -594,6 +594,79 @@
         }
 
         /* 比較ビュー */
+        #text-preview-overlay {
+            position: fixed;
+            top: 0; left: 0;
+            width: 100%; height: 100%;
+            background: rgba(0,0,0,0.7);
+            display: none;
+            justify-content: center;
+            align-items: center;
+            z-index: 200;
+        }
+        #text-preview-overlay.open { display: flex; }
+        #text-preview-box {
+            background: white;
+            width: 90%;
+            max-width: 900px;
+            height: 85%;
+            border-radius: 6px;
+            display: flex;
+            flex-direction: column;
+            overflow: hidden;
+        }
+        #text-preview-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 0.6rem 1rem;
+            background: #f0f2f5;
+            border-bottom: 1px solid #ddd;
+        }
+        #text-preview-title {
+            font-weight: 500;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+        #text-preview-close {
+            background: none;
+            border: none;
+            font-size: 1.2rem;
+            cursor: pointer;
+            padding: 0 0.5rem;
+        }
+        #text-preview-controls {
+            display: flex;
+            gap: 0.75rem;
+            align-items: center;
+            padding: 0.5rem 1rem;
+            background: #fafafa;
+            border-bottom: 1px solid #eee;
+            flex-wrap: wrap;
+        }
+        #text-preview-controls label { font-size: 0.85rem; }
+        #text-preview-controls select,
+        #text-preview-controls input { font-size: 0.85rem; padding: 0.2rem 0.4rem; }
+        #text-preview-controls button {
+            padding: 0.3rem 0.8rem;
+            border: 1px solid #ccc;
+            background: white;
+            border-radius: 3px;
+            cursor: pointer;
+            font-size: 0.85rem;
+        }
+        #text-preview-body {
+            flex: 1;
+            margin: 0;
+            padding: 1rem;
+            overflow: auto;
+            font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+            font-size: 0.85rem;
+            white-space: pre;
+            background: #fafafa;
+        }
+
         #comparison-view {
             display: none;
             position: fixed;
@@ -755,6 +828,32 @@
         <div id="lightbox-zoom-hint">スクロールでズーム • 矢印キーで移動</div>
     </div>
 
+    <!-- #193: テキストプレビュー -->
+    <div id="text-preview-overlay">
+        <div id="text-preview-box">
+            <div id="text-preview-header">
+                <span id="text-preview-title"></span>
+                <button id="text-preview-close">✕</button>
+            </div>
+            <div id="text-preview-controls">
+                <label>モード:
+                    <select id="text-preview-mode">
+                        <option value="head">先頭</option>
+                        <option value="tail">末尾</option>
+                        <option value="full">全体</option>
+                    </select>
+                </label>
+                <label>行数:
+                    <input type="number" id="text-preview-lines" value="200" min="10" max="10000" step="50">
+                </label>
+                <button id="text-preview-reload">表示</button>
+                <span id="text-preview-info" style="margin-left:auto; font-size:0.85rem; color:#666;"></span>
+                <button id="text-preview-download">⬇ 保存</button>
+            </div>
+            <pre id="text-preview-body"></pre>
+        </div>
+    </div>
+
     <!-- 比較ビュー -->
     <div id="comparison-view">
         <div id="comparison-header">
@@ -804,6 +903,20 @@
 
             const IMAGE_EXTS = new Set(['png','jpg','jpeg','gif','webp','bmp']);
             const isImageFile = (name) => IMAGE_EXTS.has((name.split('.').pop() || '').toLowerCase());
+
+            // #193: テキストファイル判定
+            const TEXT_EXTS = new Set([
+                'txt','md','log','json','csv','tsv','xml',
+                'yaml','yml','ini','conf','toml','env',
+                'sh','bat','ps1','py','js','ts','dart',
+                'html','htm','css','sql','rb','go','rs','java',
+                'c','h','cpp','hpp','cs','swift','kt','php',
+                'gitignore','gitattributes'
+            ]);
+            const isTextFile = (name) => {
+                const ext = (name.split('.').pop() || '').toLowerCase();
+                return TEXT_EXTS.has(ext);
+            };
 
             const renderBreadcrumb = () => {
                 const breadcrumb = document.getElementById('breadcrumb');
@@ -1494,6 +1607,14 @@
                             tdActions.appendChild(delBtn);
                         }
                         row.append(tdIcon, tdName, tdActions);
+                        // #193: テキストファイル行クリックでプレビュー
+                        if (isTextFile(item.name)) {
+                            row.style.cursor = 'pointer';
+                            row.addEventListener('click', (e) => {
+                                if (e.target.tagName === 'BUTTON') return;
+                                openTextPreview(item.id, item.name);
+                            });
+                        }
                     }
                     tbody.appendChild(row);
                 });
@@ -1571,7 +1692,11 @@
                         iconDiv.className = 'viewer-icon';
                         iconDiv.textContent = getFilePreview(item);
                         viewerItem.append(iconDiv, nameDiv);
-                        viewerItem.addEventListener('click', () => downloadFile(item.id, item.name));
+                        if (isTextFile(item.name)) {
+                            viewerItem.addEventListener('click', () => openTextPreview(item.id, item.name));
+                        } else {
+                            viewerItem.addEventListener('click', () => downloadFile(item.id, item.name));
+                        }
                     }
                     grid.appendChild(viewerItem);
                 });
@@ -1639,6 +1764,66 @@
                 if (item) downloadFile(item.id, item.name);
             });
 
+            // #193: テキストプレビュー
+            let textPreviewState = { id: null, name: null };
+            const textPreviewOverlay = document.getElementById('text-preview-overlay');
+            const textPreviewBody = document.getElementById('text-preview-body');
+            const textPreviewInfo = document.getElementById('text-preview-info');
+            const textPreviewTitle = document.getElementById('text-preview-title');
+            const textPreviewMode = document.getElementById('text-preview-mode');
+            const textPreviewLines = document.getElementById('text-preview-lines');
+
+            const loadTextPreview = async () => {
+                if (!textPreviewState.id) return;
+                textPreviewBody.textContent = '読み込み中...';
+                textPreviewInfo.textContent = '';
+                try {
+                    const mode = textPreviewMode.value;
+                    const lines = parseInt(textPreviewLines.value, 10) || 200;
+                    const url = `/api/text-preview/${textPreviewState.id}?mode=${mode}&lines=${lines}`;
+                    const res = await safeFetch(url);
+                    if (!res.ok) {
+                        const msg = await res.text();
+                        textPreviewBody.textContent = `表示できませんでした: ${msg}`;
+                        return;
+                    }
+                    const data = await res.json();
+                    textPreviewBody.textContent = data.content;
+                    const truncatedNote = data.truncated ? `（${mode === 'head' ? '先頭' : '末尾'} ${data.lines} 行のみ）` : '';
+                    textPreviewInfo.textContent = `全 ${data.totalLines} 行 ${truncatedNote}`;
+                } catch (e) {
+                    textPreviewBody.textContent = `エラー: ${e.message}`;
+                }
+            };
+
+            window.openTextPreview = (id, name) => {
+                textPreviewState = { id, name };
+                textPreviewTitle.textContent = name;
+                textPreviewMode.value = 'head';
+                textPreviewLines.value = 200;
+                textPreviewOverlay.classList.add('open');
+                document.body.style.overflow = 'hidden';
+                loadTextPreview();
+            };
+
+            const closeTextPreview = () => {
+                textPreviewOverlay.classList.remove('open');
+                document.body.style.overflow = '';
+                textPreviewBody.textContent = '';
+            };
+
+            document.getElementById('text-preview-close').addEventListener('click', closeTextPreview);
+            textPreviewOverlay.addEventListener('click', (e) => {
+                if (e.target === textPreviewOverlay) closeTextPreview();
+            });
+            document.getElementById('text-preview-reload').addEventListener('click', loadTextPreview);
+            textPreviewMode.addEventListener('change', loadTextPreview);
+            document.getElementById('text-preview-download').addEventListener('click', () => {
+                if (textPreviewState.id && textPreviewState.name) {
+                    downloadFile(textPreviewState.id, textPreviewState.name);
+                }
+            });
+
             document.getElementById('lightbox-prev').addEventListener('click', () => {
                 lightboxIndex = (lightboxIndex - 1 + lightboxImageList.length) % lightboxImageList.length;
                 lightboxScale = 1;
@@ -1660,10 +1845,13 @@
             }, { passive: false });
 
             document.addEventListener('keydown', (e) => {
-                if (!lightboxEl.classList.contains('open')) return;
-                if (e.key === 'ArrowLeft') document.getElementById('lightbox-prev').click();
-                else if (e.key === 'ArrowRight') document.getElementById('lightbox-next').click();
-                else if (e.key === 'Escape') closeLightbox();
+                if (lightboxEl.classList.contains('open')) {
+                    if (e.key === 'ArrowLeft') document.getElementById('lightbox-prev').click();
+                    else if (e.key === 'ArrowRight') document.getElementById('lightbox-next').click();
+                    else if (e.key === 'Escape') closeLightbox();
+                } else if (textPreviewOverlay.classList.contains('open')) {
+                    if (e.key === 'Escape') closeTextPreview();
+                }
             });
 
             // === ソートボタン ===

--- a/assets/web/index.html
+++ b/assets/web/index.html
@@ -1229,7 +1229,14 @@
                 }
             });
 
-            window.downloadFile = (id, filename) => {
+            window.downloadFile = async (id, filename) => {
+                // #201: 直接 anchor 起動だとセッション期限切れ時に 401 JSON が
+                // ダウンロードされてしまうので、事前に check-auth で確認する。
+                try {
+                    await safeFetch('/api/check-auth');
+                } catch (_) {
+                    return; // safeFetch が 401 を検知して PIN モーダルを表示済み
+                }
                 // #194: 直接 <a href> でブラウザの DL マネージャに任せ、
                 // ストリーミングと進捗表示を有効にする
                 const a = document.createElement('a');

--- a/assets/web/index.html
+++ b/assets/web/index.html
@@ -661,8 +661,8 @@
                 </div>
 
                 <div class="all-actions-container">
-                    <button id="downloadAllBtn">すべてをzipでダウンロード</button>
-                    <button id="deleteAllBtn">すべてを削除</button>
+                    <button id="downloadAllBtn">このフォルダのファイルをzipでダウンロード</button>
+                    <button id="deleteAllBtn">このフォルダのファイルを削除</button>
                 </div>
 
                 <div id="breadcrumb"></div>

--- a/assets/web/index.html
+++ b/assets/web/index.html
@@ -700,6 +700,9 @@
                     <div class="section-header">
                         <h2>📋 クリップボード共有</h2>
                         <div class="section-header-actions">
+                            <label id="clipboardNotifyLabel" style="font-size:0.85rem; color:#00695c; user-select:none; cursor:pointer;">
+                                <input type="checkbox" id="clipboardNotifyToggle"> 新着を通知
+                            </label>
                             <button id="downloadClipboardBtn" class="btn-download-clip" style="display: none;">TXTで保存</button>
                             <button id="clearClipboardBtn" class="btn-clear-clip" style="display: none;">すべて削除</button>
                         </div>
@@ -837,12 +840,12 @@
             const showMainContent = () => {
                 pinModal.style.display = 'none';
                 mainContent.style.display = 'block';
-                fetchFiles();
-                if (serverInfo.clipboardEnabled !== false) startClipboardPolling();
-                applyModeRestrictions();
                 const name = serverInfo.serverName || 'LocalNode';
                 document.title = name;
                 document.querySelector('#main-content h1').textContent = name;
+                fetchFiles();
+                if (serverInfo.clipboardEnabled !== false) startClipboardPolling();
+                applyModeRestrictions();
                 if (serverInfo.version) {
                     document.getElementById('version-badge').textContent = `v${serverInfo.version}`;
                 }
@@ -1098,7 +1101,44 @@
                 }
             };
 
+            // #196: 新着通知 (タブタイトルの先頭に ● を付与)
+            const NOTIFY_PREFIX = '● ';
+            let notifyEnabled = localStorage.getItem('localnode_clipboardNotify') === '1';
+            let baseTitle = document.title;
+            let hasUnread = false;
+            let firstClipboardFetch = true;
+
+            const applyTitleIndicator = () => {
+                const target = hasUnread ? NOTIFY_PREFIX + baseTitle : baseTitle;
+                if (document.title !== target) document.title = target;
+            };
+            const clearUnread = () => {
+                if (!hasUnread) return;
+                hasUnread = false;
+                applyTitleIndicator();
+            };
+            const markUnread = () => {
+                if (!notifyEnabled) return;
+                if (!document.hidden) return; // タブが見えていれば通知不要
+                hasUnread = true;
+                applyTitleIndicator();
+            };
+            document.addEventListener('visibilitychange', () => {
+                if (!document.hidden) clearUnread();
+            });
+            window.addEventListener('focus', clearUnread);
+
+            const notifyToggle = document.getElementById('clipboardNotifyToggle');
+            notifyToggle.checked = notifyEnabled;
+            notifyToggle.addEventListener('change', () => {
+                notifyEnabled = notifyToggle.checked;
+                localStorage.setItem('localnode_clipboardNotify', notifyEnabled ? '1' : '0');
+                if (!notifyEnabled) clearUnread();
+            });
+
             const startClipboardPolling = () => {
+                // タブタイトルが setServerName で更新されたあとの値を基準にする
+                baseTitle = document.title;
                 fetchClipboard();
                 clipboardPollingInterval = setInterval(fetchClipboard, 2000);
             };
@@ -1120,6 +1160,10 @@
                     if (data.lastModified !== clipboardLastModified) {
                         clipboardLastModified = data.lastModified;
                         renderClipboardItems(data.items);
+                        if (!firstClipboardFetch) markUnread();
+                        firstClipboardFetch = false;
+                    } else if (firstClipboardFetch) {
+                        firstClipboardFetch = false;
                     }
                 } catch (error) {
                     if (error.message !== 'Authentication required.') {

--- a/assets/web/index.html
+++ b/assets/web/index.html
@@ -1009,24 +1009,16 @@
                 }
             });
 
-            window.downloadFile = async (id, filename) => {
-                try {
-                    const response = await safeFetch(`/api/download/${id}`);
-                    if (!response.ok) throw new Error('Download failed.');
-
-                    const blob = await response.blob();
-                    const url = window.URL.createObjectURL(blob);
-                    const a = document.createElement('a');
-                    a.style.display = 'none';
-                    a.href = url;
-                    a.download = filename;
-                    document.body.appendChild(a);
-                    a.click();
-                    window.URL.revokeObjectURL(url);
-                    a.remove();
-                } catch (error) {
-                    alert(error.message);
-                }
+            window.downloadFile = (id, filename) => {
+                // #194: 直接 <a href> でブラウザの DL マネージャに任せ、
+                // ストリーミングと進捗表示を有効にする
+                const a = document.createElement('a');
+                a.style.display = 'none';
+                a.href = `/api/download/${id}`;
+                a.download = filename;
+                document.body.appendChild(a);
+                a.click();
+                a.remove();
             };
 
             window.deleteFile = async (id, filename) => {

--- a/assets/web/index.html
+++ b/assets/web/index.html
@@ -423,7 +423,8 @@
             color: white;
             border-color: #1a73e8;
         }
-        #viewerModeBtn {
+        #viewerModeBtn,
+        #refreshBtn {
             padding: 0.35rem 0.8rem;
             border: 1px solid #ccc;
             border-radius: 4px;
@@ -431,6 +432,7 @@
             cursor: pointer;
             font-size: 0.85rem;
         }
+        #refreshBtn { margin-right: 0.3rem; }
         #viewerModeBtn.active {
             background: #1a73e8;
             color: white;
@@ -683,7 +685,10 @@
                         <button id="sortSizeBtn">サイズ</button>
                         <button id="sortOrderBtn" title="昇順/降順">↑</button>
                     </div>
-                    <button id="viewerModeBtn">🖼 グリッド</button>
+                    <div>
+                        <button id="refreshBtn" title="更新">⟳</button>
+                        <button id="viewerModeBtn">🖼 グリッド</button>
+                    </div>
                 </div>
 
                 <div id="file-list"></div>
@@ -1563,6 +1568,9 @@
                 btn.classList.toggle('active', isViewerMode);
                 btn.textContent = isViewerMode ? '☰ リスト' : '🖼 グリッド';
                 renderView();
+            });
+            document.getElementById('refreshBtn').addEventListener('click', () => {
+                fetchFiles();
             });
 
             // 初期化処理：サーバー情報を取得し、認証モードに応じてPINモーダルを表示

--- a/assets/web/index.html
+++ b/assets/web/index.html
@@ -594,6 +594,59 @@
         }
 
         /* 比較ビュー */
+        #video-player-overlay {
+            position: fixed;
+            top: 0; left: 0;
+            width: 100%; height: 100%;
+            background: rgba(0,0,0,0.9);
+            display: none;
+            justify-content: center;
+            align-items: center;
+            flex-direction: column;
+            z-index: 200;
+        }
+        #video-player-overlay.open { display: flex; }
+        #video-player {
+            max-width: 95%;
+            max-height: 80%;
+            background: black;
+        }
+        #video-player-close {
+            position: fixed;
+            top: 1rem;
+            right: 1rem;
+            background: rgba(255,255,255,0.2);
+            border: none;
+            color: white;
+            font-size: 1.5rem;
+            padding: 0.3rem 0.7rem;
+            cursor: pointer;
+            border-radius: 4px;
+        }
+        #video-player-meta {
+            color: white;
+            font-size: 0.85rem;
+            margin-top: 0.75rem;
+            opacity: 0.85;
+        }
+        #video-player-download {
+            margin-top: 0.5rem;
+            background: rgba(255,255,255,0.2);
+            border: none;
+            color: white;
+            font-size: 0.9rem;
+            padding: 0.3rem 0.8rem;
+            cursor: pointer;
+            border-radius: 4px;
+        }
+        .viewer-item video {
+            width: 100%;
+            height: 100%;
+            object-fit: cover;
+            background: black;
+            cursor: pointer;
+        }
+
         #text-preview-overlay {
             position: fixed;
             top: 0; left: 0;
@@ -828,6 +881,14 @@
         <div id="lightbox-zoom-hint">スクロールでズーム • 矢印キーで移動</div>
     </div>
 
+    <!-- #189: 動画プレイヤー -->
+    <div id="video-player-overlay">
+        <button id="video-player-close">✕</button>
+        <video id="video-player" controls></video>
+        <div id="video-player-meta"></div>
+        <button id="video-player-download">⬇ 保存</button>
+    </div>
+
     <!-- #193: テキストプレビュー -->
     <div id="text-preview-overlay">
         <div id="text-preview-box">
@@ -903,6 +964,10 @@
 
             const IMAGE_EXTS = new Set(['png','jpg','jpeg','gif','webp','bmp']);
             const isImageFile = (name) => IMAGE_EXTS.has((name.split('.').pop() || '').toLowerCase());
+
+            // #189: 動画ファイル判定
+            const VIDEO_EXTS = new Set(['mp4','mov','webm','m4v','ogv']);
+            const isVideoFile = (name) => VIDEO_EXTS.has((name.split('.').pop() || '').toLowerCase());
 
             // #193: テキストファイル判定
             const TEXT_EXTS = new Set([
@@ -1607,12 +1672,18 @@
                             tdActions.appendChild(delBtn);
                         }
                         row.append(tdIcon, tdName, tdActions);
-                        // #193: テキストファイル行クリックでプレビュー
+                        // #193/#189: テキスト→プレビュー、動画→プレイヤー
                         if (isTextFile(item.name)) {
                             row.style.cursor = 'pointer';
                             row.addEventListener('click', (e) => {
                                 if (e.target.tagName === 'BUTTON') return;
                                 openTextPreview(item.id, item.name);
+                            });
+                        } else if (isVideoFile(item.name)) {
+                            row.style.cursor = 'pointer';
+                            row.addEventListener('click', (e) => {
+                                if (e.target.tagName === 'BUTTON') return;
+                                openVideoPlayer(item.id, item.name);
                             });
                         }
                     }
@@ -1686,6 +1757,19 @@
                         cmpBtn.textContent = sel ? '✓ 選択済' : '比較選択';
                         cmpBtn.addEventListener('click', () => toggleCompare(item.id, item.name));
                         viewerItem.append(img, nameDiv, cmpBtn);
+                    } else if (isVideoFile(item.name)) {
+                        // #189: ファーストフレームをサムネ表示、クリックでプレイヤー
+                        viewerItem.className = 'viewer-item';
+                        const video = document.createElement('video');
+                        video.src = `/api/download/${item.id}`;
+                        video.preload = 'metadata';
+                        video.muted = true;
+                        video.playsInline = true;
+                        video.addEventListener('loadedmetadata', () => {
+                            try { video.currentTime = 0.1; } catch (_) {}
+                        });
+                        video.addEventListener('click', () => openVideoPlayer(item.id, item.name));
+                        viewerItem.append(video, nameDiv);
                     } else {
                         viewerItem.className = 'viewer-item';
                         const iconDiv = document.createElement('div');
@@ -1762,6 +1846,39 @@
             document.getElementById('lightbox-save').addEventListener('click', () => {
                 const item = lightboxImageList[lightboxIndex];
                 if (item) downloadFile(item.id, item.name);
+            });
+
+            // #189: 動画プレイヤー
+            let videoPlayerState = { id: null, name: null };
+            const videoPlayerOverlay = document.getElementById('video-player-overlay');
+            const videoPlayerEl = document.getElementById('video-player');
+            const videoPlayerMeta = document.getElementById('video-player-meta');
+
+            window.openVideoPlayer = (id, name) => {
+                videoPlayerState = { id, name };
+                videoPlayerEl.src = `/api/download/${id}`;
+                videoPlayerMeta.textContent = name;
+                videoPlayerOverlay.classList.add('open');
+                document.body.style.overflow = 'hidden';
+                videoPlayerEl.play().catch(() => {});
+            };
+
+            const closeVideoPlayer = () => {
+                videoPlayerEl.pause();
+                videoPlayerEl.removeAttribute('src');
+                videoPlayerEl.load();
+                videoPlayerOverlay.classList.remove('open');
+                document.body.style.overflow = '';
+            };
+
+            document.getElementById('video-player-close').addEventListener('click', closeVideoPlayer);
+            videoPlayerOverlay.addEventListener('click', (e) => {
+                if (e.target === videoPlayerOverlay) closeVideoPlayer();
+            });
+            document.getElementById('video-player-download').addEventListener('click', () => {
+                if (videoPlayerState.id && videoPlayerState.name) {
+                    downloadFile(videoPlayerState.id, videoPlayerState.name);
+                }
             });
 
             // #193: テキストプレビュー
@@ -1851,6 +1968,8 @@
                     else if (e.key === 'Escape') closeLightbox();
                 } else if (textPreviewOverlay.classList.contains('open')) {
                     if (e.key === 'Escape') closeTextPreview();
+                } else if (videoPlayerOverlay.classList.contains('open')) {
+                    if (e.key === 'Escape') closeVideoPlayer();
                 }
             });
 

--- a/assets/web/index.html
+++ b/assets/web/index.html
@@ -956,10 +956,18 @@
 
             // 全ファイル削除処理
             deleteAllBtn.addEventListener('click', async () => {
-                if (!confirm('本当にすべてのファイルを削除しますか？この操作は取り消せません。')) return;
+                const fileIds = allItems
+                    .filter(i => i.type !== 'directory')
+                    .map(i => i.id);
+                if (fileIds.length === 0) return;
+                if (!confirm(`このフォルダの${fileIds.length}個のファイルを削除します。よろしいですか？この操作は取り消せません。`)) return;
 
                 try {
-                    const response = await safeFetch('/api/files', { method: 'DELETE' });
+                    const response = await safeFetch('/api/files/delete-batch', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ ids: fileIds }),
+                    });
                     if (!response.ok) throw new Error('削除に失敗しました。');
                     const result = await response.json();
                     alert(`${result.deleted}個のファイルを削除しました。`);

--- a/assets/web/index.html
+++ b/assets/web/index.html
@@ -1323,14 +1323,8 @@
                         tdName.appendChild(nameDiv);
                         const tdActions = document.createElement('td');
                         tdActions.className = 'actions';
-                        const dlBtn = document.createElement('button');
-                        dlBtn.className = 'btn-download';
-                        dlBtn.textContent = 'DL';
-                        dlBtn.addEventListener('click', () => downloadFile(item.id, item.name + '.zip'));
-                        tdActions.appendChild(dlBtn);
                         row.append(tdIcon, tdName, tdActions);
-                        row.addEventListener('click', (e) => {
-                            if (e.target.tagName === 'BUTTON') return;
+                        row.addEventListener('click', () => {
                             navigateTo(currentPath ? `${currentPath}/${item.name}` : item.name);
                         });
                     } else {

--- a/assets/web/index.html
+++ b/assets/web/index.html
@@ -23,6 +23,14 @@
             color: #1a73e8;
             text-align: center;
         }
+        #version-badge {
+            position: absolute;
+            top: 0.5rem;
+            right: 0.75rem;
+            font-size: 0.75rem;
+            color: #999;
+        }
+        .container { position: relative; }
         table {
             width: 100%;
             border-collapse: collapse;
@@ -633,6 +641,7 @@
     <!-- メインコンテンツ -->
     <div id="main-content" style="display: none;">
         <div class="container">
+            <span id="version-badge"></span>
             <h1>LocalNode</h1>
             <div id="mode-indicator" style="display:none; text-align:center; margin-bottom: 1rem;"></div>
 
@@ -829,6 +838,9 @@
                 const name = serverInfo.serverName || 'LocalNode';
                 document.title = name;
                 document.querySelector('#main-content h1').textContent = name;
+                if (serverInfo.version) {
+                    document.getElementById('version-badge').textContent = `v${serverInfo.version}`;
+                }
             };
 
             // ダウンロード専用モード時にUI要素を非表示にする

--- a/bin/localnode_cli.dart
+++ b/bin/localnode_cli.dart
@@ -735,6 +735,7 @@ class _CliServer {
       ..post('/api/upload', _uploadHandler)
       ..get('/api/download/<id>', _downloadHandler)
       ..get('/api/thumbnail/<id>', _thumbnailHandler)
+      ..get('/api/thumbnail-by-path', _thumbnailByPathHandler)
       ..get('/api/download-all', _downloadAllHandler)
       ..delete('/api/files/<id>', _deleteFileHandler)
       ..post('/api/files/delete-batch', _deleteBatchHandler)
@@ -1258,6 +1259,28 @@ class _CliServer {
     } catch (e) {
       return Response.internalServerError(body: 'Download failed: $e');
     }
+  }
+
+  // #198: @file:<relpath> 用のパスベースサムネイル
+  Future<Response> _thumbnailByPathHandler(Request req) async {
+    final relPath = req.url.queryParameters['path'] ?? '';
+    if (relPath.isEmpty ||
+        relPath.contains('..') ||
+        relPath.startsWith('/') ||
+        relPath.startsWith(r'\') ||
+        relPath.contains(':')) {
+      return Response.badRequest(body: 'Invalid path.');
+    }
+    final canonicalRoot = await Directory(_storagePath!).resolveSymbolicLinks();
+    final targetPath = p.normalize(p.join(canonicalRoot, relPath));
+    final file = File(targetPath);
+    if (!await file.exists()) return Response.notFound('File not found.');
+    final canonicalTarget = await file.resolveSymbolicLinks();
+    if (!p.isWithin(canonicalRoot, canonicalTarget)) {
+      return Response.forbidden('Access denied');
+    }
+    final id = base64Url.encode(utf8.encode(targetPath));
+    return _thumbnailHandler(req, id);
   }
 
   Future<Response> _thumbnailHandler(Request req, String id) async {

--- a/bin/localnode_cli.dart
+++ b/bin/localnode_cli.dart
@@ -1266,38 +1266,84 @@ class _CliServer {
   Future<Response> _textPreviewHandler(Request req, String id) async {
     const maxFullBytes = 5 * 1024 * 1024;
     final mode = req.url.queryParameters['mode'] ?? 'head';
+    if (mode != 'head' && mode != 'tail' && mode != 'full') {
+      return Response.badRequest(body: 'mode must be head|tail|full');
+    }
     final lines = int.tryParse(req.url.queryParameters['lines'] ?? '') ?? 200;
     if (lines < 1 || lines > 10000) {
       return Response.badRequest(body: 'lines out of range');
     }
     try {
       final filePath = utf8.decode(base64Url.decode(id));
+
+      // パストラバーサル検証 (Copilot #199 review)
+      if (await FileSystemEntity.isDirectory(filePath)) {
+        return Response.badRequest(body: 'Target is a directory.');
+      }
+      final canonicalRoot = await Directory(_storagePath!).resolveSymbolicLinks();
       final file = File(filePath);
       if (!await file.exists()) return Response.notFound('File not found.');
+      final canonicalFile = await file.resolveSymbolicLinks();
+      if (!p.isWithin(canonicalRoot, canonicalFile)) {
+        return Response.forbidden('Access denied');
+      }
+
+      if (mode == 'head' || mode == 'tail') {
+        // ファイル全体をメモリに乗せず、行をストリームで処理
+        final stream = file
+            .openRead()
+            .transform(utf8.decoder)
+            .transform(const LineSplitter());
+        if (mode == 'head') {
+          final collected = <String>[];
+          var totalLines = 0;
+          await for (final line in stream) {
+            totalLines++;
+            if (collected.length < lines) collected.add(line);
+          }
+          return Response.ok(
+            json.encode({
+              'content': collected.join('\n'),
+              'totalLines': totalLines,
+              'truncated': totalLines > lines,
+              'mode': mode,
+              'lines': lines,
+            }),
+            headers: {'Content-Type': 'application/json'},
+          );
+        } else {
+          final buf = <String>[];
+          var totalLines = 0;
+          await for (final line in stream) {
+            totalLines++;
+            buf.add(line);
+            if (buf.length > lines) buf.removeAt(0);
+          }
+          return Response.ok(
+            json.encode({
+              'content': buf.join('\n'),
+              'totalLines': totalLines,
+              'truncated': totalLines > lines,
+              'mode': mode,
+              'lines': lines,
+            }),
+            headers: {'Content-Type': 'application/json'},
+          );
+        }
+      }
+
+      // mode == 'full'
       final size = await file.length();
-      if (mode == 'full' && size > maxFullBytes) {
+      if (size > maxFullBytes) {
         return Response.badRequest(body: 'File too large for full preview (max 5MB).');
       }
       final content = await file.readAsString(encoding: utf8);
-
-      String result;
       final totalLines = '\n'.allMatches(content).length + 1;
-      if (mode == 'head') {
-        result = content.split('\n').take(lines).join('\n');
-      } else if (mode == 'tail') {
-        final all = content.split('\n');
-        result = all.length > lines
-            ? all.sublist(all.length - lines).join('\n')
-            : content;
-      } else {
-        result = content;
-      }
-
       return Response.ok(
         json.encode({
-          'content': result,
+          'content': content,
           'totalLines': totalLines,
-          'truncated': mode != 'full' && totalLines > lines,
+          'truncated': false,
           'mode': mode,
           'lines': lines,
         }),

--- a/bin/localnode_cli.dart
+++ b/bin/localnode_cli.dart
@@ -731,6 +731,7 @@ class _CliServer {
       ..post('/api/auth', _authHandler)
       ..get('/api/health', _healthHandler)
       ..get('/api/info', _infoHandler)
+      ..get('/api/check-auth', _checkAuthHandler)
       ..get('/api/files', _getFilesHandler)
       ..post('/api/upload', _uploadHandler)
       ..get('/api/download/<id>', _downloadHandler)
@@ -1051,6 +1052,12 @@ class _CliServer {
 
   Response _healthHandler(Request _) =>
       Response.ok(json.encode({'startedAt': _startedAt}),
+          headers: {'Content-Type': 'application/json'});
+
+  // #201: 認証チェック専用エンドポイント。認証ミドルウェアを通るので、
+  // 200 が返れば有効、401 が返ればセッション切れ。
+  Response _checkAuthHandler(Request _) =>
+      Response.ok(json.encode({'ok': true}),
           headers: {'Content-Type': 'application/json'});
 
   Response _infoHandler(Request _) => Response.ok(

--- a/bin/localnode_cli.dart
+++ b/bin/localnode_cli.dart
@@ -13,6 +13,7 @@ import 'dart:math';
 import 'dart:typed_data';
 
 import 'package:archive/archive.dart';
+import 'package:archive/archive_io.dart';
 import 'package:args/args.dart';
 import 'package:basic_utils/basic_utils.dart';
 import 'package:image/image.dart' as img;
@@ -1296,20 +1297,42 @@ class _CliServer {
         !p.isWithin(canonicalRoot, canonicalTarget)) {
       return Response.forbidden('Access denied');
     }
-    final archive = Archive();
-    final files = dir.listSync(followLinks: false).whereType<File>();
-    for (final f in files) {
-      final bytes = await f.readAsBytes();
-      archive.addFile(ArchiveFile(p.basename(f.path), bytes.length, bytes));
+
+    // #195: ZIP を一時ファイルへストリーミング書き出ししてレスポンスとして流す
+    final tempDir = await Directory.systemTemp.createTemp('localnode_zip_');
+    final zipPath = p.join(tempDir.path, 'localnode_files.zip');
+    try {
+      final zipEncoder = ZipFileEncoder()..create(zipPath);
+      final files = dir.listSync(followLinks: false).whereType<File>();
+      for (final f in files) {
+        await zipEncoder.addFile(f, p.basename(f.path));
+      }
+      await zipEncoder.close();
+
+      final zipFile = File(zipPath);
+      final length = await zipFile.length();
+
+      Stream<List<int>> streamAndCleanup() async* {
+        try {
+          yield* zipFile.openRead();
+        } finally {
+          try {
+            await tempDir.delete(recursive: true);
+          } catch (_) {}
+        }
+      }
+
+      return Response.ok(streamAndCleanup(), headers: {
+        'Content-Type': 'application/zip',
+        'Content-Length': '$length',
+        'Content-Disposition': 'attachment; filename="localnode_files.zip"',
+      });
+    } catch (e) {
+      try {
+        await tempDir.delete(recursive: true);
+      } catch (_) {}
+      return Response.internalServerError(body: 'Failed to create zip: $e');
     }
-    final zip = ZipEncoder().encode(archive);
-    if (zip == null) {
-      return Response.internalServerError(body: 'Failed to create zip.');
-    }
-    return Response.ok(zip, headers: {
-      'Content-Type': 'application/zip',
-      'Content-Disposition': 'attachment; filename="localnode_files.zip"',
-    });
   }
 
   Future<Response> _deleteFileHandler(Request req, String id) async {

--- a/bin/localnode_cli.dart
+++ b/bin/localnode_cli.dart
@@ -727,7 +727,7 @@ class _CliServer {
       ..get('/api/thumbnail/<id>', _thumbnailHandler)
       ..get('/api/download-all', _downloadAllHandler)
       ..delete('/api/files/<id>', _deleteFileHandler)
-      ..delete('/api/files', _deleteAllFilesHandler)
+      ..post('/api/files/delete-batch', _deleteBatchHandler)
       ..get('/api/clipboard', _getClipboardHandler)
       ..post('/api/clipboard', _postClipboardHandler)
       ..delete('/api/clipboard/<id>', _deleteClipboardItemHandler)
@@ -1331,28 +1331,51 @@ class _CliServer {
     }
   }
 
-  Future<Response> _deleteAllFilesHandler(Request req) async {
+  // #190: クライアントが指定したファイル ID のみ削除
+  Future<Response> _deleteBatchHandler(Request req) async {
     final guard = _guardDownloadOnly();
     if (guard != null) return guard;
-    final dir = Directory(_storagePath!);
-    int deleted = 0, failed = 0;
-    if (await dir.exists()) {
-      final files =
-          await dir.list().where((e) => e is File).cast<File>().toList();
-      for (final f in files) {
-        try {
-          await f.delete();
-          deleted++;
-          final cache = File(p.join(
-              _thumbnailCacheDir!.path, '${p.basename(f.path)}.jpg'));
-          if (await cache.exists()) await cache.delete();
-        } catch (_) {
+
+    final List<dynamic> ids;
+    try {
+      final body = json.decode(await req.readAsString()) as Map<String, dynamic>;
+      ids = body['ids'] as List<dynamic>? ?? const [];
+    } catch (_) {
+      return Response.badRequest(body: 'Invalid request body.');
+    }
+
+    int deleted = 0;
+    int failed = 0;
+    final List<String> skipped = [];
+
+    final canonicalRoot = await Directory(_storagePath!).resolveSymbolicLinks();
+    for (final raw in ids) {
+      try {
+        final filePath = utf8.decode(base64Url.decode(raw as String));
+        final file = File(filePath);
+        if (!await file.exists()) {
           failed++;
+          continue;
         }
+        final canonicalFile = await file.resolveSymbolicLinks();
+        if (!p.isWithin(canonicalRoot, canonicalFile)) {
+          skipped.add(raw);
+          continue;
+        }
+        final filename = p.basename(filePath);
+        await file.delete();
+        deleted++;
+        final cache = File(p.join(_thumbnailCacheDir!.path, '$filename.jpg'));
+        if (await cache.exists()) await cache.delete();
+      } catch (_) {
+        failed++;
       }
     }
-    return Response.ok(json.encode({'deleted': deleted, 'failed': failed}),
-        headers: {'Content-Type': 'application/json'});
+
+    return Response.ok(
+      json.encode({'deleted': deleted, 'failed': failed, 'skipped': skipped}),
+      headers: {'Content-Type': 'application/json'},
+    );
   }
 
   // --- クリップボードハンドラ ---

--- a/bin/localnode_cli.dart
+++ b/bin/localnode_cli.dart
@@ -736,6 +736,7 @@ class _CliServer {
       ..get('/api/download/<id>', _downloadHandler)
       ..get('/api/thumbnail/<id>', _thumbnailHandler)
       ..get('/api/thumbnail-by-path', _thumbnailByPathHandler)
+      ..get('/api/text-preview/<id>', _textPreviewHandler)
       ..get('/api/download-all', _downloadAllHandler)
       ..delete('/api/files/<id>', _deleteFileHandler)
       ..post('/api/files/delete-batch', _deleteBatchHandler)
@@ -1258,6 +1259,52 @@ class _CliServer {
           .change(headers: {'Content-Type': _getMimeType(p.basename(filePath))});
     } catch (e) {
       return Response.internalServerError(body: 'Download failed: $e');
+    }
+  }
+
+  // #193: テキストファイルのインラインプレビュー
+  Future<Response> _textPreviewHandler(Request req, String id) async {
+    const maxFullBytes = 5 * 1024 * 1024;
+    final mode = req.url.queryParameters['mode'] ?? 'head';
+    final lines = int.tryParse(req.url.queryParameters['lines'] ?? '') ?? 200;
+    if (lines < 1 || lines > 10000) {
+      return Response.badRequest(body: 'lines out of range');
+    }
+    try {
+      final filePath = utf8.decode(base64Url.decode(id));
+      final file = File(filePath);
+      if (!await file.exists()) return Response.notFound('File not found.');
+      final size = await file.length();
+      if (mode == 'full' && size > maxFullBytes) {
+        return Response.badRequest(body: 'File too large for full preview (max 5MB).');
+      }
+      final content = await file.readAsString(encoding: utf8);
+
+      String result;
+      final totalLines = '\n'.allMatches(content).length + 1;
+      if (mode == 'head') {
+        result = content.split('\n').take(lines).join('\n');
+      } else if (mode == 'tail') {
+        final all = content.split('\n');
+        result = all.length > lines
+            ? all.sublist(all.length - lines).join('\n')
+            : content;
+      } else {
+        result = content;
+      }
+
+      return Response.ok(
+        json.encode({
+          'content': result,
+          'totalLines': totalLines,
+          'truncated': mode != 'full' && totalLines > lines,
+          'mode': mode,
+          'lines': lines,
+        }),
+        headers: {'Content-Type': 'application/json'},
+      );
+    } catch (e) {
+      return Response.internalServerError(body: 'Text preview failed: $e');
     }
   }
 

--- a/bin/localnode_cli.dart
+++ b/bin/localnode_cli.dart
@@ -24,6 +24,9 @@ import 'package:shelf/shelf_io.dart' as shelf_io;
 import 'package:shelf_router/shelf_router.dart';
 import 'package:shelf_static/shelf_static.dart';
 
+// pubspec.yaml の version と一致させる
+const String _appVersion = '1.5.0';
+
 // =============================================================================
 // エントリポイント
 // =============================================================================
@@ -1042,7 +1045,7 @@ class _CliServer {
 
   Response _infoHandler(Request _) => Response.ok(
         json.encode({
-          'version': '1.1.2',
+          'version': _appVersion,
           'name': _serverName,
           'serverName': _serverName,
           'operationMode': _downloadOnly ? 'downloadOnly' : 'normal',

--- a/bin/localnode_cli.dart
+++ b/bin/localnode_cli.dart
@@ -1255,11 +1255,63 @@ class _CliServer {
       final filePath = utf8.decode(base64Url.decode(id));
       final file = File(filePath);
       if (!await file.exists()) return Response.notFound('File not found.');
-      return Response.ok(file.openRead())
-          .change(headers: {'Content-Type': _getMimeType(p.basename(filePath))});
+      final mimeType = _getMimeType(p.basename(filePath));
+      final length = await file.length();
+      // #200: Range リクエスト対応 (動画サムネ生成等で部分取得を可能に)
+      final rangeHeader = req.headers['range'];
+      ({int start, int end})? range;
+      try {
+        range = _parseHttpRange(rangeHeader, length);
+      } on RangeError {
+        return Response(416, body: 'Requested Range Not Satisfiable',
+            headers: {'Content-Range': 'bytes */$length'});
+      }
+      if (range == null) {
+        return Response.ok(file.openRead(), headers: {
+          'Content-Type': mimeType,
+          'Accept-Ranges': 'bytes',
+          'Content-Length': '$length',
+        });
+      }
+      final contentLength = range.end - range.start + 1;
+      return Response(206, body: file.openRead(range.start, range.end + 1),
+          headers: {
+            'Content-Type': mimeType,
+            'Accept-Ranges': 'bytes',
+            'Content-Length': '$contentLength',
+            'Content-Range': 'bytes ${range.start}-${range.end}/$length',
+          });
     } catch (e) {
       return Response.internalServerError(body: 'Download failed: $e');
     }
+  }
+
+  // #200: Range ヘッダ解析（単一範囲のみ）
+  ({int start, int end})? _parseHttpRange(String? header, int fileLength) {
+    if (header == null || header.isEmpty) return null;
+    if (!header.startsWith('bytes=')) throw RangeError('Invalid range unit');
+    final spec = header.substring('bytes='.length).trim();
+    if (spec.contains(',')) return null;
+    final dash = spec.indexOf('-');
+    if (dash < 0) throw RangeError('Invalid range spec');
+    final startStr = spec.substring(0, dash);
+    final endStr = spec.substring(dash + 1);
+    int start, end;
+    if (startStr.isEmpty) {
+      final suffix = int.tryParse(endStr);
+      if (suffix == null || suffix <= 0) throw RangeError('Invalid suffix');
+      start = (fileLength - suffix).clamp(0, fileLength);
+      end = fileLength - 1;
+    } else {
+      final s = int.tryParse(startStr);
+      if (s == null || s < 0) throw RangeError('Invalid start');
+      start = s;
+      end = endStr.isEmpty ? fileLength - 1 : (int.tryParse(endStr) ?? -1);
+      if (end < 0) throw RangeError('Invalid end');
+      if (end >= fileLength) end = fileLength - 1;
+    }
+    if (start > end || start >= fileLength) throw RangeError('Unsatisfiable');
+    return (start: start, end: end);
   }
 
   // #193: テキストファイルのインラインプレビュー

--- a/bin/localnode_cli.dart
+++ b/bin/localnode_cli.dart
@@ -207,6 +207,12 @@ Future<void> main(List<String> args) async {
     stdout.writeln('         -H "x-filename: myfile.txt" \\');
     stdout.writeln('         --data-binary @/path/to/myfile.txt \\');
     stdout.writeln('         $serverUrl/api/upload');
+    stdout.writeln('');
+    stdout.writeln('  curl example (clipboard):');
+    stdout.writeln('    curl -H "Authorization: Bearer $uploadToken" \\');
+    stdout.writeln('         -H "Content-Type: application/json" \\');
+    stdout.writeln('         -d \'{"text":"hello from curl"}\' \\');
+    stdout.writeln('         $serverUrl/api/clipboard');
   }
   stdout.writeln('');
   stdout.writeln('QR Code:');
@@ -967,10 +973,12 @@ class _CliServer {
           }
           if (token != null && _sessions.contains(token)) return inner(req);
 
-          // #173: Bearer トークンによるアップロード認証
+          // #173/#188: Bearer トークンによる API 認証
+          //   - POST /api/upload      … ファイルアップロード（#173）
+          //   - POST /api/clipboard   … クリップボードへの送信（#188）
           if (_uploadToken != null &&
               req.method == 'POST' &&
-              path == 'api/upload') {
+              (path == 'api/upload' || path == 'api/clipboard')) {
             final authHeader = req.headers['authorization'] ?? '';
             if (authHeader == 'Bearer $_uploadToken') return inner(req);
           }

--- a/lib/server_service.dart
+++ b/lib/server_service.dart
@@ -5,6 +5,7 @@ import 'dart:typed_data';
 import 'dart:math';
 
 import 'package:archive/archive.dart';
+import 'package:archive/archive_io.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
@@ -876,62 +877,99 @@ class ServerService {
       return Response.internalServerError(body: 'Documents directory not initialized.');
     }
 
-    final encoder = ZipEncoder();
-    final archive = Archive();
+    // #195: ZIP を一時ファイルへストリーミングして書き出し、レスポンスとして
+    // 流す。これによりサーバ側でも巨大ファイル × 多数を扱える。
+    final tempDir = await Directory.systemTemp.createTemp('localnode_zip_');
+    final zipPath = p.join(tempDir.path, 'localnode_files.zip');
 
-    // AndroidでSAF URIが設定されている場合
-    if (Platform.isAndroid && _safDirectoryUri != null) {
-      try {
-        final List<dynamic>? files = await _safPlatform.invokeMethod('listFiles', {'uri': _safDirectoryUri});
-        if (files == null) {
-          return Response.internalServerError(body: 'Failed to list files for zipping.');
-        }
+    try {
+      final zipEncoder = ZipFileEncoder()..create(zipPath);
 
-        for (final fileInfo in files) {
-          final String fileUri = fileInfo['uri'];
-          final String filename = fileInfo['name'];
-          final Uint8List? bytes = await _safPlatform.invokeMethod('readFile', {'uri': fileUri});
-          if (bytes != null) {
-            archive.addFile(ArchiveFile(filename, bytes.length, bytes));
+      // AndroidでSAF URIが設定されている場合
+      if (Platform.isAndroid && _safDirectoryUri != null) {
+        try {
+          final List<dynamic>? files = await _safPlatform
+              .invokeMethod('listFiles', {'uri': _safDirectoryUri});
+          if (files == null) {
+            await zipEncoder.close();
+            await tempDir.delete(recursive: true);
+            return Response.internalServerError(
+                body: 'Failed to list files for zipping.');
           }
+          for (final fileInfo in files) {
+            final String fileUri = fileInfo['uri'];
+            final String filename = fileInfo['name'];
+            final Uint8List? bytes = await _safPlatform
+                .invokeMethod('readFile', {'uri': fileUri});
+            if (bytes != null) {
+              // SAF はバイト列でしか取れないため、一時ファイルへ書いてから
+              // ZipFileEncoder に渡してストリーム圧縮
+              final tmpFile = File(p.join(tempDir.path, filename));
+              await tmpFile.writeAsBytes(bytes, flush: true);
+              await zipEncoder.addFile(tmpFile, filename);
+              await tmpFile.delete();
+            }
+          }
+        } on PlatformException catch (e) {
+          await zipEncoder.close();
+          await tempDir.delete(recursive: true);
+          return Response.internalServerError(
+              body: 'Failed to read files for zipping: ${e.message}');
         }
-      } on PlatformException catch(e) {
-        return Response.internalServerError(body: 'Failed to read files for zipping: ${e.message}');
+      } else {
+        // ?path= で現在フォルダを指定し、そのフォルダのファイルのみをZIP (#179)
+        final relPath = request.url.queryParameters['path'] ?? '';
+        final canonicalRoot =
+            await Directory(storagePath).resolveSymbolicLinks();
+        final targetPath = p.normalize(p.join(canonicalRoot, relPath));
+        final directory = Directory(targetPath);
+        if (!await directory.exists()) {
+          await zipEncoder.close();
+          await tempDir.delete(recursive: true);
+          return Response.internalServerError(
+              body: 'Documents directory not found.');
+        }
+        final canonicalTarget = await directory.resolveSymbolicLinks();
+        if (canonicalTarget != canonicalRoot &&
+            !p.isWithin(canonicalRoot, canonicalTarget)) {
+          await zipEncoder.close();
+          await tempDir.delete(recursive: true);
+          return Response.forbidden('Access denied');
+        }
+        // 現在フォルダの直下ファイルのみ（再帰なし）
+        final files = directory.listSync(followLinks: false).whereType<File>();
+        for (final file in files) {
+          await zipEncoder.addFile(file, p.basename(file.path));
+        }
       }
-    }
-    // 他のプラットフォーム、またはSAFが設定されていないAndroidの場合
-    else {
-      // ?path= で現在フォルダを指定し、そのフォルダのファイルのみをZIP (#179)
-      final relPath = request.url.queryParameters['path'] ?? '';
-      final canonicalRoot = await Directory(storagePath).resolveSymbolicLinks();
-      final targetPath = p.normalize(p.join(canonicalRoot, relPath));
-      final directory = Directory(targetPath);
-      if (!await directory.exists()) {
-        return Response.internalServerError(body: 'Documents directory not found.');
-      }
-      final canonicalTarget = await directory.resolveSymbolicLinks();
-      if (canonicalTarget != canonicalRoot &&
-          !p.isWithin(canonicalRoot, canonicalTarget)) {
-        return Response.forbidden('Access denied');
-      }
-      // 現在フォルダの直下ファイルのみ（再帰なし）
-      final files = directory.listSync(followLinks: false).whereType<File>();
-      for (final file in files) {
-        final bytes = await file.readAsBytes();
-        final filename = p.basename(file.path);
-        archive.addFile(ArchiveFile(filename, bytes.length, bytes));
-      }
-    }
 
-    final zipData = encoder.encode(archive);
-    if (zipData == null) {
-      return Response.internalServerError(body: 'Failed to create zip file.');
-    }
+      await zipEncoder.close();
 
-    return Response.ok(zipData, headers: {
-      'Content-Type': 'application/zip',
-      'Content-Disposition': 'attachment; filename="localnode_files.zip"',
-    });
+      final zipFile = File(zipPath);
+      final length = await zipFile.length();
+
+      // ストリーム完了後（成功・中断問わず）に一時ディレクトリを削除
+      Stream<List<int>> streamAndCleanup() async* {
+        try {
+          yield* zipFile.openRead();
+        } finally {
+          try {
+            await tempDir.delete(recursive: true);
+          } catch (_) {}
+        }
+      }
+
+      return Response.ok(streamAndCleanup(), headers: {
+        'Content-Type': 'application/zip',
+        'Content-Length': '$length',
+        'Content-Disposition': 'attachment; filename="localnode_files.zip"',
+      });
+    } catch (e) {
+      try {
+        await tempDir.delete(recursive: true);
+      } catch (_) {}
+      return Response.internalServerError(body: 'Failed to create zip: $e');
+    }
   }
 
   // === Clipboard Handlers ===

--- a/lib/server_service.dart
+++ b/lib/server_service.dart
@@ -208,7 +208,7 @@ class ServerService {
     _router.get('/api/thumbnail/<id>', _thumbnailHandler);
     _router.get('/api/download-all', _downloadAllHandler);
     _router.delete('/api/files/<id>', _deleteFileHandler);
-    _router.delete('/api/files', _deleteAllFilesHandler);
+    _router.post('/api/files/delete-batch', _deleteBatchHandler);
     // クリップボード共有API
     _router.get('/api/clipboard', _getClipboardHandler);
     _router.post('/api/clipboard', _postClipboardHandler);
@@ -814,7 +814,8 @@ class ServerService {
     }
   }
 
-  Future<Response> _deleteAllFilesHandler(Request request) async {
+  // #190: 表示されているファイル ID のリストを受け取って削除
+  Future<Response> _deleteBatchHandler(Request request) async {
     final guard = _checkDownloadOnlyMode();
     if (guard != null) return guard;
 
@@ -823,64 +824,70 @@ class ServerService {
       return Response.internalServerError(body: 'Documents directory not initialized.');
     }
 
+    final List<dynamic> ids;
+    try {
+      final body = json.decode(await request.readAsString()) as Map<String, dynamic>;
+      ids = body['ids'] as List<dynamic>? ?? const [];
+    } catch (_) {
+      return Response.badRequest(body: 'Invalid request body.');
+    }
+
     int deleted = 0;
     int failed = 0;
+    final List<String> skipped = [];
 
-    try {
-      // AndroidでSAF URIが設定されている場合
-      if (Platform.isAndroid && _safDirectoryUri != null) {
-        final List<dynamic>? files = await _safPlatform.invokeMethod('listFiles', {'uri': _safDirectoryUri});
-        if (files != null) {
-          for (final fileInfo in files) {
-            try {
-              final String fileUri = fileInfo['uri'];
-              final String filename = fileInfo['name'];
-              final bool? success = await _safPlatform.invokeMethod('deleteFile', {'uri': fileUri});
-              if (success == true) {
-                deleted++;
-                // サムネイルキャッシュも削除
-                final cacheFile = File(p.join(_thumbnailCacheDir!.path, '$filename.jpg'));
-                if (await cacheFile.exists()) {
-                  await cacheFile.delete();
-                }
-              } else {
-                failed++;
-              }
-            } catch (e) {
-              failed++;
-            }
+    // Android SAF
+    if (Platform.isAndroid && _safDirectoryUri != null) {
+      for (final raw in ids) {
+        try {
+          final fileUri = utf8.decode(base64Url.decode(raw as String));
+          if (!fileUri.startsWith(_safDirectoryUri!)) {
+            skipped.add(raw);
+            continue;
           }
+          final filename = Uri.parse(fileUri).pathSegments.last;
+          final success = await _safPlatform.invokeMethod('deleteFile', {'uri': fileUri});
+          if (success == true) {
+            deleted++;
+            final cacheFile = File(p.join(_thumbnailCacheDir!.path, '$filename.jpg'));
+            if (await cacheFile.exists()) await cacheFile.delete();
+          } else {
+            failed++;
+          }
+        } catch (_) {
+          failed++;
         }
       }
-      // 他のプラットフォーム、またはSAFが設定されていないAndroidの場合
-      else {
-        final directory = Directory(storagePath);
-        if (await directory.exists()) {
-          final files = await directory.list().where((item) => item is File).cast<File>().toList();
-          for (final file in files) {
-            try {
-              final filename = p.basename(file.path);
-              await file.delete();
-              deleted++;
-              // サムネイルキャッシュも削除
-              final cacheFile = File(p.join(_thumbnailCacheDir!.path, '$filename.jpg'));
-              if (await cacheFile.exists()) {
-                await cacheFile.delete();
-              }
-            } catch (e) {
-              failed++;
-            }
+    } else {
+      final canonicalRoot = await Directory(storagePath).resolveSymbolicLinks();
+      for (final raw in ids) {
+        try {
+          final filePath = utf8.decode(base64Url.decode(raw as String));
+          final file = File(filePath);
+          if (!await file.exists()) {
+            failed++;
+            continue;
           }
+          final canonicalFile = await file.resolveSymbolicLinks();
+          if (!p.isWithin(canonicalRoot, canonicalFile)) {
+            skipped.add(raw as String);
+            continue;
+          }
+          final filename = p.basename(filePath);
+          await file.delete();
+          deleted++;
+          final cacheFile = File(p.join(_thumbnailCacheDir!.path, '$filename.jpg'));
+          if (await cacheFile.exists()) await cacheFile.delete();
+        } catch (_) {
+          failed++;
         }
       }
-
-      return Response.ok(
-        json.encode({'deleted': deleted, 'failed': failed}),
-        headers: {'Content-Type': 'application/json'},
-      );
-    } catch (e) {
-      return Response.internalServerError(body: "Failed to delete files: $e");
     }
+
+    return Response.ok(
+      json.encode({'deleted': deleted, 'failed': failed, 'skipped': skipped}),
+      headers: {'Content-Type': 'application/json'},
+    );
   }
 
   Future<Response> _downloadAllHandler(Request request) async {

--- a/lib/server_service.dart
+++ b/lib/server_service.dart
@@ -581,7 +581,7 @@ class ServerService {
 
     try {
       final decoded = utf8.decode(base64Url.decode(id));
-      
+
       // AndroidでSAF URIが設定されている場合
       if (Platform.isAndroid && _safDirectoryUri != null) {
         final fileUri = decoded;
@@ -590,12 +590,12 @@ class ServerService {
         if (bytes == null) {
           return Response.internalServerError(body: 'Failed to read file.');
         }
-        
+
         final filename = Uri.parse(fileUri).pathSegments.last;
         final mimeType = _getMimeType(filename);
-        return Response.ok(bytes, headers: {'Content-Type': mimeType});
-
-      } 
+        // #200: SAF はメモリ上で範囲スライス（大ファイルは非効率だが互換のため）
+        return _maybeRangeResponseFromBytes(request, bytes, mimeType);
+      }
       // 他のプラットフォーム、またはSAFが設定されていないAndroidの場合
       else {
         final filePath = decoded;
@@ -619,12 +619,99 @@ class ServerService {
           return Response.notFound('File not found: $filePath');
         }
         final mimeType = _getMimeType(p.basename(filePath));
-        return Response.ok(file.openRead())
-            .change(headers: {'Content-Type': mimeType});
+        return _maybeRangeResponseFromFile(request, file, mimeType);
       }
     } catch (e) {
       return Response.internalServerError(body: "Failed to process download request: $e");
     }
+  }
+
+  // #200: 単一 Range リクエストの解析。"bytes=start-end" の形式のみ対応。
+  // 戻り値: 範囲 (start, end inclusive) または null（Range ヘッダなし）。
+  // 無効な Range の場合は throw RangeError。
+  ({int start, int end})? _parseRange(String? header, int fileLength) {
+    if (header == null || header.isEmpty) return null;
+    if (!header.startsWith('bytes=')) throw RangeError('Invalid range unit');
+    final spec = header.substring('bytes='.length).trim();
+    if (spec.contains(',')) {
+      // multipart range は未対応 → 全体を返すよう null を返す
+      return null;
+    }
+    final dash = spec.indexOf('-');
+    if (dash < 0) throw RangeError('Invalid range spec');
+    final startStr = spec.substring(0, dash);
+    final endStr = spec.substring(dash + 1);
+    int start, end;
+    if (startStr.isEmpty) {
+      // "bytes=-N" : 末尾 N バイト
+      final suffix = int.tryParse(endStr);
+      if (suffix == null || suffix <= 0) throw RangeError('Invalid suffix');
+      start = (fileLength - suffix).clamp(0, fileLength);
+      end = fileLength - 1;
+    } else {
+      final s = int.tryParse(startStr);
+      if (s == null || s < 0) throw RangeError('Invalid start');
+      start = s;
+      end = endStr.isEmpty ? fileLength - 1 : (int.tryParse(endStr) ?? -1);
+      if (end < 0) throw RangeError('Invalid end');
+      if (end >= fileLength) end = fileLength - 1;
+    }
+    if (start > end || start >= fileLength) throw RangeError('Unsatisfiable');
+    return (start: start, end: end);
+  }
+
+  Future<Response> _maybeRangeResponseFromFile(
+      Request request, File file, String mimeType) async {
+    final length = await file.length();
+    final rangeHeader = request.headers['range'];
+    ({int start, int end})? range;
+    try {
+      range = _parseRange(rangeHeader, length);
+    } on RangeError {
+      return Response(416, body: 'Requested Range Not Satisfiable',
+          headers: {'Content-Range': 'bytes */$length'});
+    }
+    if (range == null) {
+      return Response.ok(file.openRead(), headers: {
+        'Content-Type': mimeType,
+        'Accept-Ranges': 'bytes',
+        'Content-Length': '$length',
+      });
+    }
+    final contentLength = range.end - range.start + 1;
+    return Response(206, body: file.openRead(range.start, range.end + 1),
+        headers: {
+          'Content-Type': mimeType,
+          'Accept-Ranges': 'bytes',
+          'Content-Length': '$contentLength',
+          'Content-Range': 'bytes ${range.start}-${range.end}/$length',
+        });
+  }
+
+  Response _maybeRangeResponseFromBytes(
+      Request request, Uint8List bytes, String mimeType) {
+    final rangeHeader = request.headers['range'];
+    ({int start, int end})? range;
+    try {
+      range = _parseRange(rangeHeader, bytes.length);
+    } on RangeError {
+      return Response(416, body: 'Requested Range Not Satisfiable',
+          headers: {'Content-Range': 'bytes */${bytes.length}'});
+    }
+    if (range == null) {
+      return Response.ok(bytes, headers: {
+        'Content-Type': mimeType,
+        'Accept-Ranges': 'bytes',
+        'Content-Length': '${bytes.length}',
+      });
+    }
+    final slice = bytes.sublist(range.start, range.end + 1);
+    return Response(206, body: slice, headers: {
+      'Content-Type': mimeType,
+      'Accept-Ranges': 'bytes',
+      'Content-Length': '${slice.length}',
+      'Content-Range': 'bytes ${range.start}-${range.end}/${bytes.length}',
+    });
   }
 
   // Android SAF URI から表示用パスを生成するヘルパー

--- a/lib/server_service.dart
+++ b/lib/server_service.dart
@@ -205,6 +205,7 @@ class ServerService {
     _router.post('/api/auth', _authHandler);
     _router.get('/api/health', _healthHandler);
     _router.get('/api/info', _infoHandler);
+    _router.get('/api/check-auth', _checkAuthHandler);
     _router.get('/api/files', _getFilesHandler);
     _router.post('/api/upload', _uploadHandler);
     _router.get('/api/download/<id>', _downloadHandler);
@@ -386,6 +387,14 @@ class ServerService {
   /// ヘルスチェック: 認証不要。クライアントがサーバ再起動を検知するために使用
   Response _healthHandler(Request request) {
     return Response.ok(json.encode({'startedAt': _startedAt}),
+        headers: {'Content-Type': 'application/json'});
+  }
+
+  // #201: 認証チェック専用エンドポイント。
+  // 認証ミドルウェアがセッション未確立時に 401 を返すので、
+  // 200 で来ればセッションは有効。downloadFile の事前チェック用。
+  Response _checkAuthHandler(Request request) {
+    return Response.ok(json.encode({'ok': true}),
         headers: {'Content-Type': 'application/json'});
   }
 

--- a/lib/server_service.dart
+++ b/lib/server_service.dart
@@ -605,29 +605,9 @@ class ServerService {
             !p.isWithin(canonicalRoot, canonicalFile)) {
           return Response.forbidden('Access denied');
         }
-        // フォルダの場合はZIPで返す (#179)
+        // #191: フォルダは個別ダウンロード対象外（download-all のみ使用）
         if (await FileSystemEntity.isDirectory(filePath)) {
-          final dirName = Uri.encodeComponent(p.basename(filePath))
-              .replaceAll("'", '%27');
-          final encoder = ZipEncoder();
-          final archive = Archive();
-          final dir = Directory(filePath);
-          final files =
-              dir.listSync(recursive: true, followLinks: false).whereType<File>();
-          for (final file in files) {
-            final bytes = await file.readAsBytes();
-            final rel = p.relative(file.path, from: filePath);
-            archive.addFile(ArchiveFile(rel, bytes.length, bytes));
-          }
-          final zipData = encoder.encode(archive);
-          if (zipData == null) {
-            return Response.internalServerError(body: 'Failed to create zip.');
-          }
-          return Response.ok(zipData, headers: {
-            'Content-Type': 'application/zip',
-            'Content-Disposition':
-                "attachment; filename*=UTF-8''$dirName.zip",
-          });
+          return Response.notFound('Directory download is not supported.');
         }
         final file = File(filePath);
         if (!await file.exists()) {

--- a/lib/server_service.dart
+++ b/lib/server_service.dart
@@ -71,6 +71,7 @@ class ServerService {
   bool _verboseLogging = false;
   bool _clipboardEnabled = true;
   String _serverName = 'LocalNode';
+  String _appVersion = '';
   int _startedAt = 0; // サーバ起動タイムスタンプ（エポックミリ秒）
 
   // クリップボード共有用
@@ -139,6 +140,7 @@ class ServerService {
     if (kIsWeb) return;
     final packageInfo = await PackageInfo.fromPlatform();
     final appName = packageInfo.appName;
+    _appVersion = packageInfo.version;
     final docDir = await getApplicationDocumentsDirectory();
 
     // デフォルトパスを設定
@@ -387,7 +389,7 @@ class ServerService {
 
   Response _infoHandler(Request request) {
     final info = {
-      'version': '1.2.0',
+      'version': _appVersion,
       'name': 'LocalNode Server',
       'serverName': _serverName,
       'operationMode': _operationMode == OperationMode.downloadOnly ? 'downloadOnly' : 'normal',

--- a/lib/server_service.dart
+++ b/lib/server_service.dart
@@ -209,6 +209,7 @@ class ServerService {
     _router.post('/api/upload', _uploadHandler);
     _router.get('/api/download/<id>', _downloadHandler);
     _router.get('/api/thumbnail/<id>', _thumbnailHandler);
+    _router.get('/api/thumbnail-by-path', _thumbnailByPathHandler);
     _router.get('/api/download-all', _downloadAllHandler);
     _router.delete('/api/files/<id>', _deleteFileHandler);
     _router.post('/api/files/delete-batch', _deleteBatchHandler);
@@ -745,6 +746,38 @@ class ServerService {
     }
   }
   
+  // #198: @file:<relpath> 用のパスベースサムネイル取得
+  Future<Response> _thumbnailByPathHandler(Request request) async {
+    final storagePath = _safDirectoryUri ?? _fallbackStoragePath;
+    if (storagePath == null) {
+      return Response.internalServerError(body: 'Server directory not initialized.');
+    }
+    final relPath = request.url.queryParameters['path'] ?? '';
+    if (relPath.isEmpty ||
+        relPath.contains('..') ||
+        relPath.startsWith('/') ||
+        relPath.startsWith(r'\') ||
+        relPath.contains(':')) {
+      return Response.badRequest(body: 'Invalid path.');
+    }
+    if (Platform.isAndroid && _safDirectoryUri != null) {
+      return Response.notFound('Path-based access not supported on Android SAF.');
+    }
+    final canonicalRoot =
+        await Directory(storagePath).resolveSymbolicLinks();
+    final targetPath = p.normalize(p.join(canonicalRoot, relPath));
+    final file = File(targetPath);
+    if (!await file.exists()) {
+      return Response.notFound('File not found.');
+    }
+    final canonicalTarget = await file.resolveSymbolicLinks();
+    if (!p.isWithin(canonicalRoot, canonicalTarget)) {
+      return Response.forbidden('Access denied');
+    }
+    final id = base64Url.encode(utf8.encode(targetPath));
+    return _thumbnailHandler(request, id);
+  }
+
   bool _isImageFile(String filename) {
     final extension = p.extension(filename).toLowerCase();
     const imageExtensions = {'.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp'};

--- a/lib/server_service.dart
+++ b/lib/server_service.dart
@@ -210,6 +210,7 @@ class ServerService {
     _router.get('/api/download/<id>', _downloadHandler);
     _router.get('/api/thumbnail/<id>', _thumbnailHandler);
     _router.get('/api/thumbnail-by-path', _thumbnailByPathHandler);
+    _router.get('/api/text-preview/<id>', _textPreviewHandler);
     _router.get('/api/download-all', _downloadAllHandler);
     _router.delete('/api/files/<id>', _deleteFileHandler);
     _router.post('/api/files/delete-batch', _deleteBatchHandler);
@@ -776,6 +777,64 @@ class ServerService {
     }
     final id = base64Url.encode(utf8.encode(targetPath));
     return _thumbnailHandler(request, id);
+  }
+
+  // #193: テキストファイルのインラインプレビュー（head / tail / full）
+  Future<Response> _textPreviewHandler(Request request, String id) async {
+    const maxFullBytes = 5 * 1024 * 1024; // 5MB
+    final mode = request.url.queryParameters['mode'] ?? 'head';
+    final lines = int.tryParse(request.url.queryParameters['lines'] ?? '') ?? 200;
+    if (lines < 1 || lines > 10000) {
+      return Response.badRequest(body: 'lines out of range');
+    }
+    try {
+      final decoded = utf8.decode(base64Url.decode(id));
+      String content;
+
+      if (Platform.isAndroid && _safDirectoryUri != null) {
+        final bytes = await _safPlatform.invokeMethod('readFile', {'uri': decoded});
+        if (bytes == null) return Response.notFound('File not found.');
+        if (mode == 'full' && bytes.length > maxFullBytes) {
+          return Response.badRequest(body: 'File too large for full preview (max 5MB).');
+        }
+        content = utf8.decode(bytes, allowMalformed: true);
+      } else {
+        final file = File(decoded);
+        if (!await file.exists()) return Response.notFound('File not found.');
+        final size = await file.length();
+        if (mode == 'full' && size > maxFullBytes) {
+          return Response.badRequest(body: 'File too large for full preview (max 5MB).');
+        }
+        content = await file.readAsString(encoding: utf8);
+      }
+
+      String result;
+      int totalLines = '\n'.allMatches(content).length + 1;
+      if (mode == 'head') {
+        final all = content.split('\n');
+        result = all.take(lines).join('\n');
+      } else if (mode == 'tail') {
+        final all = content.split('\n');
+        result = all.length > lines
+            ? all.sublist(all.length - lines).join('\n')
+            : content;
+      } else {
+        result = content;
+      }
+
+      return Response.ok(
+        json.encode({
+          'content': result,
+          'totalLines': totalLines,
+          'truncated': mode != 'full' && totalLines > lines,
+          'mode': mode,
+          'lines': lines,
+        }),
+        headers: {'Content-Type': 'application/json'},
+      );
+    } catch (e) {
+      return Response.internalServerError(body: 'Text preview failed: $e');
+    }
   }
 
   bool _isImageFile(String filename) {

--- a/lib/server_service.dart
+++ b/lib/server_service.dart
@@ -782,51 +782,72 @@ class ServerService {
   // #193: テキストファイルのインラインプレビュー（head / tail / full）
   Future<Response> _textPreviewHandler(Request request, String id) async {
     const maxFullBytes = 5 * 1024 * 1024; // 5MB
-    final mode = request.url.queryParameters['mode'] ?? 'head';
+    final modeRaw = request.url.queryParameters['mode'] ?? 'head';
+    if (modeRaw != 'head' && modeRaw != 'tail' && modeRaw != 'full') {
+      return Response.badRequest(body: 'mode must be head|tail|full');
+    }
+    final mode = modeRaw;
     final lines = int.tryParse(request.url.queryParameters['lines'] ?? '') ?? 200;
     if (lines < 1 || lines > 10000) {
       return Response.badRequest(body: 'lines out of range');
     }
+    final storagePath = _safDirectoryUri ?? _fallbackStoragePath;
+    if (storagePath == null) {
+      return Response.internalServerError(body: 'Server directory not initialized.');
+    }
     try {
       final decoded = utf8.decode(base64Url.decode(id));
-      String content;
 
+      // パストラバーサル検証 (Copilot #199 review)
+      if (Platform.isAndroid && _safDirectoryUri != null) {
+        if (!decoded.startsWith(_safDirectoryUri!)) {
+          return Response.forbidden('Access denied');
+        }
+      } else {
+        if (await FileSystemEntity.isDirectory(decoded)) {
+          return Response.badRequest(body: 'Target is a directory.');
+        }
+        final canonicalRoot =
+            await Directory(storagePath).resolveSymbolicLinks();
+        final target = File(decoded);
+        if (!await target.exists()) {
+          return Response.notFound('File not found.');
+        }
+        final canonicalFile = await target.resolveSymbolicLinks();
+        if (!p.isWithin(canonicalRoot, canonicalFile)) {
+          return Response.forbidden('Access denied');
+        }
+      }
+
+      // head/tail は全読みせず、行数だけ集める（バウンドメモリ）
+      if (mode == 'head' || mode == 'tail') {
+        return _streamTextLines(decoded, mode, lines);
+      }
+
+      // mode == 'full' は 5MB キャップ
+      String content;
+      int totalLines;
       if (Platform.isAndroid && _safDirectoryUri != null) {
         final bytes = await _safPlatform.invokeMethod('readFile', {'uri': decoded});
         if (bytes == null) return Response.notFound('File not found.');
-        if (mode == 'full' && bytes.length > maxFullBytes) {
+        if (bytes.length > maxFullBytes) {
           return Response.badRequest(body: 'File too large for full preview (max 5MB).');
         }
         content = utf8.decode(bytes, allowMalformed: true);
       } else {
         final file = File(decoded);
-        if (!await file.exists()) return Response.notFound('File not found.');
         final size = await file.length();
-        if (mode == 'full' && size > maxFullBytes) {
+        if (size > maxFullBytes) {
           return Response.badRequest(body: 'File too large for full preview (max 5MB).');
         }
         content = await file.readAsString(encoding: utf8);
       }
-
-      String result;
-      int totalLines = '\n'.allMatches(content).length + 1;
-      if (mode == 'head') {
-        final all = content.split('\n');
-        result = all.take(lines).join('\n');
-      } else if (mode == 'tail') {
-        final all = content.split('\n');
-        result = all.length > lines
-            ? all.sublist(all.length - lines).join('\n')
-            : content;
-      } else {
-        result = content;
-      }
-
+      totalLines = '\n'.allMatches(content).length + 1;
       return Response.ok(
         json.encode({
-          'content': result,
+          'content': content,
           'totalLines': totalLines,
-          'truncated': mode != 'full' && totalLines > lines,
+          'truncated': false,
           'mode': mode,
           'lines': lines,
         }),
@@ -834,6 +855,74 @@ class ServerService {
       );
     } catch (e) {
       return Response.internalServerError(body: 'Text preview failed: $e');
+    }
+  }
+
+  // head/tail のストリーミング読み込み（ファイル全体をメモリに乗せない）
+  Future<Response> _streamTextLines(String filePath, String mode, int lines) async {
+    // SAF はストリーミング読み込みが面倒なので、SAFの場合は読み切ってから head/tail
+    if (Platform.isAndroid && _safDirectoryUri != null) {
+      final bytes = await _safPlatform.invokeMethod('readFile', {'uri': filePath});
+      if (bytes == null) return Response.notFound('File not found.');
+      final content = utf8.decode(bytes, allowMalformed: true);
+      final all = content.split('\n');
+      final result = mode == 'head'
+          ? all.take(lines).join('\n')
+          : (all.length > lines
+              ? all.sublist(all.length - lines).join('\n')
+              : content);
+      return Response.ok(
+        json.encode({
+          'content': result,
+          'totalLines': all.length,
+          'truncated': all.length > lines,
+          'mode': mode,
+          'lines': lines,
+        }),
+        headers: {'Content-Type': 'application/json'},
+      );
+    }
+    final file = File(filePath);
+    final stream = file
+        .openRead()
+        .transform(utf8.decoder)
+        .transform(const LineSplitter());
+    if (mode == 'head') {
+      final collected = <String>[];
+      var totalLines = 0;
+      await for (final line in stream) {
+        totalLines++;
+        if (collected.length < lines) collected.add(line);
+      }
+      return Response.ok(
+        json.encode({
+          'content': collected.join('\n'),
+          'totalLines': totalLines,
+          'truncated': totalLines > lines,
+          'mode': mode,
+          'lines': lines,
+        }),
+        headers: {'Content-Type': 'application/json'},
+      );
+    } else {
+      // tail: 末尾 N 行を循環バッファで保持
+      final buf = <String>[];
+      var totalLines = 0;
+      await for (final line in stream) {
+        totalLines++;
+        buf.add(line);
+        if (buf.length > lines) buf.removeAt(0);
+      }
+      return Response.ok(
+        json.encode({
+          'content': buf.join('\n'),
+          'totalLines': totalLines,
+          'truncated': totalLines > lines,
+          'mode': mode,
+          'lines': lines,
+        }),
+        headers: {'Content-Type': 'application/json'},
+      );
     }
   }
 
@@ -974,7 +1063,11 @@ class ServerService {
     // #195: ZIP を一時ファイルへストリーミングして書き出し、レスポンスとして
     // 流す。これによりサーバ側でも巨大ファイル × 多数を扱える。
     final tempDir = await Directory.systemTemp.createTemp('localnode_zip_');
-    final zipPath = p.join(tempDir.path, 'localnode_files.zip');
+    final zipPath = p.join(tempDir.path, 'archive.zip');
+    // ステージング用サブディレクトリ (Copilot #199 review):
+    // ユーザのファイル名と zip 出力名/パス・パス区切り文字の衝突を避ける
+    final stagingDir =
+        await Directory(p.join(tempDir.path, 'staging')).create();
 
     try {
       final zipEncoder = ZipFileEncoder()..create(zipPath);
@@ -990,15 +1083,18 @@ class ServerService {
             return Response.internalServerError(
                 body: 'Failed to list files for zipping.');
           }
+          int stagingSeq = 0;
           for (final fileInfo in files) {
             final String fileUri = fileInfo['uri'];
             final String filename = fileInfo['name'];
             final Uint8List? bytes = await _safPlatform
                 .invokeMethod('readFile', {'uri': fileUri});
             if (bytes != null) {
-              // SAF はバイト列でしか取れないため、一時ファイルへ書いてから
-              // ZipFileEncoder に渡してストリーム圧縮
-              final tmpFile = File(p.join(tempDir.path, filename));
+              // SAF はバイト列でしか取れないため、ステージングディレクトリへ
+              // ユニーク名 (連番) で書いて ZipFileEncoder に渡す。
+              // ZIP 内の entry 名はオリジナル filename を使用する。
+              final tmpFile = File(p.join(stagingDir.path, '$stagingSeq.bin'));
+              stagingSeq++;
               await tmpFile.writeAsBytes(bytes, flush: true);
               await zipEncoder.addFile(tmpFile, filename);
               await tmpFile.delete();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.4.0+1
+version: 1.5.0+1
 
 environment:
   sdk: '>=3.4.3 <4.0.0'


### PR DESCRIPTION
## Summary

v1.5.0 covers bugfixes and small/medium UX additions on top of v1.4.0.

### Bug fixes
- #190 Delete-all now scopes to the currently displayed folder via new `POST /api/files/delete-batch`
- #191 Folder-row DL button removed; download behavior unified to non-recursive current folder
- #194 Web UI downloads stream via direct anchor (native progress, no memory buffering)
- #195 Download-all ZIP streamed to a temp file (no OOM on ~1GB+ totals)
- #186 "すべて..." button labels renamed to "このフォルダの…" to reflect actual scope

### New features / UX
- #192 Refresh button on the file list
- #197 Real LocalNode version shown in the top-right; both GUI and CLI servers now report it via /api/info
- #188 Bearer upload token also authenticates POST /api/clipboard (curl-friendly clipboard send)
- #196 Tab-title indicator (●) for new clipboard items when tab is in the background
- #198 Clipboard `@file:<relpath>` markers render as inline thumbnails (image) or 📎 chips (other) and jump to the folder on click; max 5 per message
- #193 Inline preview for text files with head/tail/full modes (5MB cap on full)
- #189 Video files get a frame-zero thumbnail in grid view and play inline in an overlay

## API changes (breaking)

- `DELETE /api/files` (delete-all) removed; replaced by `POST /api/files/delete-batch` with `{ "ids": [...] }`
- `/api/download/<id>` no longer returns ZIP for directories (returns 404)

## New endpoints

- `POST /api/files/delete-batch`
- `GET /api/thumbnail-by-path?path=<relpath>`
- `GET /api/text-preview/<id>?mode=head|tail|full&lines=N`

## Test plan

- See `work/1.5.0_check.md`
- Cross-platform device test before merging to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)