### PR TITLE
version/1.5.0: post-device-test bugfixes

### DIFF
--- a/assets/web/index.html
+++ b/assets/web/index.html
@@ -396,6 +396,17 @@
             vertical-align: middle;
         }
         .tab-unread-dot[hidden] { display: none; }
+        .visually-hidden {
+            position: absolute;
+            width: 1px;
+            height: 1px;
+            padding: 0;
+            margin: -1px;
+            overflow: hidden;
+            clip: rect(0, 0, 0, 0);
+            white-space: nowrap;
+            border: 0;
+        }
         .tab-content {
             display: none;
         }
@@ -811,10 +822,11 @@
                     <span class="tab-icon">📁</span>
                     <span>ファイル</span>
                 </button>
-                <button class="tab-btn" data-tab="clipboard">
+                <button class="tab-btn" data-tab="clipboard" id="clipboardTabBtn">
                     <span class="tab-icon">📋</span>
                     <span>クリップボード</span>
-                    <span class="tab-unread-dot" id="clipboardTabUnreadDot" hidden></span>
+                    <span class="tab-unread-dot" id="clipboardTabUnreadDot" hidden aria-hidden="true"></span>
+                    <span class="visually-hidden" id="clipboardTabUnreadSr" hidden>新着あり</span>
                 </button>
             </div>
 
@@ -1339,8 +1351,17 @@
                 const target = hasUnread ? NOTIFY_PREFIX + baseTitle : baseTitle;
                 if (document.title !== target) document.title = target;
             };
