### PR TITLE
version/1.5.1: fix ?path= query dropped after shelf_router routing (#213)

### DIFF
--- a/bin/localnode_cli.dart
+++ b/bin/localnode_cli.dart
@@ -25,7 +25,7 @@ import 'package:shelf_router/shelf_router.dart';
 import 'package:shelf_static/shelf_static.dart';
 
 // pubspec.yaml の version と一致させる
-const String _appVersion = '1.5.0';
+const String _appVersion = '1.5.1';
 
 // =============================================================================
 // エントリポイント
@@ -1084,7 +1084,7 @@ class _CliServer {
     if (!await root.exists()) {
       return Response.internalServerError(body: 'Storage directory not found.');
     }
-    final relPath = req.url.queryParameters['path'] ?? '';
+    final relPath = req.requestedUri.queryParameters['path'] ?? '';
     final canonicalRoot = await root.resolveSymbolicLinks();
     final targetPath = p.normalize(p.join(canonicalRoot, relPath));
     final dir = Directory(targetPath);
@@ -1132,7 +1132,7 @@ class _CliServer {
 
     // #203: ?path=<relpath> でサブフォルダ宛のアップロードを許可
     // (Copilot #207 review): セグメント単位で .. のみ拒否
-    final relPath = req.url.queryParameters['path'] ?? '';
+    final relPath = req.requestedUri.queryParameters['path'] ?? '';
     if (relPath.startsWith('/') || relPath.startsWith(r'\')) {
       return Response.badRequest(body: 'Invalid path.');
     }
@@ -1348,11 +1348,11 @@ class _CliServer {
   // #193: テキストファイルのインラインプレビュー
   Future<Response> _textPreviewHandler(Request req, String id) async {
     const maxFullBytes = 5 * 1024 * 1024;
-    final mode = req.url.queryParameters['mode'] ?? 'head';
+    final mode = req.requestedUri.queryParameters['mode'] ?? 'head';
     if (mode != 'head' && mode != 'tail' && mode != 'full') {
       return Response.badRequest(body: 'mode must be head|tail|full');
     }
-    final lines = int.tryParse(req.url.queryParameters['lines'] ?? '') ?? 200;
+    final lines = int.tryParse(req.requestedUri.queryParameters['lines'] ?? '') ?? 200;
     if (lines < 1 || lines > 10000) {
       return Response.badRequest(body: 'lines out of range');
     }
@@ -1439,7 +1439,7 @@ class _CliServer {
 
   // #198: @file:<relpath> 用のパスベースサムネイル
   Future<Response> _thumbnailByPathHandler(Request req) async {
-    final relPath = req.url.queryParameters['path'] ?? '';
+    final relPath = req.requestedUri.queryParameters['path'] ?? '';
     if (relPath.isEmpty ||
         relPath.contains('..') ||
         relPath.startsWith('/') ||
@@ -1495,7 +1495,7 @@ class _CliServer {
     if (!await root.exists()) {
       return Response.internalServerError(body: 'Storage directory not found.');
     }
-    final relPath = req.url.queryParameters['path'] ?? '';
+    final relPath = req.requestedUri.queryParameters['path'] ?? '';
     final canonicalRoot = await root.resolveSymbolicLinks();
     final targetPath = p.normalize(p.join(canonicalRoot, relPath));
     final dir = Directory(targetPath);

--- a/lib/server_service.dart
+++ b/lib/server_service.dart
@@ -439,7 +439,7 @@ class ServerService {
     // 他のプラットフォーム、またはSAFが設定されていないAndroidの場合は、従来のdart:ioを使用
     else {
       // ?path= パラメータで相対パスを受け取りサブフォルダナビゲーションに対応 (#178, #179)
-      final relPath = request.url.queryParameters['path'] ?? '';
+      final relPath = request.requestedUri.queryParameters['path'] ?? '';
       final rootDir = Directory(storagePath);
       if (!await rootDir.exists()) {
         return Response.internalServerError(body: 'Documents directory not found.');
@@ -512,7 +512,7 @@ class ServerService {
     final filename = Uri.decodeComponent(encodedFilename);
     final sanitizedFilename = p.basename(filename);
 
-    final relPath = request.url.queryParameters['path'] ?? '';
+    final relPath = request.requestedUri.queryParameters['path'] ?? '';
 
     // AndroidでSAF URIが設定されている場合
     if (Platform.isAndroid && _safDirectoryUri != null) {
@@ -878,7 +878,7 @@ class ServerService {
     if (storagePath == null) {
       return Response.internalServerError(body: 'Server directory not initialized.');
     }
-    final relPath = request.url.queryParameters['path'] ?? '';
+    final relPath = request.requestedUri.queryParameters['path'] ?? '';
     if (relPath.isEmpty ||
         relPath.contains('..') ||
         relPath.startsWith('/') ||
@@ -907,12 +907,12 @@ class ServerService {
   // #193: テキストファイルのインラインプレビュー（head / tail / full）
   Future<Response> _textPreviewHandler(Request request, String id) async {
     const maxFullBytes = 5 * 1024 * 1024; // 5MB
-    final modeRaw = request.url.queryParameters['mode'] ?? 'head';
+    final modeRaw = request.requestedUri.queryParameters['mode'] ?? 'head';
     if (modeRaw != 'head' && modeRaw != 'tail' && modeRaw != 'full') {
       return Response.badRequest(body: 'mode must be head|tail|full');
     }
     final mode = modeRaw;
-    final lines = int.tryParse(request.url.queryParameters['lines'] ?? '') ?? 200;
+    final lines = int.tryParse(request.requestedUri.queryParameters['lines'] ?? '') ?? 200;
     if (lines < 1 || lines > 10000) {
       return Response.badRequest(body: 'lines out of range');
     }
@@ -1233,7 +1233,7 @@ class ServerService {
         }
       } else {
         // ?path= で現在フォルダを指定し、そのフォルダのファイルのみをZIP (#179)
-        final relPath = request.url.queryParameters['path'] ?? '';
+        final relPath = request.requestedUri.queryParameters['path'] ?? '';
         final canonicalRoot =
             await Directory(storagePath).resolveSymbolicLinks();
         final targetPath = p.normalize(p.join(canonicalRoot, relPath));

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.5.0+1
+version: 1.5.1+1
 
 environment:
   sdk: '>=3.4.3 <4.0.0'


### PR DESCRIPTION
## Summary

Patch release. Fixes the core bug where `?path=` (and other query params) were ignored after shelf_router matched a route, so subfolder uploads silently landed in the storage root.

- #213 Read query params from `Request.requestedUri` instead of `Request.url`. `Request.url` is rebuilt relative to the matched route and can drop the query string; `requestedUri` always retains the full original URI.
- Applied to all 6 sites in each server (upload, file listing, download-all, thumbnail-by-path, text-preview).
- CLI `_appVersion` bumped to 1.5.1 so `/api/info` (#197) reports correctly.

## Evidence

`--verbose` showed `POST [200] /api/upload?path=test` reaching the server while the handler saw an empty path and saved to root.

## Test plan

See `work/1.5.1_check.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)