+            const clipboardTabBtn = document.getElementById('clipboardTabBtn');
+            const clipboardTabSr = document.getElementById('clipboardTabUnreadSr');
             const applyTabDot = () => {
                 clipboardTabDot.hidden = !tabUnread;
+                clipboardTabSr.hidden = !tabUnread;
+                // (Copilot #207 review): スクリーンリーダ向けに状態を露出
+                if (tabUnread) {
+                    clipboardTabBtn.setAttribute('aria-label', 'クリップボード（新着あり）');
+                } else {
+                    clipboardTabBtn.removeAttribute('aria-label');
+                }
             };
             const clearUnread = () => {
                 if (hasUnread) {
@@ -1357,16 +1378,15 @@
             const isClipboardTabActive = () =>
                 document.querySelector('.tab-btn[data-tab="clipboard"]').classList.contains('active');
             const markUnread = () => {
-                if (!notifyEnabled) return;
-                // ブラウザタブが裏ならタイトルに ●
-                if (document.hidden) {
-                    hasUnread = true;
-                    applyTitleIndicator();
-                }
-                // ページ内のクリップボードタブが非アクティブならドット表示
+                // (Copilot #207 review): ページ内ドットはトグルと独立 - 常にON
                 if (!isClipboardTabActive()) {
                     tabUnread = true;
                     applyTabDot();
+                }
+                // ブラウザタブタイトルの ● は notifyEnabled トグルでON/OFF
+                if (notifyEnabled && document.hidden) {
+                    hasUnread = true;
+                    applyTitleIndicator();
                 }
             };
             document.addEventListener('visibilitychange', () => {
@@ -1379,10 +1399,9 @@
             notifyToggle.addEventListener('change', () => {
                 notifyEnabled = notifyToggle.checked;
                 localStorage.setItem('localnode_clipboardNotify', notifyEnabled ? '1' : '0');
-                if (!notifyEnabled) {
-                    clearUnread();
-                    clearTabUnread();
-                }
+                // (Copilot #207 review): タブドットはトグルと独立。ブラウザタブ
+                // タイトルの ● のみここでクリア。
+                if (!notifyEnabled) clearUnread();
             });
 
             const startClipboardPolling = () => {

--- a/assets/web/index.html
+++ b/assets/web/index.html
@@ -1207,10 +1207,14 @@
                 uploadStatus.textContent = `アップロード開始...`;
 
                 try {
+                    // #203: 現在のフォルダに対してアップロード
+                    const uploadUrl = currentPath
+                        ? `/api/upload?path=${encodeURIComponent(currentPath)}`
+                        : '/api/upload';
                     for (let i = 0; i < files.length; i++) {
                         const file = files[i];
                         uploadStatus.textContent = `アップロード中... (${i + 1}/${files.length}) - ${file.name}`;
-                        const response = await safeFetch('/api/upload', {
+                        const response = await safeFetch(uploadUrl, {
                             method: 'POST',
                             headers: { 'x-filename': encodeURIComponent(file.name) },
                             body: file

--- a/assets/web/index.html
+++ b/assets/web/index.html
@@ -1461,8 +1461,14 @@
             document.getElementById('clipboardList').addEventListener('click', (e) => {
                 const target = e.target.closest('[data-folder]');
                 if (!target) return;
+                // dataset.folder は HTML エンティティをデコードした生の文字列が入る
                 const folder = target.dataset.folder || '';
                 navigateTo(folder);
+                // #202: クリップボードタブにいる場合があるので、ファイルタブへ強制切替
+                const filesTabBtn = document.querySelector('.tab-btn[data-tab="files"]');
+                if (filesTabBtn && !filesTabBtn.classList.contains('active')) {
+                    filesTabBtn.click();
+                }
                 document.getElementById('file-list').scrollIntoView({ behavior: 'smooth', block: 'start' });
             });
 

--- a/assets/web/index.html
+++ b/assets/web/index.html
@@ -386,6 +386,16 @@
         .tab-btn .tab-icon {
             font-size: 1.2rem;
         }
+        .tab-unread-dot {
+            display: inline-block;
+            width: 8px;
+            height: 8px;
+            background: #e53935;
+            border-radius: 50%;
+            margin-left: 0.25rem;
+            vertical-align: middle;
+        }
+        .tab-unread-dot[hidden] { display: none; }
         .tab-content {
             display: none;
         }
@@ -804,6 +814,7 @@
                 <button class="tab-btn" data-tab="clipboard">
                     <span class="tab-icon">📋</span>
                     <span>クリップボード</span>
+                    <span class="tab-unread-dot" id="clipboardTabUnreadDot" hidden></span>
                 </button>
             </div>
 
@@ -1093,6 +1104,9 @@
                     tabContents.forEach(content => content.classList.remove('active'));
                     // 対象のタブコンテンツを表示
                     document.getElementById(`tab-${targetTab}`).classList.add('active');
+
+                    // #204: クリップボードタブに切り替えた時点でドットを消す
+                    if (targetTab === 'clipboard') clearTabUnread();
                 });
             });
 
@@ -1312,27 +1326,48 @@
                 }
             };
 
-            // #196: 新着通知 (タブタイトルの先頭に ● を付与)
+            // #196/#204: 新着通知 (タブタイトルの ● とページ内タブのドット)
             const NOTIFY_PREFIX = '● ';
             let notifyEnabled = localStorage.getItem('localnode_clipboardNotify') === '1';
             let baseTitle = document.title;
-            let hasUnread = false;
+            let hasUnread = false;        // タブタイトル用 (ブラウザタブが裏のとき)
+            let tabUnread = false;        // ページ内タブのドット用
             let firstClipboardFetch = true;
+            const clipboardTabDot = document.getElementById('clipboardTabUnreadDot');
 
             const applyTitleIndicator = () => {
                 const target = hasUnread ? NOTIFY_PREFIX + baseTitle : baseTitle;
                 if (document.title !== target) document.title = target;
             };
-            const clearUnread = () => {
-                if (!hasUnread) return;
-                hasUnread = false;
-                applyTitleIndicator();
+            const applyTabDot = () => {
+                clipboardTabDot.hidden = !tabUnread;
             };
+            const clearUnread = () => {
+                if (hasUnread) {
+                    hasUnread = false;
+                    applyTitleIndicator();
+                }
+            };
+            const clearTabUnread = () => {
+                if (tabUnread) {
+                    tabUnread = false;
+                    applyTabDot();
+                }
+            };
+            const isClipboardTabActive = () =>
+                document.querySelector('.tab-btn[data-tab="clipboard"]').classList.contains('active');
             const markUnread = () => {
                 if (!notifyEnabled) return;
-                if (!document.hidden) return; // タブが見えていれば通知不要
-                hasUnread = true;
-                applyTitleIndicator();
+                // ブラウザタブが裏ならタイトルに ●
+                if (document.hidden) {
+                    hasUnread = true;
+                    applyTitleIndicator();
+                }
+                // ページ内のクリップボードタブが非アクティブならドット表示
+                if (!isClipboardTabActive()) {
+                    tabUnread = true;
+                    applyTabDot();
+                }
             };
             document.addEventListener('visibilitychange', () => {
                 if (!document.hidden) clearUnread();
@@ -1344,7 +1379,10 @@
             notifyToggle.addEventListener('change', () => {
                 notifyEnabled = notifyToggle.checked;
                 localStorage.setItem('localnode_clipboardNotify', notifyEnabled ? '1' : '0');
-                if (!notifyEnabled) clearUnread();
+                if (!notifyEnabled) {
+                    clearUnread();
+                    clearTabUnread();
+                }
             });
 
             const startClipboardPolling = () => {

--- a/bin/localnode_cli.dart
+++ b/bin/localnode_cli.dart
@@ -207,6 +207,8 @@ Future<void> main(List<String> args) async {
     stdout.writeln('         -H "x-filename: myfile.txt" \\');
     stdout.writeln('         --data-binary @/path/to/myfile.txt \\');
     stdout.writeln('         $serverUrl/api/upload');
+    stdout.writeln('    # subfolder upload: append ?path=<relpath>');
+    stdout.writeln('    #   $serverUrl/api/upload?path=photos%2F2026');
     stdout.writeln('');
     stdout.writeln('  curl example (clipboard):');
     stdout.writeln('    curl -H "Authorization: Bearer $uploadToken" \\');
@@ -1127,9 +1129,25 @@ class _CliServer {
       return Response.badRequest(body: 'x-filename header is required.');
     }
     final filename = p.basename(Uri.decodeComponent(encodedName));
-    final dir = Directory(_storagePath!);
+
+    // #203: ?path=<relpath> でサブフォルダ宛のアップロードを許可
+    final relPath = req.url.queryParameters['path'] ?? '';
+    if (relPath.contains('..') ||
+        relPath.startsWith('/') ||
+        relPath.startsWith(r'\') ||
+        relPath.contains(':')) {
+      return Response.badRequest(body: 'Invalid path.');
+    }
+    final canonicalRoot = await Directory(_storagePath!).resolveSymbolicLinks();
+    final targetDirPath = p.normalize(p.join(canonicalRoot, relPath));
+    final dir = Directory(targetDirPath);
     if (!await dir.exists()) {
-      return Response.internalServerError(body: 'Storage directory not found.');
+      return Response.notFound('Target directory not found.');
+    }
+    final canonicalTarget = await dir.resolveSymbolicLinks();
+    if (canonicalTarget != canonicalRoot &&
+        !p.isWithin(canonicalRoot, canonicalTarget)) {
+      return Response.forbidden('Access denied');
     }
 
     final file = await _uniqueFile(dir, filename);

--- a/bin/localnode_cli.dart
+++ b/bin/localnode_cli.dart
@@ -1131,14 +1131,20 @@ class _CliServer {
     final filename = p.basename(Uri.decodeComponent(encodedName));
 
     // #203: ?path=<relpath> でサブフォルダ宛のアップロードを許可
+    // (Copilot #207 review): セグメント単位で .. のみ拒否
     final relPath = req.url.queryParameters['path'] ?? '';
-    if (relPath.contains('..') ||
-        relPath.startsWith('/') ||
-        relPath.startsWith(r'\') ||
-        relPath.contains(':')) {
+    if (relPath.startsWith('/') || relPath.startsWith(r'\')) {
       return Response.badRequest(body: 'Invalid path.');
     }
-    final canonicalRoot = await Directory(_storagePath!).resolveSymbolicLinks();
+    if (p.split(relPath).contains('..')) {
+      return Response.badRequest(body: 'Invalid path.');
+    }
+    // (Copilot #207 review): root 不在を resolveSymbolicLinks より先に検出
+    final rootDir = Directory(_storagePath!);
+    if (!await rootDir.exists()) {
+      return Response.internalServerError(body: 'Storage directory not found.');
+    }
+    final canonicalRoot = await rootDir.resolveSymbolicLinks();
     final targetDirPath = p.normalize(p.join(canonicalRoot, relPath));
     final dir = Directory(targetDirPath);
     if (!await dir.exists()) {

--- a/lib/server_service.dart
+++ b/lib/server_service.dart
@@ -536,10 +536,26 @@ class ServerService {
     }
     // 他のプラットフォーム、またはSAFが設定されていないAndroidの場合
     else {
-      final directory = Directory(storagePath);
+      // #203: ?path=<relpath> でサブフォルダ宛のアップロードを許可
+      final relPath = request.url.queryParameters['path'] ?? '';
+      if (relPath.contains('..') ||
+          relPath.startsWith('/') ||
+          relPath.startsWith(r'\') ||
+          relPath.contains(':')) {
+        return Response.badRequest(body: 'Invalid path.');
+      }
+      final canonicalRoot =
+          await Directory(storagePath).resolveSymbolicLinks();
+      final targetDirPath = p.normalize(p.join(canonicalRoot, relPath));
+      final directory = Directory(targetDirPath);
       if (!await directory.exists()) {
-        _log('Upload error: storage directory missing -> $storagePath');
-        return Response.internalServerError(body: 'Documents directory not found.');
+        _log('Upload error: target directory missing -> $targetDirPath');
+        return Response.notFound('Target directory not found.');
+      }
+      final canonicalTarget = await directory.resolveSymbolicLinks();
+      if (canonicalTarget != canonicalRoot &&
+          !p.isWithin(canonicalRoot, canonicalTarget)) {
+        return Response.forbidden('Access denied');
       }
 
       final file = await _getUniqueFilePath(directory, sanitizedFilename);

--- a/lib/server_service.dart
+++ b/lib/server_service.dart
@@ -512,8 +512,16 @@ class ServerService {
     final filename = Uri.decodeComponent(encodedFilename);
     final sanitizedFilename = p.basename(filename);
 
+    final relPath = request.url.queryParameters['path'] ?? '';
+
     // AndroidでSAF URIが設定されている場合
     if (Platform.isAndroid && _safDirectoryUri != null) {
+      // SAF はサブディレクトリ URI 解決が未実装なので、path 指定はサポートしない
+      // (Copilot #207 review): silent root fallback を避け、明示的に 400 を返す
+      if (relPath.isNotEmpty) {
+        return Response.badRequest(
+            body: 'Subfolder upload is not supported on Android SAF.');
+      }
       try {
         final bytes = await request.read().fold<List<int>>([], (prev, chunk) => prev..addAll(chunk));
         final mimeType = _getMimeType(sanitizedFilename);
@@ -537,15 +545,20 @@ class ServerService {
     // 他のプラットフォーム、またはSAFが設定されていないAndroidの場合
     else {
       // #203: ?path=<relpath> でサブフォルダ宛のアップロードを許可
-      final relPath = request.url.queryParameters['path'] ?? '';
-      if (relPath.contains('..') ||
-          relPath.startsWith('/') ||
-          relPath.startsWith(r'\') ||
-          relPath.contains(':')) {
+      // (Copilot #207 review): セグメント単位で .. のみ拒否 (`..backup` 等は許可)
+      if (relPath.startsWith('/') || relPath.startsWith(r'\')) {
         return Response.badRequest(body: 'Invalid path.');
       }
-      final canonicalRoot =
-          await Directory(storagePath).resolveSymbolicLinks();
+      if (p.split(relPath).contains('..')) {
+        return Response.badRequest(body: 'Invalid path.');
+      }
+      // (Copilot #207 review): root ディレクトリ消失を resolveSymbolicLinks より先に検出
+      final rootDir = Directory(storagePath);
+      if (!await rootDir.exists()) {
+        _log('Upload error: storage directory missing -> $storagePath');
+        return Response.internalServerError(body: 'Documents directory not found.');
+      }
+      final canonicalRoot = await rootDir.resolveSymbolicLinks();
       final targetDirPath = p.normalize(p.join(canonicalRoot, relPath));
       final directory = Directory(targetDirPath);
       if (!await directory.exists()) {


### PR DESCRIPTION
## Summary

Follow-up to PR #199 — fixes reported during device testing on 2026-05-14.

- #202 Clipboard `@file:` marker click now switches to the files tab and navigates to the referenced folder (subfolder paths work as a side effect)
- #203 Uploads can now target the currently displayed subfolder via `POST /api/upload?path=<relpath>`; web UI sends current path automatically
- #204 In-page red dot on the クリップボード tab label when new clipboard items arrive while the user is viewing the files tab (complements the browser-tab title indicator from #196)

## Test plan

- See updated checklist in \`work/1.5.0_check.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)