### PR TITLE
Release v1.6.0 — federation, clipboard scalability, PIN strengthening

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ localnode --cli [options]
 | `--ip` | IP address to advertise (skip auto-detection) |
 | `--name`, `-n` | Custom server name (shown in browser tab/title) |
 | `--pin` | Fixed PIN (random if not specified) |
+| `--pin-length` | PIN length for random generation: 4..8 (default 4) |
+| `--pin-charset` | PIN character set for random generation: `digits` (default), `alnum`, or `alnum_symbols` |
 | `--dir`, `-d` | Shared directory path |
 | `--mode`, `-m` | Operation mode: `normal` or `download-only` |
 | `--https-cert` | Path to TLS certificate file (cert.pem) |

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ localnode --cli [options]
 | Option | Description |
 |--------|-------------|
 | `--config`, `-c` | Path to YAML config file (overridden by CLI args, see [examples/config.example.yaml](examples/config.example.yaml)) |
+| `--state-file` | Path to persistent state file (device_id for federation). Default: `$XDG_STATE_HOME/localnode-cli/state.json` on POSIX, `%LOCALAPPDATA%\localnode-cli\state.json` on Windows |
 | `--port`, `-p` | Server port (default: 8080) |
 | `--ip` | IP address to advertise (skip auto-detection) |
 | `--name`, `-n` | Custom server name (shown in browser tab/title) |

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ localnode --cli [options]
 
 | Option | Description |
 |--------|-------------|
+| `--config`, `-c` | Path to YAML config file (overridden by CLI args, see [examples/config.example.yaml](examples/config.example.yaml)) |
 | `--port`, `-p` | Server port (default: 8080) |
 | `--ip` | IP address to advertise (skip auto-detection) |
 | `--name`, `-n` | Custom server name (shown in browser tab/title) |
@@ -137,7 +138,12 @@ localnode-cli --post-action "*=./notify.sh"
 # Trigger scripts via clipboard mention commands
 localnode-cli --mention-action backup=./backup.sh --mention-action notify=./notify.sh
 
+# Load options from a YAML config file (1.6.0+)
+localnode-cli --config /etc/localnode/config.yaml
+
 ```
+
+**Config file (YAML):** Long command lines can be replaced with a YAML config. See [examples/config.example.yaml](examples/config.example.yaml) for the full schema. CLI args always override config file values.
 
 > **Note (`--post-action` / `--mention-action`):** The `script` value must be a path to an executable file only — passing arguments inline (e.g. `script=./notify.sh arg1`) is not supported. For `--post-action`, the uploaded file path is automatically passed as the first argument to the script.
 >

--- a/android/app/src/main/kotlin/com/ictglab/localnode/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/ictglab/localnode/MainActivity.kt
@@ -103,6 +103,41 @@ class MainActivity: FlutterActivity() {
                         result.error("READ_FAILED", "Failed to read file: ${e.message}", null)
                     }
                 }
+                "resolvePath" -> {
+                    // #209: 相対パスを SAF ツリー配下の document URI に解決する
+                    val uriString = call.argument<String>("uri")
+                    val relPath = call.argument<String>("path")
+                    if (uriString == null || relPath == null) {
+                        result.error("ARGUMENT_ERROR", "uri and path are required.", null)
+                        return@setMethodCallHandler
+                    }
+                    // パストラバーサル防止
+                    val segments = relPath.split('/', '\\').filter { it.isNotEmpty() }
+                    if (segments.isEmpty() || segments.any { it == ".." || it == "." } || segments.size > 16) {
+                        result.error("INVALID_PATH", "Invalid relative path.", null)
+                        return@setMethodCallHandler
+                    }
+                    try {
+                        val treeUri = Uri.parse(uriString)
+                        var current: DocumentFile? = DocumentFile.fromTreeUri(context, treeUri)
+                        for (seg in segments) {
+                            val next = current?.findFile(seg)
+                            if (next == null || !next.exists()) {
+                                result.error("NOT_FOUND", "Segment not found: $seg", null)
+                                return@setMethodCallHandler
+                            }
+                            current = next
+                        }
+                        val target = current
+                        if (target == null || !target.isFile) {
+                            result.error("NOT_FILE", "Resolved entry is not a file.", null)
+                            return@setMethodCallHandler
+                        }
+                        result.success(target.uri.toString())
+                    } catch (e: Exception) {
+                        result.error("RESOLVE_FAILED", "Failed to resolve path: ${e.message}", null)
+                    }
+                }
                 "deleteFile" -> {
                     val uriString = call.argument<String>("uri")
                     if (uriString == null) {

--- a/assets/web/index.html
+++ b/assets/web/index.html
@@ -31,7 +31,9 @@
             background: #eee;
             color: #444;
             font-size: 0.8rem;
+            cursor: pointer;
         }
+        #fed-status .fed-peer:hover { opacity: 0.8; }
         #fed-status .fed-connected { background: #c8e6c9; color: #1b5e20; }
         #fed-status .fed-offline { background: #ffcdd2; color: #b71c1c; }
         #fed-status .fed-paused { background: #fff3cd; color: #856404; }
@@ -1109,7 +1111,6 @@
                 try {
                     const res = await safeFetch('/api/federation/status');
                     if (!res.ok) {
-                        // 404 等: federation 設定なし -> 非表示
                         fedStatusEl.style.display = 'none';
                         return;
                     }
@@ -1119,10 +1120,19 @@
                         fedStatusEl.style.display = 'none';
                         return;
                     }
+                    const now = Date.now();
                     const chips = peers.map(p => {
                         const cls = `fed-peer fed-${p.status || 'unknown'}`;
+                        let label = `${p.name}: ${p.status || 'unknown'}`;
+                        if (p.pauseUntilMs && p.pauseUntilMs > now) {
+                            const remainSec = Math.round((p.pauseUntilMs - now) / 1000);
+                            const remainStr = remainSec > 3600
+                                ? `${Math.round(remainSec / 3600)}h`
+                                : `${Math.round(remainSec / 60)}min`;
+                            label += ` (${remainStr})`;
+                        }
                         const title = `${p.kind} • ${p.relation}${p.lastError ? ' • ' + p.lastError : ''}`;
-                        return `<span class="${cls}" title="${title}">${p.name}: ${p.status || 'unknown'}</span>`;
+                        return `<span class="${cls}" title="${title}" data-peer-name="${escapeHtml(p.name)}" data-paused="${p.pauseUntilMs && p.pauseUntilMs > now ? '1' : '0'}">${label}</span>`;
                     }).join('');
                     fedStatusEl.innerHTML = `Federation: ${chips}`;
                     fedStatusEl.style.display = 'block';
@@ -1130,6 +1140,38 @@
                     fedStatusEl.style.display = 'none';
                 }
             };
+
+            // #223: peer chip クリックで pause/resume 操作
+            fedStatusEl.addEventListener('click', async (e) => {
+                const chip = e.target.closest('[data-peer-name]');
+                if (!chip) return;
+                const name = chip.dataset.peerName;
+                const isPaused = chip.dataset.paused === '1';
+                if (isPaused) {
+                    if (!confirm(`${name} の pause を解除しますか？`)) return;
+                    try {
+                        await safeFetch(`/api/federation/peers/${encodeURIComponent(name)}/pause`, { method: 'DELETE' });
+                        refreshFederationStatus();
+                    } catch (_) { alert('解除に失敗しました'); }
+                    return;
+                }
+                // pause メニュー
+                const choice = prompt(
+                    `${name} を pause します。秒数を選択してください:\n  1800 = 30分\n  3600 = 1時間\n  10800 = 3時間\n  43200 = 12時間\n  86400 = 24時間`,
+                    '3600'
+                );
+                if (!choice) return;
+                try {
+                    const r = await safeFetch(`/api/federation/peers/${encodeURIComponent(name)}/pause?duration=${encodeURIComponent(choice)}`, { method: 'POST' });
+                    if (!r.ok) {
+                        const txt = await r.text();
+                        alert(`pause 失敗: ${txt}`);
+                        return;
+                    }
+                    refreshFederationStatus();
+                } catch (_) { alert('pause に失敗しました'); }
+            });
+
             const startFederationStatusPolling = () => {
                 refreshFederationStatus();
                 if (fedStatusInterval) clearInterval(fedStatusInterval);

--- a/assets/web/index.html
+++ b/assets/web/index.html
@@ -1189,6 +1189,22 @@
             };
 
             const showPinModal = () => {
+                // #206: PIN charset / length のヒントに応じて input mode を切り替え
+                const charset = serverInfo.pinCharset || 'digits';
+                const length = Number.isInteger(serverInfo.pinLength) ? serverInfo.pinLength : 4;
+                if (charset === 'digits') {
+                    pinInput.setAttribute('inputmode', 'numeric');
+                    pinInput.setAttribute('pattern', `[0-9]{${length}}`);
+                } else {
+                    pinInput.setAttribute('inputmode', 'text');
+                    pinInput.removeAttribute('pattern');
+                    pinInput.setAttribute('autocapitalize', 'off');
+                    pinInput.setAttribute('autocomplete', 'one-time-code');
+                    pinInput.setAttribute('spellcheck', 'false');
+                }
+                // maxlength は最低でも 4 を許容しつつ、固定 PIN の場合 length と異なる可能性があるので
+                // length+4 までの余裕を持たせる
+                pinInput.setAttribute('maxlength', String(Math.max(length, 4) + 4));
                 mainContent.style.display = 'none';
                 pinModal.style.display = 'flex';
                 pinInput.focus();

--- a/assets/web/index.html
+++ b/assets/web/index.html
@@ -23,6 +23,20 @@
             color: #1a73e8;
             text-align: center;
         }
+        #fed-status .fed-peer {
+            display: inline-block;
+            padding: 0.15rem 0.5rem;
+            margin: 0 0.25rem;
+            border-radius: 10px;
+            background: #eee;
+            color: #444;
+            font-size: 0.8rem;
+        }
+        #fed-status .fed-connected { background: #c8e6c9; color: #1b5e20; }
+        #fed-status .fed-offline { background: #ffcdd2; color: #b71c1c; }
+        #fed-status .fed-paused { background: #fff3cd; color: #856404; }
+        #fed-status .fed-unknown { background: #eee; color: #555; }
+
         #version-badge {
             position: absolute;
             top: 0.5rem;
@@ -814,6 +828,8 @@
         <div class="container">
             <span id="version-badge"></span>
             <h1>LocalNode</h1>
+            <!-- #222: federation 接続状態 -->
+            <div id="fed-status" style="display:none; text-align:center; margin: 0 0 0.75rem; font-size: 0.85rem;"></div>
             <div id="mode-indicator" style="display:none; text-align:center; margin-bottom: 1rem;"></div>
 
             <!-- タブナビゲーション -->
@@ -1072,6 +1088,42 @@
                 if (serverInfo.version) {
                     document.getElementById('version-badge').textContent = `v${serverInfo.version}`;
                 }
+                // #222: federation 状態を定期取得
+                startFederationStatusPolling();
+            };
+
+            // #222: federation 状態ポーリング
+            const fedStatusEl = document.getElementById('fed-status');
+            let fedStatusInterval = null;
+            const refreshFederationStatus = async () => {
+                try {
+                    const res = await safeFetch('/api/federation/status');
+                    if (!res.ok) {
+                        // 404 等: federation 設定なし -> 非表示
+                        fedStatusEl.style.display = 'none';
+                        return;
+                    }
+                    const data = await res.json();
+                    const peers = Array.isArray(data.peers) ? data.peers : [];
+                    if (peers.length === 0) {
+                        fedStatusEl.style.display = 'none';
+                        return;
+                    }
+                    const chips = peers.map(p => {
+                        const cls = `fed-peer fed-${p.status || 'unknown'}`;
+                        const title = `${p.kind} • ${p.relation}${p.lastError ? ' • ' + p.lastError : ''}`;
+                        return `<span class="${cls}" title="${title}">${p.name}: ${p.status || 'unknown'}</span>`;
+                    }).join('');
+                    fedStatusEl.innerHTML = `Federation: ${chips}`;
+                    fedStatusEl.style.display = 'block';
+                } catch (_) {
+                    fedStatusEl.style.display = 'none';
+                }
+            };
+            const startFederationStatusPolling = () => {
+                refreshFederationStatus();
+                if (fedStatusInterval) clearInterval(fedStatusInterval);
+                fedStatusInterval = setInterval(refreshFederationStatus, 30000);
             };
 
             // ダウンロード専用モード時にUI要素を非表示にする

--- a/assets/web/index.html
+++ b/assets/web/index.html
@@ -245,6 +245,50 @@
             max-height: 300px;
             overflow-y: auto;
         }
+        /* #225: mention picker */
+        #mentionPickerBtn {
+            background: transparent;
+            color: #00796b;
+            border: 1px solid #b2dfdb;
+            border-radius: 4px;
+            font-weight: bold;
+            padding: 0 0.6rem;
+            cursor: pointer;
+            font-size: 1rem;
+            line-height: 1;
+            min-width: 2rem;
+        }
+        #mentionPickerBtn:hover { background: #e0f2f1; }
+        .clipboard-input { position: relative; display: flex; gap: 0.4rem; align-items: stretch; }
+        .clipboard-input textarea { flex: 1; }
+        #mentionPickerPopover {
+            position: absolute;
+            z-index: 30;
+            background: white;
+            border: 1px solid #b2dfdb;
+            border-radius: 4px;
+            box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+            max-height: 260px;
+            overflow-y: auto;
+            min-width: 220px;
+            padding: 0.25rem 0;
+        }
+        .mention-picker-item {
+            padding: 0.5rem 0.75rem;
+            cursor: pointer;
+            font-size: 0.9rem;
+            border-bottom: 1px solid #f0f0f0;
+        }
+        .mention-picker-item:last-child { border-bottom: none; }
+        .mention-picker-item:hover, .mention-picker-item.focused { background: #e0f2f1; }
+        .mention-picker-item .mp-label { font-weight: bold; color: #00796b; }
+        .mention-picker-item .mp-desc { color: #555; font-size: 0.8rem; margin-top: 0.15rem; }
+        .mention-picker-empty {
+            padding: 0.5rem 0.75rem;
+            color: #888;
+            font-style: italic;
+            font-size: 0.85rem;
+        }
         /* #229: filter / search row */
         #clipboard-filter-row {
             display: flex;
@@ -961,8 +1005,11 @@
                     <input type="text" id="clipboardTagInput" class="clipboard-tag-input" placeholder="送信元の名前（例: iPhone）" maxlength="30">
                     <div class="clipboard-input">
                         <textarea id="clipboardInput" placeholder="共有するテキストを入力..." rows="2"></textarea>
+                        <button id="mentionPickerBtn" type="button" title="メンション一覧" aria-label="メンション一覧">@</button>
                         <button id="sendClipboardBtn">送信</button>
                     </div>
+                    <!-- #225: mention picker popover -->
+                    <div id="mentionPickerPopover" role="listbox" aria-label="メンション候補" hidden></div>
                     <!-- #229: フィルタ / 検索 -->
                     <div id="clipboard-filter-row" style="display:none;">
                         <input type="search" id="clipboardSearch" placeholder="🔍 テキスト検索" />
@@ -1887,6 +1934,115 @@
             };
 
             sendClipboardBtn.addEventListener('click', sendClipboardText);
+
+            // === #225: mention picker ===
+            const mentionPickerBtn = document.getElementById('mentionPickerBtn');
+            const mentionPickerPopover = document.getElementById('mentionPickerPopover');
+            const MENTION_CACHE_KEY = 'localnode.mentions.v1';
+            const MENTION_CACHE_TTL_MS = 5 * 60 * 1000;
+
+            const loadMentionsCache = () => {
+                try {
+                    const raw = sessionStorage.getItem(MENTION_CACHE_KEY);
+                    if (!raw) return null;
+                    const o = JSON.parse(raw);
+                    if (!o || !Array.isArray(o.items) || typeof o.ts !== 'number') return null;
+                    if (Date.now() - o.ts > MENTION_CACHE_TTL_MS) return null;
+                    return o.items;
+                } catch (_) { return null; }
+            };
+            const saveMentionsCache = (items) => {
+                try { sessionStorage.setItem(MENTION_CACHE_KEY, JSON.stringify({ ts: Date.now(), items })); } catch (_) {}
+            };
+
+            const fetchMentions = async () => {
+                const cached = loadMentionsCache();
+                if (cached) return cached;
+                const res = await safeFetch('/api/mentions');
+                if (!res.ok) throw new Error('/api/mentions HTTP ' + res.status);
+                const data = await res.json();
+                const items = Array.isArray(data?.items) ? data.items : [];
+                saveMentionsCache(items);
+                return items;
+            };
+
+            const insertAtCursor = (textarea, insertText) => {
+                const start = textarea.selectionStart ?? textarea.value.length;
+                const end = textarea.selectionEnd ?? textarea.value.length;
+                const before = textarea.value.slice(0, start);
+                const after = textarea.value.slice(end);
+                // Add space after the mention so the user can keep typing args
+                const needSpace = !after.startsWith(' ') && !after.startsWith('\n');
+                const tail = needSpace ? ' ' : '';
+                textarea.value = before + insertText + tail + after;
+                const caret = start + insertText.length + tail.length;
+                textarea.setSelectionRange(caret, caret);
+                textarea.focus();
+            };
+
+            const closeMentionPicker = () => {
+                mentionPickerPopover.hidden = true;
+                mentionPickerPopover.innerHTML = '';
+            };
+
+            const openMentionPicker = async () => {
+                if (!mentionPickerPopover.hidden) { closeMentionPicker(); return; }
+                // Position above the input row
+                mentionPickerPopover.innerHTML = '<div class="mention-picker-empty">読込中…</div>';
+                mentionPickerPopover.hidden = false;
+                positionMentionPicker();
+                let items = [];
+                try {
+                    items = await fetchMentions();
+                } catch (e) {
+                    mentionPickerPopover.innerHTML = `<div class="mention-picker-empty">取得失敗: ${escapeHtml(e.message)}</div>`;
+                    return;
+                }
+                if (items.length === 0) {
+                    mentionPickerPopover.innerHTML = '<div class="mention-picker-empty">利用可能なメンションはありません</div>';
+                    return;
+                }
+                mentionPickerPopover.innerHTML = items.map((it, idx) => {
+                    const label = escapeHtml(it.label ?? it.insert ?? '');
+                    const desc = it.description ? `<div class="mp-desc">${escapeHtml(it.description)}</div>` : '';
+                    return `<div class="mention-picker-item" role="option" data-idx="${idx}"><span class="mp-label">${label}</span>${desc}</div>`;
+                }).join('');
+                positionMentionPicker();
+                mentionPickerPopover.querySelectorAll('.mention-picker-item').forEach(el => {
+                    el.addEventListener('click', () => {
+                        const idx = parseInt(el.dataset.idx, 10);
+                        const it = items[idx];
+                        if (it) insertAtCursor(clipboardInput, it.insert ?? it.label ?? '');
+                        closeMentionPicker();
+                    });
+                });
+            };
+
+            const positionMentionPicker = () => {
+                // Place the popover just above the button, right-aligned to it
+                const btn = mentionPickerBtn;
+                const inputRow = btn.parentElement;
+                if (!inputRow) return;
+                const pop = mentionPickerPopover;
+                // Use the input row as relative container (already position:relative)
+                pop.style.left = '';
+                pop.style.right = (inputRow.clientWidth - btn.offsetLeft - btn.offsetWidth) + 'px';
+                pop.style.bottom = (inputRow.clientHeight - btn.offsetTop + 4) + 'px';
+                pop.style.top = '';
+            };
+
+            mentionPickerBtn.addEventListener('click', (e) => {
+                e.stopPropagation();
+                openMentionPicker();
+            });
+            document.addEventListener('click', (e) => {
+                if (mentionPickerPopover.hidden) return;
+                if (mentionPickerPopover.contains(e.target) || e.target === mentionPickerBtn) return;
+                closeMentionPicker();
+            });
+            document.addEventListener('keydown', (e) => {
+                if (e.key === 'Escape' && !mentionPickerPopover.hidden) closeMentionPicker();
+            });
             clipboardInput.addEventListener('keydown', (e) => {
                 if (e.key === 'Enter' && !e.shiftKey) {
                     e.preventDefault();

--- a/assets/web/index.html
+++ b/assets/web/index.html
@@ -1243,9 +1243,13 @@
                         return;
                     }
                     const now = Date.now();
+                    // peer.* は config 由来の任意文字列。HTML/属性インジェクション防止のため
+                    // status は enum に丸めて className を固定、それ以外はすべて escapeHtml。
+                    const ALLOWED_STATUS = new Set(['connected', 'offline', 'paused']);
                     const chips = peers.map(p => {
-                        const cls = `fed-peer fed-${p.status || 'unknown'}`;
-                        let label = `${p.name}: ${p.status || 'unknown'}`;
+                        const status = ALLOWED_STATUS.has(p.status) ? p.status : 'unknown';
+                        const cls = `fed-peer fed-${status}`;
+                        let label = `${p.name}: ${status}`;
                         if (p.pauseUntilMs && p.pauseUntilMs > now) {
                             const remainSec = Math.round((p.pauseUntilMs - now) / 1000);
                             const remainStr = remainSec > 3600
@@ -1253,8 +1257,8 @@
                                 : `${Math.round(remainSec / 60)}min`;
                             label += ` (${remainStr})`;
                         }
-                        const title = `${p.kind} • ${p.relation}${p.lastError ? ' • ' + p.lastError : ''}`;
-                        return `<span class="${cls}" title="${title}" data-peer-name="${escapeHtml(p.name)}" data-paused="${p.pauseUntilMs && p.pauseUntilMs > now ? '1' : '0'}">${label}</span>`;
+                        const title = `${p.kind ?? ''} • ${p.relation ?? ''}${p.lastError ? ' • ' + p.lastError : ''}`;
+                        return `<span class="${cls}" title="${escapeHtml(title)}" data-peer-name="${escapeHtml(p.name)}" data-paused="${p.pauseUntilMs && p.pauseUntilMs > now ? '1' : '0'}">${escapeHtml(label)}</span>`;
                     }).join('');
                     fedStatusEl.innerHTML = `Federation: ${chips}`;
                     fedStatusEl.style.display = 'block';

--- a/assets/web/index.html
+++ b/assets/web/index.html
@@ -263,6 +263,16 @@
             white-space: pre-wrap;
             margin: 0 0 0.5rem 0;
         }
+        /* #220 / #230: @up でマークされた重要アイテム */
+        .clipboard-item.clipboard-important {
+            border-left: 4px solid #f57c00;
+            background: #fff8e1;
+        }
+        .clipboard-item .important-badge {
+            color: #f57c00;
+            font-weight: bold;
+            margin-right: 0.2rem;
+        }
         .clipboard-file-thumb {
             max-width: 80px;
             max-height: 80px;
@@ -1553,9 +1563,9 @@
                 downloadClipboardBtn.style.display = 'inline-block';
 
                 clipboardList.innerHTML = items.map(item => `
-                    <div class="clipboard-item" data-id="${escapeHtml(item.id)}">
+                    <div class="clipboard-item${item.important ? ' clipboard-important' : ''}" data-id="${escapeHtml(item.id)}">
                         <div class="clipboard-item-content">
-                            <p class="clipboard-item-text">${renderClipboardText(item.text)}</p>
+                            <p class="clipboard-item-text">${item.important ? '<span class="important-badge">★</span> ' : ''}${renderClipboardText(item.text)}</p>
                             <div class="clipboard-item-meta">
                                 ${item.tag ? `<span class="clipboard-item-tag">${escapeHtml(item.tag)}</span>` : ''}
                                 <span class="clipboard-item-time">${formatTime(item.createdAt)}</span>

--- a/assets/web/index.html
+++ b/assets/web/index.html
@@ -1418,29 +1418,71 @@
                 }
             };
 
+            // #228: 差分ポーリング
+            // 初回は ?limit=1000 で取得、以降は ?since=<lastModified> で差分のみ取得。
+            // refresh:true (サーバ削除リングバッファの外) のとき full re-fetch。
+            let currentClipboardItems = [];
+
             const fetchClipboard = async () => {
                 try {
-                    const response = await safeFetch('/api/clipboard');
+                    let url;
+                    if (clipboardLastModified === 0) {
+                        // 初回 (or refresh 後): 全件取得 (上限 1000)
+                        url = '/api/clipboard?limit=1000';
+                    } else {
+                        url = `/api/clipboard?since=${clipboardLastModified}`;
+                    }
+                    const response = await safeFetch(url);
                     if (!response.ok) throw new Error('Failed to fetch clipboard.');
-
                     const data = await response.json();
+
+                    if (data.refresh) {
+                        // サーバが「削除リングの外」と判断 → 全件取り直し
+                        clipboardLastModified = 0;
+                        currentClipboardItems = [];
+                        // 次の poll で初回扱いとして fetch
+                        return fetchClipboard();
+                    }
+
+                    const incoming = Array.isArray(data.items) ? data.items : [];
+                    const deletedIds = Array.isArray(data.deleted) ? data.deleted : null;
+                    const isDifferential = url.includes('?since=');
+
+                    let changed = false;
+                    if (isDifferential) {
+                        // 差分マージ: 新規追加 + 削除適用
+                        if (deletedIds && deletedIds.length > 0) {
+                            const delSet = new Set(deletedIds);
+                            currentClipboardItems = currentClipboardItems.filter(i => !delSet.has(i.id));
+                            changed = true;
+                        }
+                        if (incoming.length > 0) {
+                            // incoming は新しい順。既存と被るものは置き換え (id 一意前提)
+                            const incomingIds = new Set(incoming.map(i => i.id));
+                            currentClipboardItems = currentClipboardItems.filter(i => !incomingIds.has(i.id));
+                            currentClipboardItems = [...incoming, ...currentClipboardItems];
+                            changed = true;
+                        }
+                    } else {
+                        // 初回 / refresh: 全件置き換え
+                        currentClipboardItems = incoming;
+                        changed = true;
+                    }
 
                     if (data.lastModified !== clipboardLastModified) {
                         clipboardLastModified = data.lastModified;
-                        renderClipboardItems(data.items);
-                        if (!firstClipboardFetch) markUnread();
-                        firstClipboardFetch = false;
-                    } else if (firstClipboardFetch) {
-                        firstClipboardFetch = false;
                     }
+                    if (changed) {
+                        renderClipboardItems(currentClipboardItems);
+                        if (!firstClipboardFetch) markUnread();
+                    }
+                    firstClipboardFetch = false;
                 } catch (error) {
                     if (error.message !== 'Authentication required.') {
                         console.error('Clipboard fetch error:', error);
                     }
                 }
             };
-
-            let currentClipboardItems = [];
 
             const renderClipboardItems = (items) => {
                 currentClipboardItems = items;

--- a/assets/web/index.html
+++ b/assets/web/index.html
@@ -245,6 +245,58 @@
             max-height: 300px;
             overflow-y: auto;
         }
+        /* #229: filter / search row */
+        #clipboard-filter-row {
+            display: flex;
+            flex-direction: column;
+            gap: 0.4rem;
+            margin: 0.5rem 0;
+        }
+        #clipboardSearch {
+            padding: 0.4rem 0.6rem;
+            border: 1px solid #ccc;
+            border-radius: 4px;
+            font-size: 0.9rem;
+        }
+        #clipboardTagFilters {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.3rem;
+        }
+        .clip-tag-chip {
+            padding: 0.15rem 0.55rem;
+            border-radius: 12px;
+            background: #eee;
+            color: #555;
+            font-size: 0.78rem;
+            cursor: pointer;
+            border: 1px solid transparent;
+            user-select: none;
+        }
+        .clip-tag-chip:hover { opacity: 0.85; }
+        .clip-tag-chip.active {
+            background: #00796b;
+            color: white;
+            border-color: #004d40;
+        }
+        #clipboardLoadMore {
+            display: block;
+            margin: 0.5rem auto 0;
+            padding: 0.4rem 1.2rem;
+            background: #00796b;
+            color: white;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+            font-size: 0.85rem;
+        }
+        #clipboardLoadMore:hover { background: #00695c; }
+        .clipboard-filter-hit {
+            text-align: center;
+            color: #888;
+            font-size: 0.8rem;
+            margin: 0.3rem 0 0;
+        }
         .clipboard-item {
             display: flex;
             justify-content: space-between;
@@ -911,9 +963,16 @@
                         <textarea id="clipboardInput" placeholder="共有するテキストを入力..." rows="2"></textarea>
                         <button id="sendClipboardBtn">送信</button>
                     </div>
+                    <!-- #229: フィルタ / 検索 -->
+                    <div id="clipboard-filter-row" style="display:none;">
+                        <input type="search" id="clipboardSearch" placeholder="🔍 テキスト検索" />
+                        <div id="clipboardTagFilters"></div>
+                    </div>
                     <div id="clipboardList" class="clipboard-list">
                         <p class="empty-message">テキストを入力して共有しましょう</p>
                     </div>
+                    <!-- #229: 続きを表示 -->
+                    <button id="clipboardLoadMore" style="display:none;">もっと見る</button>
                 </div>
             </div>
         </div>
@@ -1405,6 +1464,40 @@
             const clipboardList = document.getElementById('clipboardList');
             const clearClipboardBtn = document.getElementById('clearClipboardBtn');
             const downloadClipboardBtn = document.getElementById('downloadClipboardBtn');
+            // #229: filter / search / paging
+            const clipboardSearchInput = document.getElementById('clipboardSearch');
+            const clipboardTagFilters = document.getElementById('clipboardTagFilters');
+            const clipboardFilterRow = document.getElementById('clipboard-filter-row');
+            const clipboardLoadMoreBtn = document.getElementById('clipboardLoadMore');
+            const CLIP_PAGE_SIZE = 100;
+            const CLIP_FILTER_STORAGE_KEY = 'localnode.clipboard.filter.v1';
+            let clipboardFilterState = (() => {
+                try {
+                    const raw = localStorage.getItem(CLIP_FILTER_STORAGE_KEY);
+                    if (!raw) return { q: '', tags: [] };
+                    const o = JSON.parse(raw);
+                    return { q: typeof o.q === 'string' ? o.q : '', tags: Array.isArray(o.tags) ? o.tags : [] };
+                } catch (_) { return { q: '', tags: [] }; }
+            })();
+            let clipboardDisplayLimit = CLIP_PAGE_SIZE;
+            const persistClipboardFilter = () => {
+                try { localStorage.setItem(CLIP_FILTER_STORAGE_KEY, JSON.stringify(clipboardFilterState)); } catch (_) {}
+            };
+            const applyClipboardFilter = (items) => {
+                const q = (clipboardFilterState.q || '').toLowerCase().trim();
+                const tagSet = new Set(clipboardFilterState.tags || []);
+                return items.filter(it => {
+                    if (tagSet.size > 0) {
+                        const tag = it.tag || '';
+                        if (!tagSet.has(tag)) return false;
+                    }
+                    if (q) {
+                        const hay = ((it.text || '') + ' ' + (it.tag || '')).toLowerCase();
+                        if (!hay.includes(q)) return false;
+                    }
+                    return true;
+                });
+            };
 
             // タグのデフォルト値: UserAgentからデバイス名を簡易抽出
             const getDefaultDeviceName = () => {
@@ -1588,6 +1681,25 @@
                 }
             };
 
+            const renderClipboardTagFilters = () => {
+                const tagCounts = new Map();
+                for (const it of currentClipboardItems) {
+                    const t = it.tag || '';
+                    tagCounts.set(t, (tagCounts.get(t) || 0) + 1);
+                }
+                const tags = [...tagCounts.keys()].sort((a, b) => {
+                    if (a === '' && b !== '') return 1;
+                    if (b === '' && a !== '') return -1;
+                    return a.localeCompare(b);
+                });
+                const activeSet = new Set(clipboardFilterState.tags || []);
+                clipboardTagFilters.innerHTML = tags.map(t => {
+                    const label = t === '' ? '(no tag)' : t;
+                    const cls = 'clip-tag-chip' + (activeSet.has(t) ? ' active' : '');
+                    return `<span class="${cls}" data-tag="${escapeHtml(t)}">${escapeHtml(label)} ${tagCounts.get(t)}</span>`;
+                }).join('');
+            };
+
             const renderClipboardItems = (items) => {
                 currentClipboardItems = items;
                 const isDownloadOnly = serverInfo.operationMode === 'downloadOnly';
@@ -1598,13 +1710,31 @@
                         : '<p class="empty-message">テキストを入力して共有しましょう</p>';
                     clearClipboardBtn.style.display = 'none';
                     downloadClipboardBtn.style.display = 'none';
+                    clipboardFilterRow.style.display = 'none';
+                    clipboardLoadMoreBtn.style.display = 'none';
                     return;
                 }
 
                 clearClipboardBtn.style.display = isDownloadOnly ? 'none' : 'inline-block';
                 downloadClipboardBtn.style.display = 'inline-block';
 
-                clipboardList.innerHTML = items.map(item => `
+                // #229: filter row only when there's enough material to need it
+                const showFilter = items.length >= 5;
+                clipboardFilterRow.style.display = showFilter ? 'flex' : 'none';
+                if (showFilter) renderClipboardTagFilters();
+
+                const filtered = applyClipboardFilter(items);
+                if (clipboardDisplayLimit > filtered.length) clipboardDisplayLimit = Math.max(CLIP_PAGE_SIZE, filtered.length);
+                const shown = filtered.slice(0, clipboardDisplayLimit);
+                const hiddenCount = filtered.length - shown.length;
+
+                if (filtered.length === 0) {
+                    clipboardList.innerHTML = '<p class="empty-message">フィルタ条件に合うアイテムはありません</p>';
+                    clipboardLoadMoreBtn.style.display = 'none';
+                    return;
+                }
+
+                clipboardList.innerHTML = shown.map(item => `
                     <div class="clipboard-item${item.important ? ' clipboard-important' : ''}" data-id="${escapeHtml(item.id)}">
                         <div class="clipboard-item-content">
                             <p class="clipboard-item-text">${item.important ? '<span class="important-badge">★</span> ' : ''}${renderClipboardText(item.text)}</p>
@@ -1618,8 +1748,45 @@
                             ${isDownloadOnly ? '' : `<button class="btn-delete-clip" onclick="deleteClipboardItem('${escapeHtml(item.id)}')">削除</button>`}
                         </div>
                     </div>
-                `).join('');
+                `).join('') + (filtered.length !== items.length
+                    ? `<p class="clipboard-filter-hit">${filtered.length} / ${items.length} 件を表示</p>`
+                    : '');
+
+                if (hiddenCount > 0) {
+                    clipboardLoadMoreBtn.textContent = `もっと見る（残り ${hiddenCount} 件）`;
+                    clipboardLoadMoreBtn.style.display = 'block';
+                } else {
+                    clipboardLoadMoreBtn.style.display = 'none';
+                }
             };
+
+            // #229: filter / search / load-more wiring
+            clipboardSearchInput.value = clipboardFilterState.q || '';
+            let clipboardSearchTimer = null;
+            clipboardSearchInput.addEventListener('input', () => {
+                if (clipboardSearchTimer) clearTimeout(clipboardSearchTimer);
+                clipboardSearchTimer = setTimeout(() => {
+                    clipboardFilterState.q = clipboardSearchInput.value;
+                    persistClipboardFilter();
+                    clipboardDisplayLimit = CLIP_PAGE_SIZE;
+                    renderClipboardItems(currentClipboardItems);
+                }, 150);
+            });
+            clipboardTagFilters.addEventListener('click', (e) => {
+                const chip = e.target.closest('.clip-tag-chip');
+                if (!chip) return;
+                const tag = chip.dataset.tag ?? '';
+                const tags = new Set(clipboardFilterState.tags || []);
+                if (tags.has(tag)) tags.delete(tag); else tags.add(tag);
+                clipboardFilterState.tags = [...tags];
+                persistClipboardFilter();
+                clipboardDisplayLimit = CLIP_PAGE_SIZE;
+                renderClipboardItems(currentClipboardItems);
+            });
+            clipboardLoadMoreBtn.addEventListener('click', () => {
+                clipboardDisplayLimit += CLIP_PAGE_SIZE;
+                renderClipboardItems(currentClipboardItems);
+            });
 
             // #198: @file:<relpath> をサムネイル/チップに変換（メッセージあたり最大5個）
             const renderClipboardText = (text) => {
@@ -1767,7 +1934,9 @@
             };
 
             downloadClipboardBtn.addEventListener('click', () => {
-                const text = currentClipboardItems.map(item => {
+                // #229: TXT export respects current filter (search + tags)
+                const source = applyClipboardFilter(currentClipboardItems);
+                const text = source.map(item => {
                     const prefix = item.tag ? `[${item.tag}] ` : '';
                     return `${prefix}${item.text}`;
                 }).join('\n---\n');

--- a/bin/localnode_cli.dart
+++ b/bin/localnode_cli.dart
@@ -25,7 +25,7 @@ import 'package:shelf_router/shelf_router.dart';
 import 'package:shelf_static/shelf_static.dart';
 
 // pubspec.yaml の version と一致させる
-const String _appVersion = '1.5.1';
+const String _appVersion = '1.6.0';
 
 // =============================================================================
 // エントリポイント

--- a/bin/localnode_cli.dart
+++ b/bin/localnode_cli.dart
@@ -429,7 +429,32 @@ Future<void> main(List<String> args) async {
       ? (fixedToken ?? _generateUploadToken())
       : null;
 
-  final server = _CliServer(verbose: verbose);
+  // #227: clipboard 設定を config から読む (config.clipboard.max_items / max_text_length)
+  final clipboardCfg = cfg?.clipboardRaw;
+  int maxClipboardItems = 1000;
+  int maxTextLength = 10000;
+  if (clipboardCfg != null) {
+    final mi = clipboardCfg['max_items'];
+    if (mi is int && mi > 0 && mi <= 100000) {
+      maxClipboardItems = mi;
+    } else if (mi != null) {
+      stderr.writeln('Error: clipboard.max_items must be a positive integer (1-100000).');
+      exit(1);
+    }
+    final ml = clipboardCfg['max_text_length'];
+    if (ml is int && ml > 0 && ml <= 1000000) {
+      maxTextLength = ml;
+    } else if (ml != null) {
+      stderr.writeln('Error: clipboard.max_text_length must be a positive integer (1-1000000).');
+      exit(1);
+    }
+  }
+
+  final server = _CliServer(
+    verbose: verbose,
+    maxClipboardItems: maxClipboardItems,
+    maxTextLength: maxTextLength,
+  );
 
   try {
     await server.start(
@@ -979,8 +1004,9 @@ class _ClipboardItem {
 // =============================================================================
 
 class _CliServer {
-  static const int _maxClipboardItems = 10;
-  static const int _maxTextLength = 10000;
+  // #227: clipboard 件数 / 文字長は config から指定可能 (デフォルト 1000 / 10000)
+  final int _maxClipboardItems;
+  final int _maxTextLength;
   static const int _maxFailedAttempts = 5;
   static const Duration _lockoutDuration = Duration(minutes: 5);
 
@@ -1013,7 +1039,12 @@ class _CliServer {
   List<_ClipboardItem> get clipboardItems => List.unmodifiable(_clipboardItems);
   int get clipboardLastModified => _clipboardLastModified;
 
-  _CliServer({required this.verbose}) {
+  _CliServer({
+    required this.verbose,
+    int maxClipboardItems = 1000,
+    int maxTextLength = 10000,
+  })  : _maxClipboardItems = maxClipboardItems,
+        _maxTextLength = maxTextLength {
     _router = Router()
       ..post('/api/auth', _authHandler)
       ..get('/api/health', _healthHandler)

--- a/bin/localnode_cli.dart
+++ b/bin/localnode_cli.dart
@@ -372,7 +372,7 @@ Future<void> main(List<String> args) async {
     postActions.add((pattern: pattern, script: script));
   }
   // mention_actions: CLI > config
-  final mentionActions = <String, String>{};
+  final mentionActions = <String, ({String script, String? description})>{};
   if (results.wasParsed('mention-action')) {
     final raw = results['mention-action'] as List<String>;
     for (final entry in raw) {
@@ -392,7 +392,8 @@ Future<void> main(List<String> args) async {
         stderr.writeln('Error: "$alias" is a reserved mention name and cannot be used as an alias.');
         exit(1);
       }
-      mentionActions[alias] = script;
+      // CLI には description フィールドが無い (YAML config 専用、#224)
+      mentionActions[alias] = (script: script, description: null);
     }
   } else if (cfg?.mentionActions != null) {
     for (final m in cfg!.mentionActions!) {
@@ -400,7 +401,7 @@ Future<void> main(List<String> args) async {
         stderr.writeln('Error: "${m.alias}" is a reserved mention name and cannot be used as an alias.');
         exit(1);
       }
-      mentionActions[m.alias] = m.script;
+      mentionActions[m.alias] = (script: m.script, description: m.description);
     }
   }
   final httpsCertPath = results.wasParsed('https-cert')
@@ -606,7 +607,9 @@ Future<void> main(List<String> args) async {
   if (mentionActions.isNotEmpty) {
     stdout.writeln('  Mention action(s):');
     for (final entry in mentionActions.entries) {
-      stdout.writeln('    @run ${entry.key} -> ${entry.value}');
+      final desc = entry.value.description;
+      final suffix = (desc == null || desc.isEmpty) ? '' : '  # $desc';
+      stdout.writeln('    @run ${entry.key} -> ${entry.value.script}$suffix');
     }
   }
   if (uploadToken != null) {
@@ -1343,7 +1346,7 @@ class _CliServer {
   final Map<String, DateTime> _lockoutUntil = {};
   String? _uploadToken;
   List<({String pattern, String script})> _postActions = [];
-  Map<String, String> _mentionActions = {};
+  Map<String, ({String script, String? description})> _mentionActions = {};
 
   late final Router _router;
 
@@ -1728,7 +1731,7 @@ class _CliServer {
     String? httpsKeyPath,
     String? uploadToken,
     List<({String pattern, String script})> postActions = const [],
-    Map<String, String> mentionActions = const {},
+    Map<String, ({String script, String? description})> mentionActions = const {},
   }) async {
     _authMode = authMode;
     _downloadOnly = downloadOnly;
@@ -2268,7 +2271,15 @@ class _CliServer {
     if (_mentionActions.isEmpty) {
       lines.add('  (no @run actions registered)');
     } else {
-      lines.addAll(_mentionActions.keys.map((a) => '  @run $a'));
+      // #224: YAML config の mention_actions[].description があれば付与
+      for (final e in _mentionActions.entries) {
+        final desc = e.value.description;
+        if (desc != null && desc.isNotEmpty) {
+          lines.add('  @run ${e.key} — $desc');
+        } else {
+          lines.add('  @run ${e.key}');
+        }
+      }
     }
 
     if (_postActions.isNotEmpty) {
@@ -2852,9 +2863,9 @@ class _CliServer {
     final runMatch = RegExp(r'^@run\s+(\S+)$').firstMatch(text);
     if (runMatch != null) {
       final alias = runMatch.group(1)!;
-      final script = _mentionActions[alias];
-      if (script != null) {
-        _runMentionAction(alias, script);
+      final entry = _mentionActions[alias];
+      if (entry != null) {
+        _runMentionAction(alias, entry.script);
       }
     }
   }

--- a/bin/localnode_cli.dart
+++ b/bin/localnode_cli.dart
@@ -1315,6 +1315,21 @@ class _CliServer {
     }
   }
 
+  // #230: クリップボード件数超過時の退避。非 important から先に削る。
+  // 全部 important なら最古の important を退避（ハードピンしない）。
+  // 退避した item を返す。
+  _ClipboardItem _evictClipboardItem() {
+    // list は新しい順 (insert(0, ...)) なので末尾が最古
+    // 末尾から最初に見つかった非 important を取り除く
+    for (var i = _clipboardItems.length - 1; i >= 0; i--) {
+      if (!_clipboardItems[i].important) {
+        return _clipboardItems.removeAt(i);
+      }
+    }
+    // 全て important: 最古を退避
+    return _clipboardItems.removeLast();
+  }
+
   final Set<String> _sessions = {};
   final Map<String, int> _failedAttempts = {};
   final Map<String, DateTime> _lockoutUntil = {};
@@ -1626,7 +1641,7 @@ class _CliServer {
           ),
         );
         while (_clipboardItems.length > _maxClipboardItems) {
-          final ev = _clipboardItems.removeLast();
+          final ev = _evictClipboardItem();
           _recordDeletion(ev.id);
         }
         _clipboardLastModified = DateTime.now().millisecondsSinceEpoch;
@@ -2199,7 +2214,7 @@ class _CliServer {
     );
     _clipboardItems.insert(0, item);
     while (_clipboardItems.length > _maxClipboardItems) {
-      final evicted = _clipboardItems.removeLast();
+      final evicted = _evictClipboardItem();
       _recordDeletion(evicted.id);
     }
     _clipboardLastModified = DateTime.now().millisecondsSinceEpoch;
@@ -2675,7 +2690,7 @@ class _CliServer {
       );
       _clipboardItems.insert(0, item);
       while (_clipboardItems.length > _maxClipboardItems) {
-        final ev = _clipboardItems.removeLast();
+        final ev = _evictClipboardItem();
         _recordDeletion(ev.id);
       }
       _clipboardLastModified = DateTime.now().millisecondsSinceEpoch;

--- a/bin/localnode_cli.dart
+++ b/bin/localnode_cli.dart
@@ -622,6 +622,8 @@ Future<void> main(List<String> args) async {
             url: ch['url'] as String,
             token: ch['token'] as String,
             relation: ch['relation'] as String,
+            // #219: 親側設定。子から来るアップロードの上限
+            maxUploadSizeBytes: _parseSizeBytes(ch['max_upload_size']),
           ));
         }
       }
@@ -634,6 +636,8 @@ Future<void> main(List<String> args) async {
         url: pr['url'] as String,
         token: pr['token'] as String,
         relation: pr['relation'] as String,
+        // #219: 子側設定。trust:true で「親に転送したらローカル削除」
+        trust: pr['trust'] == true,
       ));
     }
     server._startHeartbeat();
@@ -1191,6 +1195,10 @@ class _FederationPeer {
   final String url;
   final String token;
   final String relation;
+  // #219: friendly + trust:true で「親に渡したら子側削除」 (parent peer 設定のみ意味あり)
+  final bool trust;
+  // #219: 子→親アップロードの 1 回の最大バイト数 (child peer 設定のみ意味あり)
+  final int? maxUploadSizeBytes;
   String? learnedDeviceId; // /api/info から学習
   String status = 'unknown'; // 'connected' / 'offline' / 'paused'
   int lastOkMs = 0;
@@ -1203,6 +1211,8 @@ class _FederationPeer {
     required this.url,
     required this.token,
     required this.relation,
+    this.trust = false,
+    this.maxUploadSizeBytes,
   });
 
   Map<String, dynamic> toJson() => {
@@ -1210,12 +1220,27 @@ class _FederationPeer {
         'name': name,
         'url': url,
         'relation': relation,
+        'trust': trust,
+        if (maxUploadSizeBytes != null) 'maxUploadSizeBytes': maxUploadSizeBytes,
         'status': status,
         'lastOkMs': lastOkMs,
         'lastTryMs': lastTryMs,
         'learnedDeviceId': learnedDeviceId,
         'lastError': lastError,
       };
+}
+
+/// #219: "100MB" / "5GB" / "1024" 等を bytes に変換 (大文字小文字無視)
+int? _parseSizeBytes(dynamic raw) {
+  if (raw == null) return null;
+  if (raw is int) return raw;
+  final s = raw.toString().trim();
+  final m = RegExp(r'^(\d+(?:\.\d+)?)\s*([kmgtKMGT]?)[bB]?$').firstMatch(s);
+  if (m == null) return null;
+  final num = double.parse(m.group(1)!);
+  final unit = m.group(2)!.toUpperCase();
+  const mult = {'': 1, 'K': 1024, 'M': 1024 * 1024, 'G': 1024 * 1024 * 1024, 'T': 1024 * 1024 * 1024 * 1024};
+  return (num * mult[unit]!).toInt();
 }
 
 class _CliServer {
@@ -1383,6 +1408,206 @@ class _CliServer {
     _heartbeatTimer = null;
     _heartbeatClient?.close(force: true);
     _heartbeatClient = null;
+  }
+
+  // ---------------------------------------------------------------------------
+  // #219: federation event 転送 (子 → 親)
+  // ---------------------------------------------------------------------------
+
+  static const String _kFedEvent = 'x-fed-event';
+
+  bool _isUpItem(String text) => text.trimLeft().startsWith('@up ');
+
+  bool _comesFromFederation(Request req) =>
+      req.headers[_kFedSeenBy] != null;
+
+  /// 子→親の clipboard 転送 (fire-and-forget)
+  /// - 受信時に federation 由来 (seen_by あり) なら再転送しない
+  /// - peer.kind=='parent' のみ
+  /// - relation=='equally' は `@up` 付きだけ転送
+  void _forwardClipboardToParents(_ClipboardItem item, Request originReq) {
+    if (_comesFromFederation(originReq)) return;
+    if (_deviceId.isEmpty) return;
+    if (_federationPeers.isEmpty) return;
+
+    final isUp = _isUpItem(item.text);
+    for (final peer in _federationPeers) {
+      if (peer.kind != 'parent') continue;
+      if (peer.relation == 'equally' && !isUp) continue;
+      // fire-and-forget
+      () async {
+        try {
+          await _sendClipboardToPeer(peer, item, isUp);
+        } catch (e) {
+          _log('[fed] forward-clip ${peer.name} unexpected: $e');
+        }
+      }();
+    }
+  }
+
+  /// 子→親の file upload 転送 (fire-and-forget)
+  /// - friendly: 実ファイルを送信。成功 + trust なら local 削除
+  /// - equally: 「@up file uploaded: <name>」を clipboard 通知のみ
+  void _forwardFileToParents(File file, Request originReq) {
+    if (_comesFromFederation(originReq)) return;
+    if (_deviceId.isEmpty) return;
+    if (_federationPeers.isEmpty) return;
+
+    for (final peer in _federationPeers) {
+      if (peer.kind != 'parent') continue;
+      () async {
+        try {
+          if (peer.relation == 'equally') {
+            // 通知のみ
+            final basename = p.basename(file.path);
+            final notice = _ClipboardItem(
+              id: _generateId(),
+              text: '@up file uploaded: $basename',
+              tag: _serverName,
+              createdAt: DateTime.now(),
+            );
+            await _sendClipboardToPeer(peer, notice, true);
+            return;
+          }
+          // friendly: 実ファイル送信
+          final ok = await _sendFileToPeer(peer, file);
+          if (ok && peer.trust) {
+            try {
+              await file.delete();
+              _log('[fed] forward-file ${peer.name} ok, local deleted (trust)');
+            } catch (e) {
+              _log('[fed] forward-file ${peer.name} local-delete fail: $e');
+            }
+          }
+        } catch (e) {
+          _log('[fed] forward-file ${peer.name} unexpected: $e');
+        }
+      }();
+    }
+  }
+
+  Future<void> _sendClipboardToPeer(
+      _FederationPeer peer, _ClipboardItem item, bool isUp) async {
+    _heartbeatClient ??=
+        HttpClient()..connectionTimeout = const Duration(seconds: 10);
+    final uri = Uri.parse('${peer.url}/api/clipboard');
+
+    for (var attempt = 1; attempt <= 3; attempt++) {
+      try {
+        final req = await _heartbeatClient!.postUrl(uri);
+        req.headers.set('Content-Type', 'application/json');
+        req.headers.set('Authorization', 'Bearer ${peer.token}');
+        req.headers.set(_kFedOrigin, _deviceId);
+        req.headers.set(_kFedSeenBy, _deviceId);
+        req.headers.set(_kFedEvent, 'clipboard');
+        req.write(json.encode({
+          'text': item.text,
+          // tag: 親側で「どの子から」かが分かるよう自サーバ名を入れる
+          'tag': _serverName,
+        }));
+        final res = await req.close().timeout(const Duration(seconds: 15));
+        await res.drain();
+
+        if (res.statusCode >= 200 && res.statusCode < 300) {
+          _log('[fed] forward-clip ${peer.name} ok attempt=$attempt up=$isUp');
+          return;
+        }
+        _log('[fed] forward-clip ${peer.name} HTTP ${res.statusCode} attempt=$attempt');
+        // 4xx (408 除く) は retry しない
+        if (res.statusCode >= 400 &&
+            res.statusCode < 500 &&
+            res.statusCode != 408) {
+          break;
+        }
+      } catch (e) {
+        _log('[fed] forward-clip ${peer.name} error attempt=$attempt: $e');
+      }
+      if (attempt < 3) {
+        await Future.delayed(Duration(seconds: 2 * attempt));
+      }
+    }
+    _log('[fed] forward-clip ${peer.name} gave-up');
+  }
+
+  Future<bool> _sendFileToPeer(_FederationPeer peer, File file) async {
+    _heartbeatClient ??=
+        HttpClient()..connectionTimeout = const Duration(seconds: 10);
+    final filename = p.basename(file.path);
+    final pathParam = Uri.encodeComponent('children/$_serverName');
+    final uri = Uri.parse('${peer.url}/api/upload?path=$pathParam');
+
+    for (var attempt = 1; attempt <= 3; attempt++) {
+      try {
+        final length = await file.length();
+        final req = await _heartbeatClient!.postUrl(uri);
+        req.headers.set('Content-Type', 'application/octet-stream');
+        req.headers.set('Authorization', 'Bearer ${peer.token}');
+        req.headers.set('x-filename', Uri.encodeComponent(filename));
+        req.headers.set(_kFedOrigin, _deviceId);
+        req.headers.set(_kFedSeenBy, _deviceId);
+        req.headers.set(_kFedEvent, 'upload');
+        req.contentLength = length;
+        await req.addStream(file.openRead());
+        final res = await req.close().timeout(const Duration(minutes: 5));
+        await res.drain();
+
+        if (res.statusCode >= 200 && res.statusCode < 300) {
+          _log('[fed] forward-file ${peer.name} ok attempt=$attempt bytes=$length');
+          return true;
+        }
+        _log('[fed] forward-file ${peer.name} HTTP ${res.statusCode} attempt=$attempt');
+        if (res.statusCode == 413) {
+          _log('[fed] over-quota ${peer.name} (skip)');
+          return false;
+        }
+        if (res.statusCode >= 400 &&
+            res.statusCode < 500 &&
+            res.statusCode != 408) {
+          return false;
+        }
+      } catch (e) {
+        _log('[fed] forward-file ${peer.name} error attempt=$attempt: $e');
+      }
+      if (attempt < 3) {
+        await Future.delayed(Duration(seconds: 2 * attempt));
+      }
+    }
+    _log('[fed] forward-file ${peer.name} gave-up');
+    return false;
+  }
+
+  /// 親側: 受信したアップロードが federation 由来 + サイズ超過なら 413
+  /// child の deviceId と peer 学習結果を突き合わせて配下の max_upload_size を引く。
+  /// 学習未了なら制限なしとして通す。
+  Response? _checkFederationUploadQuota(Request req, int contentLength) {
+    final origin = req.headers[_kFedOrigin];
+    if (origin == null || origin.isEmpty) return null;
+    for (final peer in _federationPeers) {
+      if (peer.kind != 'child') continue;
+      if (peer.learnedDeviceId != origin) continue;
+      final cap = peer.maxUploadSizeBytes;
+      if (cap != null && contentLength > cap) {
+        _log('[fed] over-quota ${peer.name} bytes=$contentLength cap=$cap');
+        // 通知: 自分の clipboard に 1 件残す (受信者側で気付けるように)
+        _clipboardItems.insert(
+          0,
+          _ClipboardItem(
+            id: _generateId(),
+            text:
+                '@up over-quota from ${peer.name}: bytes=$contentLength cap=$cap',
+            tag: 'federation',
+            createdAt: DateTime.now(),
+          ),
+        );
+        while (_clipboardItems.length > _maxClipboardItems) {
+          final ev = _clipboardItems.removeLast();
+          _recordDeletion(ev.id);
+        }
+        _clipboardLastModified = DateTime.now().millisecondsSinceEpoch;
+        return Response(413, body: 'Federation upload over quota.');
+      }
+    }
+    return null;
   }
 
   void _log(String message) {
@@ -1813,6 +2038,15 @@ class _CliServer {
     }
     final filename = p.basename(Uri.decodeComponent(encodedName));
 
+    // #219: federation 由来のアップロードなら、送信元 child の
+    // max_upload_size を Content-Length で先に検査
+    final clHeader = req.headers['content-length'];
+    final cl = clHeader != null ? int.tryParse(clHeader) : null;
+    if (cl != null) {
+      final quotaResp = _checkFederationUploadQuota(req, cl);
+      if (quotaResp != null) return quotaResp;
+    }
+
     // #203: ?path=<relpath> でサブフォルダ宛のアップロードを許可
     // (Copilot #207 review): セグメント単位で .. のみ拒否
     final relPath = req.requestedUri.queryParameters['path'] ?? '';
@@ -1849,6 +2083,8 @@ class _CliServer {
       if (_postActions.isNotEmpty) {
         _runPostActions(file.path);
       }
+      // #219: 親への転送 (自分が子のとき、かつ受信が federation 由来でない場合)
+      _forwardFileToParents(file, req);
       return Response.ok('File uploaded: ${p.basename(file.path)}');
     } catch (e) {
       await sink.close();
@@ -2396,9 +2632,13 @@ class _CliServer {
       );
       _clipboardItems.insert(0, item);
       while (_clipboardItems.length > _maxClipboardItems) {
-        _clipboardItems.removeLast();
+        final ev = _clipboardItems.removeLast();
+        _recordDeletion(ev.id);
       }
       _clipboardLastModified = DateTime.now().millisecondsSinceEpoch;
+
+      // #219: 親への転送 (自分が子のとき、かつ受信が federation 由来でない場合)
+      _forwardClipboardToParents(item, req);
 
       // #174: メンションコマンド検出
       if (text == '@list') {

--- a/bin/localnode_cli.dart
+++ b/bin/localnode_cli.dart
@@ -407,6 +407,74 @@ Future<void> main(List<String> args) async {
           ? _AuthMode.fixedPin
           : _AuthMode.randomPin;
 
+  // #218 / §1.11: 端末識別 UUID。federation 参加時の固定 ID として使う。
+  final statePath = results['state-file'] as String? ?? _defaultStateFilePath();
+  final deviceId = _loadOrCreateDeviceId(statePath);
+
+  // #218: federation 設定 (parent / children) があるなら、構成の整合性を検証
+  final hasFederation =
+      (cfg?.childrenRaw?.isNotEmpty ?? false) || (cfg?.parentRaw != null);
+  if (hasFederation) {
+    final problems = <String>[];
+    // (a) HTTPS が必須
+    if (!httpsMode) {
+      problems.add('federation requires HTTPS — set https-cert and https-key '
+          'in config or pass --https-cert / --https-key');
+    }
+    // (b) --token は固定であること（ランダムだと再起動で切れる）
+    if (noToken) {
+      problems.add('federation requires a fixed Bearer token — remove no-token');
+    } else if (fixedToken == null || fixedToken.isEmpty) {
+      problems.add('federation requires a fixed Bearer token — set server.token '
+          'in config or pass --token <value>');
+    }
+    // (c) children の各エントリを軽く検証
+    final children = cfg?.childrenRaw ?? const [];
+    for (final entry in children) {
+      if (entry is! Map) {
+        problems.add('children[]: each entry must be a mapping');
+        continue;
+      }
+      final name = entry['name'];
+      final url = entry['url'];
+      final token = entry['token'];
+      final relation = entry['relation'];
+      if (name is! String || name.isEmpty) problems.add('children[]: name is required');
+      if (url is! String || !url.startsWith('https://')) {
+        problems.add('children[]: url must start with https:// (was: $url)');
+      }
+      if (token is! String || token.isEmpty) {
+        problems.add('children[$name]: token is required (issued by the child)');
+      }
+      if (relation != 'friendly' && relation != 'equally') {
+        problems.add('children[$name]: relation must be friendly or equally');
+      }
+    }
+    // (d) parent エントリを検証
+    final parent = cfg?.parentRaw;
+    if (parent != null) {
+      final url = parent['url'];
+      final token = parent['token'];
+      final relation = parent['relation'];
+      if (url is! String || !url.startsWith('https://')) {
+        problems.add('parent.url must start with https:// (was: $url)');
+      }
+      if (token is! String || token.isEmpty) {
+        problems.add('parent.token is required (issued by the parent)');
+      }
+      if (relation != 'friendly' && relation != 'equally') {
+        problems.add('parent.relation must be friendly or equally');
+      }
+    }
+    if (problems.isNotEmpty) {
+      stderr.writeln('Error: federation config is incomplete:');
+      for (final p in problems) {
+        stderr.writeln('  - $p');
+      }
+      exit(1);
+    }
+  }
+
   // #177/#169: HTTPS モードで SAN→ホスト名→IP 解決フロー
   String ipAddress;
   String advertisedHost; // QR/URL に使うホスト名またはIP
@@ -454,6 +522,7 @@ Future<void> main(List<String> args) async {
     verbose: verbose,
     maxClipboardItems: maxClipboardItems,
     maxTextLength: maxTextLength,
+    deviceId: deviceId,
   );
 
   try {
@@ -490,6 +559,22 @@ Future<void> main(List<String> args) async {
   }
   stdout.writeln('  Name: $serverName');
   stdout.writeln('  Mode: ${downloadOnly ? "download-only" : "normal"}');
+  if (hasFederation) {
+    stdout.writeln('  DeviceID: $deviceId');
+    stdout.writeln('  Federation:');
+    if (cfg?.childrenRaw != null && cfg!.childrenRaw!.isNotEmpty) {
+      stdout.writeln('    children:');
+      for (final ch in cfg.childrenRaw!) {
+        if (ch is Map) {
+          stdout.writeln('      ${ch['name']} <${ch['url']}> [${ch['relation']}]');
+        }
+      }
+    }
+    if (cfg?.parentRaw != null) {
+      final pr = cfg!.parentRaw!;
+      stdout.writeln('    parent: ${pr['name']} <${pr['url']}> [${pr['relation']}${pr['trust'] == true ? ', trust' : ''}]');
+    }
+  }
   if (postActions.isNotEmpty) {
     stdout.writeln('  Post-action(s):');
     for (final a in postActions) {
@@ -546,6 +631,9 @@ ArgParser _buildParser() {
     ..addOption('config',
         abbr: 'c',
         help: 'Path to YAML config file (overridden by CLI args)')
+    ..addOption('state-file',
+        help: 'Path to state file for persistent device_id '
+            '(default: platform-specific user state dir, see docs)')
     ..addOption('port',
         abbr: 'p', help: 'Server port number', defaultsTo: '8080')
     ..addOption('ip', help: 'IP address to bind (skip auto-detection)')
@@ -920,6 +1008,71 @@ Future<_HttpsHostResult> _resolveHttpsHost({
   return _HttpsHostResult(bindIp: c.ip, advertisedHost: c.host);
 }
 
+// =============================================================================
+// 端末識別 UUID (#218 / §1.11)
+// =============================================================================
+//
+// federation 参加時の固定識別子。初回起動で生成し、再起動越しに保持する。
+// 表示名（`server.name`）は mutable だが、UUID は immutable。federation
+// イベントの `origin_device_id` / `seen_by` (#221) や、peer 認証時の
+// 内部キーとして使う。
+//
+// 保存先:
+//   POSIX: $XDG_STATE_HOME/localnode-cli/state.json （無ければ ~/.local/state/...）
+//   Win:   %LOCALAPPDATA%\localnode-cli\state.json
+//   または --state-file <path> で明示指定
+
+String _defaultStateFilePath() {
+  if (Platform.isWindows) {
+    final base = Platform.environment['LOCALAPPDATA'] ??
+        p.join(Platform.environment['USERPROFILE'] ?? '.', 'AppData', 'Local');
+    return p.join(base, 'localnode-cli', 'state.json');
+  }
+  final xdg = Platform.environment['XDG_STATE_HOME'];
+  if (xdg != null && xdg.isNotEmpty) {
+    return p.join(xdg, 'localnode-cli', 'state.json');
+  }
+  final home = Platform.environment['HOME'] ?? '.';
+  return p.join(home, '.local', 'state', 'localnode-cli', 'state.json');
+}
+
+/// UUID v4 (random) を生成して `xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx` 形式で返す。
+String _generateUuidV4() {
+  final r = Random.secure();
+  final bytes = List<int>.generate(16, (_) => r.nextInt(256));
+  // version (4) と variant (10xx)
+  bytes[6] = (bytes[6] & 0x0F) | 0x40;
+  bytes[8] = (bytes[8] & 0x3F) | 0x80;
+  final hex = bytes.map((b) => b.toRadixString(16).padLeft(2, '0')).join();
+  return '${hex.substring(0, 8)}-${hex.substring(8, 12)}-${hex.substring(12, 16)}-${hex.substring(16, 20)}-${hex.substring(20)}';
+}
+
+/// state.json から `device_id` を読む。無ければ生成して書き、書いた値を返す。
+String _loadOrCreateDeviceId(String statePath) {
+  final file = File(statePath);
+  if (file.existsSync()) {
+    try {
+      final raw = file.readAsStringSync();
+      final dec = json.decode(raw);
+      if (dec is Map && dec['device_id'] is String) {
+        final id = dec['device_id'] as String;
+        if (id.isNotEmpty) return id;
+      }
+    } catch (_) {
+      // 破損していたら作り直す
+    }
+  }
+  final id = _generateUuidV4();
+  try {
+    file.parent.createSync(recursive: true);
+    file.writeAsStringSync(json.encode({'device_id': id}), flush: true);
+  } catch (e) {
+    stderr.writeln('Warning: Could not persist device_id to $statePath: $e');
+    stderr.writeln('Federation pairing may not survive a restart with this server.');
+  }
+  return id;
+}
+
 /// ランダムなアップロードトークンを生成する（32文字の16進数）
 String _generateUploadToken() {
   final r = Random.secure();
@@ -1010,6 +1163,9 @@ class _CliServer {
   static const int _maxFailedAttempts = 5;
   static const Duration _lockoutDuration = Duration(minutes: 5);
 
+  // #218 / §1.11: 端末識別 UUID
+  final String _deviceId;
+
   final bool verbose;
   HttpServer? _server;
   String? _pin;
@@ -1043,8 +1199,10 @@ class _CliServer {
     required this.verbose,
     int maxClipboardItems = 1000,
     int maxTextLength = 10000,
+    String? deviceId,
   })  : _maxClipboardItems = maxClipboardItems,
-        _maxTextLength = maxTextLength {
+        _maxTextLength = maxTextLength,
+        _deviceId = deviceId ?? '' {
     _router = Router()
       ..post('/api/auth', _authHandler)
       ..get('/api/health', _healthHandler)
@@ -1391,6 +1549,9 @@ class _CliServer {
                   : 'randomPin',
           'requiresAuth': _authMode != _AuthMode.noPin,
           'clipboardEnabled': _clipboardEnabled,
+          // #218: federation 識別子。public エンドポイントなので未認証で見える。
+          // peer 同士の identity 確認に使うが、機密ではない。
+          'deviceId': _deviceId,
         }),
         headers: {'Content-Type': 'application/json'},
       );

--- a/bin/localnode_cli.dart
+++ b/bin/localnode_cli.dart
@@ -1181,6 +1181,20 @@ class _CliServer {
 
   final List<_ClipboardItem> _clipboardItems = [];
   int _clipboardLastModified = 0;
+  // #228: 削除リングバッファ。?since= で「自分が見た時刻以降」の削除を返す。
+  // bound あり (200)。これより古い削除があるとクライアントは full refresh。
+  static const int _maxDeletionLog = 200;
+  final List<({String id, int deletedAtMs})> _clipboardDeletes = [];
+
+  void _recordDeletion(String id) {
+    _clipboardDeletes.add((
+      id: id,
+      deletedAtMs: DateTime.now().millisecondsSinceEpoch,
+    ));
+    if (_clipboardDeletes.length > _maxDeletionLog) {
+      _clipboardDeletes.removeAt(0);
+    }
+  }
 
   final Set<String> _sessions = {};
   final Map<String, int> _failedAttempts = {};
@@ -1774,7 +1788,8 @@ class _CliServer {
     );
     _clipboardItems.insert(0, item);
     while (_clipboardItems.length > _maxClipboardItems) {
-      _clipboardItems.removeLast();
+      final evicted = _clipboardItems.removeLast();
+      _recordDeletion(evicted.id);
     }
     _clipboardLastModified = DateTime.now().millisecondsSinceEpoch;
   }
@@ -2133,13 +2148,75 @@ class _CliServer {
 
   // --- クリップボードハンドラ ---
 
-  Response _getClipboardHandler(Request _) => Response.ok(
+  // #228: 差分 / paginated GET
+  // クエリ:
+  //   ?since=<ms>      これより新しい item と、これ以降の削除 id を返す
+  //   ?before=<ms>     これより古い item を返す（古い方ページング）
+  //   ?limit=N         返す item 数の上限 (1..2000)
+  // 全て省略時は従来通り全件返す。
+  // since が削除リングバッファより古い → refresh:true で full re-fetch を促す。
+  Response _getClipboardHandler(Request req) {
+    final q = req.requestedUri.queryParameters;
+    final hasQuery = q.containsKey('since') || q.containsKey('before') || q.containsKey('limit');
+
+    if (!hasQuery) {
+      // 後方互換: 全件返す
+      return Response.ok(
         json.encode({
           'items': _clipboardItems.map((i) => i.toJson()).toList(),
           'lastModified': _clipboardLastModified,
         }),
         headers: {'Content-Type': 'application/json'},
       );
+    }
+
+    final since = int.tryParse(q['since'] ?? '');
+    final before = int.tryParse(q['before'] ?? '');
+    final limit = int.tryParse(q['limit'] ?? '');
+    if (limit != null && (limit < 1 || limit > 2000)) {
+      return Response.badRequest(body: 'limit must be 1..2000');
+    }
+
+    bool refresh = false;
+    List<String> deletedSince = const [];
+    if (since != null) {
+      // ring buffer が満杯で、その最古より since が古ければ full refresh
+      if (_clipboardDeletes.length >= _maxDeletionLog &&
+          _clipboardDeletes.first.deletedAtMs > since) {
+        refresh = true;
+      }
+      deletedSince = _clipboardDeletes
+          .where((d) => d.deletedAtMs > since)
+          .map((d) => d.id)
+          .toList();
+    }
+
+    // items は createdAt の新しい順に並んでいる（insert(0, ...) なので）
+    Iterable<_ClipboardItem> filtered = _clipboardItems;
+    if (since != null) {
+      filtered = filtered
+          .where((i) => i.createdAt.millisecondsSinceEpoch > since);
+    }
+    if (before != null) {
+      filtered = filtered
+          .where((i) => i.createdAt.millisecondsSinceEpoch < before);
+    }
+    final list = filtered.toList();
+    final cap = limit ?? list.length;
+    final returned = list.length > cap ? list.sublist(0, cap) : list;
+    final hasMore = list.length > cap;
+
+    return Response.ok(
+      json.encode({
+        'items': returned.map((i) => i.toJson()).toList(),
+        'deleted': deletedSince,
+        'lastModified': _clipboardLastModified,
+        'hasMore': hasMore,
+        'refresh': refresh,
+      }),
+      headers: {'Content-Type': 'application/json'},
+    );
+  }
 
   Future<Response> _postClipboardHandler(Request req) async {
     try {
@@ -2204,7 +2281,8 @@ class _CliServer {
       return Response.notFound(json.encode({'error': 'Item not found.'}),
           headers: {'Content-Type': 'application/json'});
     }
-    _clipboardItems.removeAt(idx);
+    final removed = _clipboardItems.removeAt(idx);
+    _recordDeletion(removed.id);
     _clipboardLastModified = DateTime.now().millisecondsSinceEpoch;
     return Response.ok(json.encode({'status': 'deleted'}),
         headers: {'Content-Type': 'application/json'});
@@ -2212,6 +2290,9 @@ class _CliServer {
 
   Response _clearClipboardHandler(Request req) {
     final count = _clipboardItems.length;
+    for (final it in _clipboardItems) {
+      _recordDeletion(it.id);
+    }
     _clipboardItems.clear();
     _clipboardLastModified = DateTime.now().millisecondsSinceEpoch;
     return Response.ok(json.encode({'status': 'cleared', 'count': count}),

--- a/bin/localnode_cli.dart
+++ b/bin/localnode_cli.dart
@@ -611,6 +611,34 @@ Future<void> main(List<String> args) async {
   stdout.writeln('Press Ctrl+C to stop.');
   stdout.writeln('');
 
+  // #222: federation peer を登録してハートビート開始
+  if (hasFederation) {
+    if (cfg?.childrenRaw != null) {
+      for (final ch in cfg!.childrenRaw!) {
+        if (ch is Map) {
+          server.registerFederationPeer(_FederationPeer(
+            kind: 'child',
+            name: ch['name'] as String,
+            url: ch['url'] as String,
+            token: ch['token'] as String,
+            relation: ch['relation'] as String,
+          ));
+        }
+      }
+    }
+    if (cfg?.parentRaw != null) {
+      final pr = cfg!.parentRaw!;
+      server.registerFederationPeer(_FederationPeer(
+        kind: 'parent',
+        name: pr['name'] as String,
+        url: pr['url'] as String,
+        token: pr['token'] as String,
+        relation: pr['relation'] as String,
+      ));
+    }
+    server._startHeartbeat();
+  }
+
   _setupSignalHandlers(server);
   if (!noClipboard) _startClipboardPolling(server);
   // Windows: disable echo/line-input to prevent typed chars from appearing (#139)
@@ -1156,6 +1184,40 @@ class _ClipboardItem {
 // CLI サーバー（GTK/Flutter 非依存）
 // =============================================================================
 
+/// #222: federation peer の動的状態
+class _FederationPeer {
+  final String kind; // 'child' or 'parent'
+  final String name;
+  final String url;
+  final String token;
+  final String relation;
+  String? learnedDeviceId; // /api/info から学習
+  String status = 'unknown'; // 'connected' / 'offline' / 'paused'
+  int lastOkMs = 0;
+  int lastTryMs = 0;
+  String? lastError;
+
+  _FederationPeer({
+    required this.kind,
+    required this.name,
+    required this.url,
+    required this.token,
+    required this.relation,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'kind': kind,
+        'name': name,
+        'url': url,
+        'relation': relation,
+        'status': status,
+        'lastOkMs': lastOkMs,
+        'lastTryMs': lastTryMs,
+        'learnedDeviceId': learnedDeviceId,
+        'lastError': lastError,
+      };
+}
+
 class _CliServer {
   // #227: clipboard 件数 / 文字長は config から指定可能 (デフォルト 1000 / 10000)
   final int _maxClipboardItems;
@@ -1165,6 +1227,12 @@ class _CliServer {
 
   // #218 / §1.11: 端末識別 UUID
   final String _deviceId;
+
+  // #222: federation peer の動的状態とハートビートタイマ
+  final List<_FederationPeer> _federationPeers = [];
+  Timer? _heartbeatTimer;
+  HttpClient? _heartbeatClient;
+  static const Duration _heartbeatInterval = Duration(seconds: 45);
 
   final bool verbose;
   HttpServer? _server;
@@ -1234,7 +1302,87 @@ class _CliServer {
       ..get('/api/clipboard', _getClipboardHandler)
       ..post('/api/clipboard', _postClipboardHandler)
       ..delete('/api/clipboard/<id>', _deleteClipboardItemHandler)
-      ..delete('/api/clipboard', _clearClipboardHandler);
+      ..delete('/api/clipboard', _clearClipboardHandler)
+      // #222: federation 状態（peer 一覧と接続状態）
+      ..get('/api/federation/status', _federationStatusHandler);
+  }
+
+  /// #222: federation peer を起動前に登録する
+  void registerFederationPeer(_FederationPeer peer) {
+    _federationPeers.add(peer);
+  }
+
+  Response _federationStatusHandler(Request _) => Response.ok(
+        json.encode({
+          'deviceId': _deviceId,
+          'peers': _federationPeers.map((p) => p.toJson()).toList(),
+          'heartbeatIntervalSec': _heartbeatInterval.inSeconds,
+        }),
+        headers: {'Content-Type': 'application/json'},
+      );
+
+  /// #222: 全 peer に GET /api/health を投げて状態を更新
+  Future<void> _heartbeatTick() async {
+    if (_federationPeers.isEmpty) return;
+    _heartbeatClient ??= HttpClient()..connectionTimeout = const Duration(seconds: 10);
+    for (final peer in _federationPeers) {
+      // pause 中は heartbeat だけ続ける（生死表示用）
+      try {
+        peer.lastTryMs = DateTime.now().millisecondsSinceEpoch;
+        final uri = Uri.parse('${peer.url}/api/health');
+        final req = await _heartbeatClient!.getUrl(uri);
+        req.headers.set('Authorization', 'Bearer ${peer.token}');
+        // #221: ループ防止のため自分の id を seen_by に乗せる
+        req.headers.set(_kFedOrigin, _deviceId);
+        req.headers.set(_kFedSeenBy, _deviceId);
+        final res = await req.close().timeout(const Duration(seconds: 10));
+        await res.drain();
+        if (res.statusCode >= 200 && res.statusCode < 300) {
+          peer.lastOkMs = DateTime.now().millisecondsSinceEpoch;
+          if (peer.status != 'paused') peer.status = 'connected';
+          peer.lastError = null;
+        } else {
+          peer.status = 'offline';
+          peer.lastError = 'HTTP ${res.statusCode}';
+        }
+        // peer の deviceId を学習（/api/info を別途叩く）。負荷軽減のためおおむね 10 回に1回
+        if (peer.learnedDeviceId == null) {
+          try {
+            final iReq = await _heartbeatClient!.getUrl(Uri.parse('${peer.url}/api/info'));
+            iReq.headers.set('Authorization', 'Bearer ${peer.token}');
+            final iRes = await iReq.close().timeout(const Duration(seconds: 5));
+            if (iRes.statusCode == 200) {
+              final body = await iRes.transform(utf8.decoder).join();
+              final dec = json.decode(body);
+              if (dec is Map && dec['deviceId'] is String) {
+                peer.learnedDeviceId = dec['deviceId'] as String;
+              }
+            } else {
+              await iRes.drain();
+            }
+          } catch (_) {}
+        }
+        _log('[fed] heartbeat ${peer.name} ${peer.status}');
+      } catch (e) {
+        peer.status = 'offline';
+        peer.lastError = e.toString();
+        _log('[fed] heartbeat ${peer.name} offline: $e');
+      }
+    }
+  }
+
+  void _startHeartbeat() {
+    if (_federationPeers.isEmpty) return;
+    // 起動直後に 1 回 + 以降周期実行
+    Future.microtask(_heartbeatTick);
+    _heartbeatTimer = Timer.periodic(_heartbeatInterval, (_) => _heartbeatTick());
+  }
+
+  void _stopHeartbeat() {
+    _heartbeatTimer?.cancel();
+    _heartbeatTimer = null;
+    _heartbeatClient?.close(force: true);
+    _heartbeatClient = null;
   }
 
   void _log(String message) {
@@ -1309,6 +1457,7 @@ class _CliServer {
   }
 
   Future<void> stop() async {
+    _stopHeartbeat();
     await _server?.close(force: true);
     _server = null;
   }

--- a/bin/localnode_cli.dart
+++ b/bin/localnode_cli.dart
@@ -1268,6 +1268,7 @@ class _CliServer {
     final staticHandler =
         createStaticHandler(_webRootDir!.path, defaultDocument: 'index.html');
     final apiHandler = const Pipeline()
+        .addMiddleware(_federationLoopGuard)  // #221
         .addMiddleware(_authMiddleware)
         .addHandler(_router.call);
     final cascade = Cascade().add(apiHandler).add(staticHandler);
@@ -1427,6 +1428,48 @@ class _CliServer {
   }
 
   // --- 認証ミドルウェア ---
+
+  // #221: federation ループ防止
+  // 受信 request に `x-fed-seen-by` ヘッダがあり、自分の device_id が含まれて
+  // いれば破棄。送信側がループに気付けるよう 200 OK + JSON ペイロードを返す
+  // （HTTP エラー扱いにすると意味のないリトライを誘発しかねないため）。
+  static const String _kFedOrigin = 'x-fed-origin';
+  static const String _kFedSeenBy = 'x-fed-seen-by';
+
+  Middleware get _federationLoopGuard => (inner) {
+        return (req) {
+          final seenByRaw = req.headers[_kFedSeenBy];
+          if (seenByRaw != null && _deviceId.isNotEmpty) {
+            final ids = seenByRaw
+                .split(',')
+                .map((s) => s.trim())
+                .where((s) => s.isNotEmpty)
+                .toSet();
+            if (ids.contains(_deviceId)) {
+              final origin = req.headers[_kFedOrigin] ?? '?';
+              _log('[fed] loop-drop origin=$origin seen_by_count=${ids.length}');
+              return Response.ok(
+                json.encode({'dropped': 'loop', 'device_id': _deviceId}),
+                headers: {'Content-Type': 'application/json'},
+              );
+            }
+          }
+          return inner(req);
+        };
+      };
+
+  /// #219 から使うヘルパ: federation event を転送するときの seen_by 構築。
+  /// 受信時の seen_by に自分の device_id を追加して返す（既に入っていたら追加しない）。
+  // ignore: unused_element
+  List<String> _appendSelfToSeenBy(String? incomingHeader) {
+    final ids = (incomingHeader ?? '')
+        .split(',')
+        .map((s) => s.trim())
+        .where((s) => s.isNotEmpty)
+        .toList();
+    if (_deviceId.isNotEmpty && !ids.contains(_deviceId)) ids.add(_deviceId);
+    return ids;
+  }
 
   Middleware get _authMiddleware => (inner) {
         return (req) {

--- a/bin/localnode_cli.dart
+++ b/bin/localnode_cli.dart
@@ -1377,6 +1377,7 @@ class _CliServer {
       ..delete('/api/files/<id>', _deleteFileHandler)
       ..post('/api/files/delete-batch', _deleteBatchHandler)
       ..get('/api/clipboard', _getClipboardHandler)
+      ..get('/api/mentions', _mentionsHandler)  // #225
       ..post('/api/clipboard', _postClipboardHandler)
       ..delete('/api/clipboard/<id>', _deleteClipboardItemHandler)
       ..delete('/api/clipboard', _clearClipboardHandler)
@@ -1389,6 +1390,28 @@ class _CliServer {
   /// #222: federation peer を起動前に登録する
   void registerFederationPeer(_FederationPeer peer) {
     _federationPeers.add(peer);
+  }
+
+  // #225: mobile mention picker — structured form of `@list` content
+  Response _mentionsHandler(Request _) {
+    final items = <Map<String, dynamic>>[
+      {
+        'label': '@list',
+        'insert': '@list',
+        'description': 'show this list',
+      },
+    ];
+    for (final e in _mentionActions.entries) {
+      items.add({
+        'label': '@run ${e.key}',
+        'insert': '@run ${e.key}',
+        'description': e.value.description,
+      });
+    }
+    return Response.ok(
+      json.encode({'items': items}),
+      headers: {'Content-Type': 'application/json'},
+    );
   }
 
   Response _federationStatusHandler(Request _) => Response.ok(

--- a/bin/localnode_cli.dart
+++ b/bin/localnode_cli.dart
@@ -23,9 +23,227 @@ import 'package:shelf/shelf.dart';
 import 'package:shelf/shelf_io.dart' as shelf_io;
 import 'package:shelf_router/shelf_router.dart';
 import 'package:shelf_static/shelf_static.dart';
+import 'package:yaml/yaml.dart';
 
 // pubspec.yaml の version と一致させる
 const String _appVersion = '1.6.0';
+
+// =============================================================================
+// 設定ファイル (#185)
+// =============================================================================
+//
+// YAML 構造 (1.6.0 spec §2.1):
+//
+//   server:
+//     port: 8080
+//     ip: 192.168.1.100
+//     name: home-pi
+//     dir: /srv/share
+//     pin: "1234"
+//     mode: normal              # or download-only
+//     no-pin: false
+//     no-clipboard: false
+//     verbose: false
+//     https-cert: /path/cert.pem
+//     https-key: /path/key.pem
+//     token: mytoken
+//     no-token: false
+//     pin-length: 4             # 1.6.0 #206 (parsed; consumed by #206)
+//     pin-charset: digits       # 1.6.0 #206
+//
+//   mention_actions:
+//     - alias: backup
+//       script: ./backup.sh
+//       description: ...        # 1.6.0 #224
+//
+//   post_actions:
+//     - pattern: "*.png"
+//       script: ./move-pic.sh
+//
+//   clipboard:                  # 1.6.0 #227 (parsed; consumed by #227)
+//     max_items: 1000
+//     max_text_length: 10000
+//
+//   children: [...]             # 1.6.0 #218 federation (parsed; consumed there)
+//   parent: {...}               # 1.6.0 #218 federation
+//
+// 解決優先順位: CLI 引数 > config ファイル > 既定値
+
+class _LoadedMentionAction {
+  final String alias;
+  final String script;
+  final String? description;
+  _LoadedMentionAction(this.alias, this.script, this.description);
+}
+
+class _LoadedPostAction {
+  final String pattern;
+  final String script;
+  _LoadedPostAction(this.pattern, this.script);
+}
+
+class _LoadedConfig {
+  // server section
+  int? port;
+  String? ip;
+  String? pin;
+  String? dir;
+  String? mode;
+  String? name;
+  String? httpsCert;
+  String? httpsKey;
+  String? token;
+  bool? noPin;
+  bool? noClipboard;
+  bool? verbose;
+  bool? noToken;
+  // #206 hooks (consumed by #206)
+  int? pinLength;
+  String? pinCharset;
+  // lists
+  List<_LoadedMentionAction>? mentionActions;
+  List<_LoadedPostAction>? postActions;
+  // future sections, parsed-but-not-consumed-yet
+  Map<dynamic, dynamic>? clipboardRaw;       // #227
+  List<dynamic>? childrenRaw;                // #218 federation
+  Map<dynamic, dynamic>? parentRaw;          // #218 federation
+}
+
+/// Read and validate a YAML config file. Throws on fatal errors (unreadable,
+/// syntax, type mismatch). Unknown top-level keys produce a warning to stderr.
+_LoadedConfig _loadConfig(String path) {
+  final file = File(path);
+  if (!file.existsSync()) {
+    stderr.writeln('Error: Config file not found: $path');
+    exit(1);
+  }
+  final dynamic doc;
+  try {
+    doc = loadYaml(file.readAsStringSync());
+  } catch (e) {
+    stderr.writeln('Error: Failed to parse config file: $e');
+    exit(1);
+  }
+  if (doc == null) return _LoadedConfig();
+  if (doc is! YamlMap) {
+    stderr.writeln('Error: Config file root must be a YAML mapping.');
+    exit(1);
+  }
+
+  final cfg = _LoadedConfig();
+  const knownTop = {
+    'server', 'mention_actions', 'post_actions', 'clipboard',
+    'children', 'parent',
+  };
+  for (final key in doc.keys) {
+    if (!knownTop.contains(key)) {
+      stderr.writeln('Warning: Unknown top-level key in config: $key');
+    }
+  }
+
+  // server section
+  final server = doc['server'];
+  if (server is YamlMap) {
+    cfg.port = _yamlInt(server, 'port');
+    cfg.ip = _yamlString(server, 'ip');
+    cfg.pin = _yamlString(server, 'pin');
+    cfg.dir = _yamlString(server, 'dir');
+    cfg.mode = _yamlString(server, 'mode');
+    cfg.name = _yamlString(server, 'name');
+    cfg.httpsCert = _yamlString(server, 'https-cert');
+    cfg.httpsKey = _yamlString(server, 'https-key');
+    cfg.token = _yamlString(server, 'token');
+    cfg.noPin = _yamlBool(server, 'no-pin');
+    cfg.noClipboard = _yamlBool(server, 'no-clipboard');
+    cfg.verbose = _yamlBool(server, 'verbose');
+    cfg.noToken = _yamlBool(server, 'no-token');
+    cfg.pinLength = _yamlInt(server, 'pin-length');
+    cfg.pinCharset = _yamlString(server, 'pin-charset');
+  } else if (server != null) {
+    stderr.writeln('Error: server section must be a mapping.');
+    exit(1);
+  }
+
+  // mention_actions
+  final ma = doc['mention_actions'];
+  if (ma is YamlList) {
+    final list = <_LoadedMentionAction>[];
+    for (final entry in ma) {
+      if (entry is! YamlMap) {
+        stderr.writeln('Error: mention_actions entry must be a mapping.');
+        exit(1);
+      }
+      final alias = _yamlString(entry, 'alias');
+      final script = _yamlString(entry, 'script');
+      if (alias == null || alias.isEmpty || script == null || script.isEmpty) {
+        stderr.writeln('Error: mention_actions entry requires alias and script.');
+        exit(1);
+      }
+      list.add(_LoadedMentionAction(alias, script, _yamlString(entry, 'description')));
+    }
+    cfg.mentionActions = list;
+  } else if (ma != null) {
+    stderr.writeln('Error: mention_actions must be a list.');
+    exit(1);
+  }
+
+  // post_actions
+  final pa = doc['post_actions'];
+  if (pa is YamlList) {
+    final list = <_LoadedPostAction>[];
+    for (final entry in pa) {
+      if (entry is! YamlMap) {
+        stderr.writeln('Error: post_actions entry must be a mapping.');
+        exit(1);
+      }
+      final pattern = _yamlString(entry, 'pattern');
+      final script = _yamlString(entry, 'script');
+      if (pattern == null || pattern.isEmpty || script == null || script.isEmpty) {
+        stderr.writeln('Error: post_actions entry requires pattern and script.');
+        exit(1);
+      }
+      list.add(_LoadedPostAction(pattern, script));
+    }
+    cfg.postActions = list;
+  } else if (pa != null) {
+    stderr.writeln('Error: post_actions must be a list.');
+    exit(1);
+  }
+
+  // forward-compat sections — parsed and stored but not consumed yet
+  final clip = doc['clipboard'];
+  if (clip is YamlMap) cfg.clipboardRaw = Map.from(clip);
+  final ch = doc['children'];
+  if (ch is YamlList) cfg.childrenRaw = List.from(ch);
+  final pa2 = doc['parent'];
+  if (pa2 is YamlMap) cfg.parentRaw = Map.from(pa2);
+
+  return cfg;
+}
+
+String? _yamlString(YamlMap m, String key) {
+  final v = m[key];
+  if (v == null) return null;
+  return v.toString();
+}
+
+int? _yamlInt(YamlMap m, String key) {
+  final v = m[key];
+  if (v == null) return null;
+  if (v is int) return v;
+  final s = v.toString();
+  return int.tryParse(s);
+}
+
+bool? _yamlBool(YamlMap m, String key) {
+  final v = m[key];
+  if (v == null) return null;
+  if (v is bool) return v;
+  final s = v.toString().toLowerCase();
+  if (s == 'true' || s == 'yes' || s == '1') return true;
+  if (s == 'false' || s == 'no' || s == '0') return false;
+  return null;
+}
 
 // =============================================================================
 // エントリポイント
@@ -50,28 +268,73 @@ Future<void> main(List<String> args) async {
     exit(1);
   }
 
-  final port = int.tryParse(results['port'] as String);
+  // #185: --config が指定されていれば YAML を読み込む。
+  // 解決優先順位: CLI 引数 > config > 既定値
+  _LoadedConfig? cfg;
+  if (results.wasParsed('config')) {
+    cfg = _loadConfig(results['config'] as String);
+  }
+
+  // port: CLI > config > '8080'
+  final portStr = results.wasParsed('port')
+      ? results['port'] as String
+      : (cfg?.port?.toString() ?? results['port'] as String);
+  final port = int.tryParse(portStr);
   if (port == null || port < 1 || port > 65535) {
     stderr.writeln('Error: Invalid port number. Must be between 1 and 65535.');
     exit(1);
   }
 
-  final dir = results['dir'] as String?;
+  final dir = results.wasParsed('dir')
+      ? results['dir'] as String?
+      : (cfg?.dir ?? results['dir'] as String?);
   if (dir != null && !Directory(dir).existsSync()) {
     stderr.writeln('Error: Directory does not exist: $dir');
     exit(1);
   }
 
-  final specifiedIp = results['ip'] as String?;
-  final noClipboard = results['no-clipboard'] as bool;
-  final verbose = results['verbose'] as bool;
-  final downloadOnly = (results['mode'] as String) == 'download-only';
-  final noPin = results['no-pin'] as bool;
-  final fixedPin = results['pin'] as String?;
-  final serverName = results['name'] as String;
-  final noToken = results['no-token'] as bool;
-  final fixedToken = results['token'] as String?;
-  final postActionRaw = results['post-action'] as List<String>;
+  final specifiedIp = results.wasParsed('ip')
+      ? results['ip'] as String?
+      : (cfg?.ip ?? results['ip'] as String?);
+  final noClipboard = results.wasParsed('no-clipboard')
+      ? results['no-clipboard'] as bool
+      : (cfg?.noClipboard ?? results['no-clipboard'] as bool);
+  final verbose = results.wasParsed('verbose')
+      ? results['verbose'] as bool
+      : (cfg?.verbose ?? results['verbose'] as bool);
+  final modeStr = results.wasParsed('mode')
+      ? results['mode'] as String
+      : (cfg?.mode ?? results['mode'] as String);
+  if (modeStr != 'normal' && modeStr != 'download-only') {
+    stderr.writeln('Error: Invalid mode: $modeStr. Must be normal or download-only.');
+    exit(1);
+  }
+  final downloadOnly = modeStr == 'download-only';
+  final noPin = results.wasParsed('no-pin')
+      ? results['no-pin'] as bool
+      : (cfg?.noPin ?? results['no-pin'] as bool);
+  final fixedPin = results.wasParsed('pin')
+      ? results['pin'] as String?
+      : (cfg?.pin ?? results['pin'] as String?);
+  final serverName = results.wasParsed('name')
+      ? results['name'] as String
+      : (cfg?.name ?? results['name'] as String);
+  final noToken = results.wasParsed('no-token')
+      ? results['no-token'] as bool
+      : (cfg?.noToken ?? results['no-token'] as bool);
+  final fixedToken = results.wasParsed('token')
+      ? results['token'] as String?
+      : (cfg?.token ?? results['token'] as String?);
+
+  // post_actions: CLI > config (どちらかが存在すればその全体を使う)
+  final List<String> postActionRaw;
+  if (results.wasParsed('post-action')) {
+    postActionRaw = results['post-action'] as List<String>;
+  } else if (cfg?.postActions != null) {
+    postActionRaw = cfg!.postActions!.map((a) => '${a.pattern}=${a.script}').toList();
+  } else {
+    postActionRaw = results['post-action'] as List<String>;
+  }
   final postActions = <({String pattern, String script})>[];
   for (final entry in postActionRaw) {
     final eq = entry.indexOf('=');
@@ -87,28 +350,43 @@ Future<void> main(List<String> args) async {
     }
     postActions.add((pattern: pattern, script: script));
   }
-  final mentionActionRaw = results['mention-action'] as List<String>;
+  // mention_actions: CLI > config
   final mentionActions = <String, String>{};
-  for (final entry in mentionActionRaw) {
-    final eq = entry.indexOf('=');
-    if (eq <= 0) {
-      stderr.writeln('Error: --mention-action must be in <alias>=<script> format: $entry');
-      exit(1);
+  if (results.wasParsed('mention-action')) {
+    final raw = results['mention-action'] as List<String>;
+    for (final entry in raw) {
+      final eq = entry.indexOf('=');
+      if (eq <= 0) {
+        stderr.writeln('Error: --mention-action must be in <alias>=<script> format: $entry');
+        exit(1);
+      }
+      final alias = entry.substring(0, eq).trim();
+      final script = entry.substring(eq + 1).trim();
+      if (alias.isEmpty || script.isEmpty) {
+        stderr.writeln('Error: --mention-action alias and script must not be empty: $entry');
+        exit(1);
+      }
+      if (alias == 'list') {
+        stderr.writeln('Error: "list" is a reserved mention name and cannot be used as an alias.');
+        exit(1);
+      }
+      mentionActions[alias] = script;
     }
-    final alias = entry.substring(0, eq).trim();
-    final script = entry.substring(eq + 1).trim();
-    if (alias.isEmpty || script.isEmpty) {
-      stderr.writeln('Error: --mention-action alias and script must not be empty: $entry');
-      exit(1);
+  } else if (cfg?.mentionActions != null) {
+    for (final m in cfg!.mentionActions!) {
+      if (m.alias == 'list') {
+        stderr.writeln('Error: "list" is a reserved mention name and cannot be used as an alias.');
+        exit(1);
+      }
+      mentionActions[m.alias] = m.script;
     }
-    if (alias == 'list') {
-      stderr.writeln('Error: "list" is a reserved mention name and cannot be used as an alias.');
-      exit(1);
-    }
-    mentionActions[alias] = script;
   }
-  final httpsCertPath = results['https-cert'] as String?;
-  final httpsKeyPath = results['https-key'] as String?;
+  final httpsCertPath = results.wasParsed('https-cert')
+      ? results['https-cert'] as String?
+      : (cfg?.httpsCert ?? results['https-cert'] as String?);
+  final httpsKeyPath = results.wasParsed('https-key')
+      ? results['https-key'] as String?
+      : (cfg?.httpsKey ?? results['https-key'] as String?);
   if ((httpsCertPath == null) != (httpsKeyPath == null)) {
     stderr.writeln('Error: --https-cert and --https-key must be specified together.');
     exit(1);
@@ -240,6 +518,9 @@ Future<void> main(List<String> args) async {
 
 ArgParser _buildParser() {
   return ArgParser()
+    ..addOption('config',
+        abbr: 'c',
+        help: 'Path to YAML config file (overridden by CLI args)')
     ..addOption('port',
         abbr: 'p', help: 'Server port number', defaultsTo: '8080')
     ..addOption('ip', help: 'IP address to bind (skip auto-detection)')
@@ -297,6 +578,10 @@ void _printUsage(ArgParser parser) {
   stdout.writeln('  localnode-cli --https-cert /path/to/cert.pem --https-key /path/to/key.pem');
   stdout.writeln('  localnode-cli --post-action "*.png=./resize.sh" --post-action "*.zip=./unzip.sh"');
   stdout.writeln('  localnode-cli --mention-action backup=./backup.sh --mention-action notify=./notify.sh');
+  stdout.writeln('  localnode-cli --config /etc/localnode/config.yaml');
+  stdout.writeln('');
+  stdout.writeln('Config file (YAML, see docs):');
+  stdout.writeln('  Supports server.*, mention_actions[], post_actions[]; CLI args override config.');
   stdout.writeln('');
   stdout.writeln('Security note (--post-action / --mention-action):');
   stdout.writeln('  Scripts run with the same user privileges as the LocalNode process.');

--- a/bin/localnode_cli.dart
+++ b/bin/localnode_cli.dart
@@ -1230,6 +1230,13 @@ class _FederationPeer {
   int lastOkMs = 0;
   int lastTryMs = 0;
   String? lastError;
+  // #223: pause まで有効な時刻 (epoch ms)。0 なら pause していない。
+  int pauseUntilMs = 0;
+
+  bool isPaused() {
+    if (pauseUntilMs == 0) return false;
+    return DateTime.now().millisecondsSinceEpoch < pauseUntilMs;
+  }
 
   _FederationPeer({
     required this.kind,
@@ -1253,6 +1260,7 @@ class _FederationPeer {
         'lastTryMs': lastTryMs,
         'learnedDeviceId': learnedDeviceId,
         'lastError': lastError,
+        'pauseUntilMs': pauseUntilMs,
       };
 }
 
@@ -1370,7 +1378,9 @@ class _CliServer {
       ..delete('/api/clipboard/<id>', _deleteClipboardItemHandler)
       ..delete('/api/clipboard', _clearClipboardHandler)
       // #222: federation 状態（peer 一覧と接続状態）
-      ..get('/api/federation/status', _federationStatusHandler);
+      ..get('/api/federation/status', _federationStatusHandler)
+      ..post('/api/federation/peers/<name>/pause', _federationPausePeerHandler)  // #223
+      ..delete('/api/federation/peers/<name>/pause', _federationResumePeerHandler);  // #223
   }
 
   /// #222: federation peer を起動前に登録する
@@ -1386,6 +1396,41 @@ class _CliServer {
         }),
         headers: {'Content-Type': 'application/json'},
       );
+
+  // #223: peer pause / resume
+  Response _federationPausePeerHandler(Request req, String name) {
+    final peer = _federationPeers.firstWhereOrNullExt((p) => p.name == name);
+    if (peer == null) return Response.notFound('Peer not found.');
+    final durStr = req.requestedUri.queryParameters['duration'];
+    final dur = int.tryParse(durStr ?? '');
+    // 許容プリセット (秒): 30min / 1h / 3h / 12h / 24h
+    const allowed = {1800, 3600, 10800, 43200, 86400};
+    if (dur == null || !allowed.contains(dur)) {
+      return Response.badRequest(
+          body: 'duration must be one of 1800/3600/10800/43200/86400 (seconds)');
+    }
+    peer.pauseUntilMs =
+        DateTime.now().millisecondsSinceEpoch + dur * 1000;
+    peer.status = 'paused';
+    _log('[fed] pause ${peer.name} until=${peer.pauseUntilMs}');
+    return Response.ok(
+      json.encode({'paused': true, 'pauseUntilMs': peer.pauseUntilMs}),
+      headers: {'Content-Type': 'application/json'},
+    );
+  }
+
+  Response _federationResumePeerHandler(Request _, String name) {
+    final peer = _federationPeers.firstWhereOrNullExt((p) => p.name == name);
+    if (peer == null) return Response.notFound('Peer not found.');
+    peer.pauseUntilMs = 0;
+    // 次の heartbeat で正しい status に更新される
+    peer.status = 'unknown';
+    _log('[fed] resume ${peer.name}');
+    return Response.ok(
+      json.encode({'paused': false}),
+      headers: {'Content-Type': 'application/json'},
+    );
+  }
 
   /// #222: 全 peer に GET /api/health を投げて状態を更新
   Future<void> _heartbeatTick() async {
@@ -1405,10 +1450,11 @@ class _CliServer {
         await res.drain();
         if (res.statusCode >= 200 && res.statusCode < 300) {
           peer.lastOkMs = DateTime.now().millisecondsSinceEpoch;
-          if (peer.status != 'paused') peer.status = 'connected';
+          // #223: pause 中はその表示を優先
+          peer.status = peer.isPaused() ? 'paused' : 'connected';
           peer.lastError = null;
         } else {
-          peer.status = 'offline';
+          peer.status = peer.isPaused() ? 'paused' : 'offline';
           peer.lastError = 'HTTP ${res.statusCode}';
         }
         // peer の deviceId を学習（/api/info を別途叩く）。負荷軽減のためおおむね 10 回に1回
@@ -1430,7 +1476,9 @@ class _CliServer {
         }
         _log('[fed] heartbeat ${peer.name} ${peer.status}');
       } catch (e) {
-        peer.status = 'offline';
+        // pause 中でも heartbeat 自体は流す。失敗時は status を offline にするが、
+        // pause が有効ならその表示を優先
+        peer.status = peer.isPaused() ? 'paused' : 'offline';
         peer.lastError = e.toString();
         _log('[fed] heartbeat ${peer.name} offline: $e');
       }
@@ -1529,6 +1577,11 @@ class _CliServer {
 
   Future<void> _sendClipboardToPeer(
       _FederationPeer peer, _ClipboardItem item, bool isUp) async {
+    // #223: pause 中はサイレントに skip
+    if (peer.isPaused()) {
+      _log('[fed] paused-skip clip ${peer.name}');
+      return;
+    }
     _heartbeatClient ??=
         HttpClient()..connectionTimeout = const Duration(seconds: 10);
     final uri = Uri.parse('${peer.url}/api/clipboard');
@@ -1571,6 +1624,11 @@ class _CliServer {
   }
 
   Future<bool> _sendFileToPeer(_FederationPeer peer, File file) async {
+    // #223: pause 中は skip
+    if (peer.isPaused()) {
+      _log('[fed] paused-skip file ${peer.name}');
+      return false;
+    }
     _heartbeatClient ??=
         HttpClient()..connectionTimeout = const Duration(seconds: 10);
     final filename = p.basename(file.path);
@@ -1881,6 +1939,25 @@ class _CliServer {
                 json.encode({'dropped': 'loop', 'device_id': _deviceId}),
                 headers: {'Content-Type': 'application/json'},
               );
+            }
+          }
+          // #223: federation 由来 (x-fed-origin あり) かつ送信元 peer が pause 中なら遮断。
+          //       heartbeat (/api/health) は pause 中でも通す (生死表示用)。
+          final origin = req.headers[_kFedOrigin];
+          if (origin != null && origin.isNotEmpty) {
+            final path = req.url.path;
+            if (path != 'api/health' && path != 'api/info') {
+              final peer = _federationPeers
+                  .firstWhereOrNullExt((p) => p.learnedDeviceId == origin);
+              if (peer != null && peer.isPaused()) {
+                _log('[fed] paused-block ${peer.name} path=$path');
+                return Response(503,
+                    body: json.encode({
+                      'paused': true,
+                      'pauseUntilMs': peer.pauseUntilMs,
+                    }),
+                    headers: {'Content-Type': 'application/json'});
+              }
             }
           }
           return inner(req);
@@ -2854,6 +2931,10 @@ class _CliServer {
 
   /// 任意のテキストを peer の /api/clipboard に送る (リトライ込み)
   Future<void> _sendBareTextToPeer(_FederationPeer peer, String text) async {
+    if (peer.isPaused()) {
+      _log('[fed] paused-skip text ${peer.name}');
+      throw StateError('peer paused');
+    }
     _heartbeatClient ??=
         HttpClient()..connectionTimeout = const Duration(seconds: 10);
     final uri = Uri.parse('${peer.url}/api/clipboard');

--- a/bin/localnode_cli.dart
+++ b/bin/localnode_cli.dart
@@ -28,6 +28,27 @@ import 'package:yaml/yaml.dart';
 // pubspec.yaml の version と一致させる
 const String _appVersion = '1.6.0';
 
+// #174 + #220: 予約メンション名。ユーザーが `--mention-action <name>=...` で
+// 登録できない。
+//   list      自分のメンション一覧 (既存)
+//   list <child>  (federation #220) 子のメンション一覧。引数なしと曖昧解消
+//   run       script 実行 (既存; --mention-action で登録するのが alias)
+//   to        親→子へ clipboard post を送る (federation #220)
+//   run_to    親→子へ mention 実行を依頼する (federation #220)
+//   up        子→親への重要マーカー (federation #220)
+const Set<String> _kReservedMentionNames = {
+  'list', 'run', 'to', 'run_to', 'up',
+};
+
+extension _FirstWhereOrNullExt<E> on Iterable<E> {
+  E? firstWhereOrNullExt(bool Function(E) test) {
+    for (final e in this) {
+      if (test(e)) return e;
+    }
+    return null;
+  }
+}
+
 // =============================================================================
 // 設定ファイル (#185)
 // =============================================================================
@@ -366,16 +387,17 @@ Future<void> main(List<String> args) async {
         stderr.writeln('Error: --mention-action alias and script must not be empty: $entry');
         exit(1);
       }
-      if (alias == 'list') {
-        stderr.writeln('Error: "list" is a reserved mention name and cannot be used as an alias.');
+      // #174 + #220: 予約名 list / run / to / run_to / up
+      if (_kReservedMentionNames.contains(alias)) {
+        stderr.writeln('Error: "$alias" is a reserved mention name and cannot be used as an alias.');
         exit(1);
       }
       mentionActions[alias] = script;
     }
   } else if (cfg?.mentionActions != null) {
     for (final m in cfg!.mentionActions!) {
-      if (m.alias == 'list') {
-        stderr.writeln('Error: "list" is a reserved mention name and cannot be used as an alias.');
+      if (_kReservedMentionNames.contains(m.alias)) {
+        stderr.writeln('Error: "${m.alias}" is a reserved mention name and cannot be used as an alias.');
         exit(1);
       }
       mentionActions[m.alias] = m.script;
@@ -1168,12 +1190,15 @@ class _ClipboardItem {
   final String text;
   final String? tag;
   final DateTime createdAt;
+  // #220 / #230: @up でマーク済みの重要アイテム
+  final bool important;
 
   _ClipboardItem({
     required this.id,
     required this.text,
     this.tag,
     required this.createdAt,
+    this.important = false,
   });
 
   Map<String, dynamic> toJson() => {
@@ -1181,6 +1206,7 @@ class _ClipboardItem {
         'text': text,
         'tag': tag,
         'createdAt': createdAt.toUtc().toIso8601String(),
+        'important': important,
       };
 }
 
@@ -2607,7 +2633,7 @@ class _CliServer {
     try {
       final params =
           json.decode(await req.readAsString()) as Map<String, dynamic>;
-      final text = (params['text'] as String?)?.trim();
+      var text = (params['text'] as String?)?.trim();
       final rawTag = (params['tag'] as String?)?.trim();
       final tag = (rawTag != null && rawTag.isNotEmpty) ? rawTag : null;
 
@@ -2624,11 +2650,28 @@ class _CliServer {
         );
       }
 
+      // #220: 受信時 (federation 由来) に `@up ` で始まっていれば
+      //   - important フラグを立てる
+      //   - 表示テキストから `@up ` を剥がす
+      //   ローカル直接投稿でも同様に重要フラグだけ立てる (剥がしは行わない方が
+      //   送信側の意図が見えるが、spec §1.4 で「受信側で剥がす」とあるので剥がす)
+      bool important = false;
+      if (_isUpText(text)) {
+        important = true;
+        text = text.substring(4).trimLeft();
+        if (text.isEmpty) {
+          // @up だけのメッセージは空になる -> 体裁悪いのでマーク前に戻す
+          text = '@up';
+          important = false;
+        }
+      }
+
       final item = _ClipboardItem(
         id: _generateId(),
         text: text,
         tag: tag,
         createdAt: DateTime.now(),
+        important: important,
       );
       _clipboardItems.insert(0, item);
       while (_clipboardItems.length > _maxClipboardItems) {
@@ -2638,20 +2681,18 @@ class _CliServer {
       _clipboardLastModified = DateTime.now().millisecondsSinceEpoch;
 
       // #219: 親への転送 (自分が子のとき、かつ受信が federation 由来でない場合)
-      _forwardClipboardToParents(item, req);
+      // 注: important フラグの判定は転送時にもう一度 _isUpItem で行う。
+      //     しかし剥がした後 (`text` から `@up ` が消えている) なので、
+      //     重要度を保つために item.text ではなく元の判定情報を渡す必要がある。
+      //     ここでは「重要フラグ」を考慮した転送ヘルパを呼び分ける。
+      _forwardClipboardItemWithImportance(item, req, important);
 
-      // #174: メンションコマンド検出
-      if (text == '@list') {
-        _replyToClipboard(_buildMentionList());
-      } else {
-        final match = RegExp(r'^@run\s+(\S+)$').firstMatch(text);
-        if (match != null) {
-          final alias = match.group(1)!;
-          final script = _mentionActions[alias];
-          if (script != null) {
-            _runMentionAction(alias, script);
-          }
-        }
+      // #174 / #220: メンションコマンド検出
+      // 重要フラグで剥がした text はもうコマンドではないので、元の text で判定する
+      // ためここで再度組み立てる必要はなく、剥がし前の text を扱うべき。
+      // → 改修簡素化のため: important なら mention 検出はスキップ
+      if (!important) {
+        await _handleMentionInClipboard(text);
       }
 
       return Response.ok(json.encode(item.toJson()),
@@ -2661,6 +2702,167 @@ class _CliServer {
         body: json.encode({'error': 'Invalid request body.'}),
         headers: {'Content-Type': 'application/json'},
       );
+    }
+  }
+
+  bool _isUpText(String s) => s == '@up' || s.startsWith('@up ');
+
+  /// 親への転送ヘルパ。重要フラグも含めて転送先で `@up ` を付け直すかは
+  /// 送信側で決める。
+  void _forwardClipboardItemWithImportance(
+      _ClipboardItem item, Request originReq, bool important) {
+    if (important) {
+      // 元のテキストを `@up ` 付きで送信し直すための一時 item
+      final wireItem = _ClipboardItem(
+        id: item.id,
+        text: '@up ${item.text}',
+        tag: item.tag,
+        createdAt: item.createdAt,
+        important: true,
+      );
+      _forwardClipboardToParents(wireItem, originReq);
+    } else {
+      _forwardClipboardToParents(item, originReq);
+    }
+  }
+
+  /// #220: clipboard 投稿に含まれるメンションコマンドを処理
+  Future<void> _handleMentionInClipboard(String text) async {
+    // @list (自分)
+    if (text == '@list') {
+      _replyToClipboard(_buildMentionList());
+      return;
+    }
+    // @list <child>
+    final listChild = RegExp(r'^@list\s+(\S+)$').firstMatch(text);
+    if (listChild != null) {
+      final childName = listChild.group(1)!;
+      _dispatchListToChild(childName);
+      return;
+    }
+    // @to <child|all> <message>
+    final toMatch = RegExp(r'^@to\s+(\S+)\s+(.+)$', dotAll: true).firstMatch(text);
+    if (toMatch != null) {
+      final target = toMatch.group(1)!;
+      final message = toMatch.group(2)!;
+      _dispatchToChild(target, message);
+      return;
+    }
+    // @run_to <child> <alias>
+    final runToMatch = RegExp(r'^@run_to\s+(\S+)\s+(\S+)$').firstMatch(text);
+    if (runToMatch != null) {
+      final childName = runToMatch.group(1)!;
+      final alias = runToMatch.group(2)!;
+      _dispatchRunToChild(childName, alias);
+      return;
+    }
+    // @run <alias> (既存)
+    final runMatch = RegExp(r'^@run\s+(\S+)$').firstMatch(text);
+    if (runMatch != null) {
+      final alias = runMatch.group(1)!;
+      final script = _mentionActions[alias];
+      if (script != null) {
+        _runMentionAction(alias, script);
+      }
+    }
+  }
+
+  /// 子に `@list` を投げる。子側で `@list` の結果が自分の clipboard に
+  /// 投稿され、friendly 転送なら親へ戻ってくる (equally では戻らないので
+  /// equally 子に対しては警告として local clipboard に注記)。
+  void _dispatchListToChild(String childName) {
+    final peer = _federationPeers.firstWhereOrNullExt(
+        (p) => p.kind == 'child' && p.name == childName);
+    if (peer == null) {
+      _replyToClipboard('@list $childName: child not found');
+      return;
+    }
+    if (peer.relation == 'equally') {
+      _replyToClipboard(
+          '@list $childName: equally relation — result will not be auto-forwarded');
+    }
+    () async {
+      try {
+        await _sendBareTextToPeer(peer, '@list');
+        _log('[fed] dispatched @list -> ${peer.name}');
+      } catch (e) {
+        _log('[fed] @list ${peer.name} fail: $e');
+        _replyToClipboard('@list $childName: dispatch failed');
+      }
+    }();
+  }
+
+  /// `@to <name|all> <message>` を解決して送信
+  void _dispatchToChild(String target, String message) {
+    final List<_FederationPeer> targets;
+    if (target == 'all') {
+      targets = _federationPeers.where((p) => p.kind == 'child').toList();
+    } else {
+      final t = _federationPeers.firstWhereOrNullExt(
+          (p) => p.kind == 'child' && p.name == target);
+      if (t == null) {
+        _replyToClipboard('@to $target: child not found');
+        return;
+      }
+      targets = [t];
+    }
+    for (final peer in targets) {
+      () async {
+        try {
+          await _sendBareTextToPeer(peer, message);
+          _log('[fed] @to ${peer.name} ok');
+        } catch (e) {
+          _log('[fed] @to ${peer.name} fail: $e');
+        }
+      }();
+    }
+  }
+
+  /// `@run_to <name> <alias>` を解決して `@run <alias>` を送信
+  void _dispatchRunToChild(String childName, String alias) {
+    final peer = _federationPeers.firstWhereOrNullExt(
+        (p) => p.kind == 'child' && p.name == childName);
+    if (peer == null) {
+      _replyToClipboard('@run_to $childName: child not found');
+      return;
+    }
+    () async {
+      try {
+        await _sendBareTextToPeer(peer, '@run $alias');
+        _log('[fed] @run_to ${peer.name} $alias dispatched');
+      } catch (e) {
+        _log('[fed] @run_to ${peer.name} fail: $e');
+        _replyToClipboard('@run_to $childName: dispatch failed');
+      }
+    }();
+  }
+
+  /// 任意のテキストを peer の /api/clipboard に送る (リトライ込み)
+  Future<void> _sendBareTextToPeer(_FederationPeer peer, String text) async {
+    _heartbeatClient ??=
+        HttpClient()..connectionTimeout = const Duration(seconds: 10);
+    final uri = Uri.parse('${peer.url}/api/clipboard');
+    for (var attempt = 1; attempt <= 3; attempt++) {
+      try {
+        final r = await _heartbeatClient!.postUrl(uri);
+        r.headers.set('Content-Type', 'application/json');
+        r.headers.set('Authorization', 'Bearer ${peer.token}');
+        r.headers.set(_kFedOrigin, _deviceId);
+        r.headers.set(_kFedSeenBy, _deviceId);
+        r.headers.set(_kFedEvent, 'clipboard');
+        r.write(json.encode({'text': text, 'tag': _serverName}));
+        final res = await r.close().timeout(const Duration(seconds: 15));
+        await res.drain();
+        if (res.statusCode >= 200 && res.statusCode < 300) return;
+        if (res.statusCode >= 400 &&
+            res.statusCode < 500 &&
+            res.statusCode != 408) {
+          throw HttpException('HTTP ${res.statusCode}');
+        }
+      } catch (e) {
+        if (attempt == 3) rethrow;
+      }
+      await Future.delayed(Duration(seconds: 2 * attempt));
     }
   }
 

--- a/bin/localnode_cli.dart
+++ b/bin/localnode_cli.dart
@@ -337,6 +337,31 @@ Future<void> main(List<String> args) async {
   final fixedPin = results.wasParsed('pin')
       ? results['pin'] as String?
       : (cfg?.pin ?? results['pin'] as String?);
+  // #206
+  final pinLength = () {
+    final raw = results.wasParsed('pin-length')
+        ? results['pin-length'] as String?
+        : (cfg?.pinLength?.toString());
+    if (raw == null) return 4;
+    final n = int.tryParse(raw);
+    if (n == null || n < 4 || n > 8) {
+      stderr.writeln('Error: --pin-length must be an integer 4..8 (got "$raw").');
+      exit(1);
+    }
+    return n;
+  }();
+  final pinCharset = () {
+    const allowed = {'digits', 'alnum', 'alnum_symbols'};
+    final raw = results.wasParsed('pin-charset')
+        ? results['pin-charset'] as String?
+        : (cfg?.pinCharset ?? results['pin-charset'] as String?);
+    final v = raw ?? 'digits';
+    if (!allowed.contains(v)) {
+      stderr.writeln('Error: --pin-charset must be one of ${allowed.join("/")} (got "$v").');
+      exit(1);
+    }
+    return v;
+  }();
   final serverName = results.wasParsed('name')
       ? results['name'] as String
       : (cfg?.name ?? results['name'] as String);
@@ -556,6 +581,8 @@ Future<void> main(List<String> args) async {
       downloadOnly: downloadOnly,
       authMode: authMode,
       fixedPin: fixedPin,
+      pinLength: pinLength,         // #206
+      pinCharset: pinCharset,       // #206
       serverName: serverName,
       clipboardEnabled: !noClipboard,
       httpsCertPath: httpsCertPath,
@@ -695,6 +722,13 @@ ArgParser _buildParser() {
         abbr: 'p', help: 'Server port number', defaultsTo: '8080')
     ..addOption('ip', help: 'IP address to bind (skip auto-detection)')
     ..addOption('pin', help: 'Fixed PIN (random if not specified)')
+    // #206
+    ..addOption('pin-length',
+        help: 'PIN length when generating a random PIN (4..8, default 4)')
+    ..addOption('pin-charset',
+        help: 'Character set for the generated PIN',
+        allowed: ['digits', 'alnum', 'alnum_symbols'],
+        defaultsTo: 'digits')
     ..addOption('dir', abbr: 'd', help: 'Shared directory path')
     ..addOption('mode',
         abbr: 'm',
@@ -1347,6 +1381,9 @@ class _CliServer {
   String? _uploadToken;
   List<({String pattern, String script})> _postActions = [];
   Map<String, ({String script, String? description})> _mentionActions = {};
+  // #206
+  int _pinLength = 4;
+  String _pinCharset = 'digits';
 
   late final Router _router;
 
@@ -1748,6 +1785,8 @@ class _CliServer {
     bool downloadOnly = false,
     _AuthMode authMode = _AuthMode.randomPin,
     String? fixedPin,
+    int pinLength = 4,             // #206
+    String pinCharset = 'digits',  // #206
     String serverName = 'LocalNode',
     bool clipboardEnabled = true,
     String? httpsCertPath,
@@ -1763,6 +1802,8 @@ class _CliServer {
     _mentionActions = mentionActions;
     _clipboardEnabled = clipboardEnabled;
     _serverName = serverName;
+    _pinLength = pinLength;       // #206
+    _pinCharset = pinCharset;     // #206
     _startedAt = DateTime.now().millisecondsSinceEpoch;
 
     switch (authMode) {
@@ -1884,7 +1925,24 @@ class _CliServer {
 
   // --- ユーティリティ ---
 
-  String _generatePin() => (1000 + Random().nextInt(9000)).toString();
+  // #206: configurable length (4..8) and charset (digits / alnum / alnum_symbols)
+  String _generatePin() {
+    const digits = '0123456789';
+    const alnum = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+    // 紛らわしい記号を避け、URL/CLI/Cookie で安全な印字可能 ASCII 部分集合
+    const symbols = '!@#\$%&*-_+=?';
+    final pool = switch (_pinCharset) {
+      'alnum' => alnum,
+      'alnum_symbols' => alnum + symbols,
+      _ => digits,
+    };
+    final rnd = Random.secure();
+    final buf = StringBuffer();
+    for (var i = 0; i < _pinLength; i++) {
+      buf.write(pool[rnd.nextInt(pool.length)]);
+    }
+    return buf.toString();
+  }
 
   String _generateToken() {
     final r = Random.secure();
@@ -2127,6 +2185,9 @@ class _CliServer {
           // #218: federation 識別子。public エンドポイントなので未認証で見える。
           // peer 同士の identity 確認に使うが、機密ではない。
           'deviceId': _deviceId,
+          // #206: Web UI が PIN 入力モードを切り替えるためのヒント
+          'pinCharset': _pinCharset,
+          'pinLength': _pinLength,
         }),
         headers: {'Content-Type': 'application/json'},
       );

--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -1,0 +1,66 @@
+# LocalNode CLI 設定ファイル例 (#185)
+#
+# 使い方:
+#   localnode-cli --config /path/to/this/config.yaml
+#
+# 優先順位: CLI 引数 > config ファイル > 既定値
+
+# サーバー設定 — 既存 CLI オプションに対応
+server:
+  port: 8080
+  ip: 192.168.1.100              # 省略可（自動選択）
+  name: home-server              # ブラウザタブに表示する名前
+  dir: /srv/share                # 共有フォルダ
+  pin: "1234"                    # 固定 PIN（省略するとランダム生成）
+  mode: normal                   # normal / download-only
+  no-pin: false                  # PIN 認証を無効化（信頼ネットワーク用）
+  no-clipboard: false            # クリップボード共有を無効化
+  verbose: false                 # 詳細ログを有効化
+  https-cert: /etc/letsencrypt/live/example.com/fullchain.pem
+  https-key: /etc/letsencrypt/live/example.com/privkey.pem
+  token: mytoken-for-upload      # 固定 Bearer トークン
+  no-token: false                # トークン認証を無効化
+
+  # 1.6.0 PIN 強化 (#206) — 1.6.0 で実装予定。スキーマは予約
+  pin-length: 4                  # 4-8
+  pin-charset: digits            # digits / alnum / alnum_symbols
+
+# メンションアクション (alias 形式) — #185 + description は @list で表示 (#224)
+mention_actions:
+  - alias: backup
+    script: /usr/local/bin/backup.sh
+    description: バックアップを実行
+  - alias: notify
+    script: /usr/local/bin/notify.sh
+    description: 通知を送る
+
+# post-action (アップロード後にパターン一致したファイルでスクリプト実行)
+post_actions:
+  - pattern: "*.png"
+    script: /usr/local/bin/move-pic.sh
+  - pattern: "*.zip"
+    script: /usr/local/bin/unzip.sh
+
+# === 以下は 1.6.0 の federation / clipboard scalability で使用 ===
+# 現時点ではスキーマだけ予約。中身は対応 issue で反映される。
+
+# クリップボード共有のチューニング (#227 で実装)
+clipboard:
+  max_items: 1000                # デフォルト 10 → 1000
+  max_text_length: 10000
+
+# 親子連携: 自分が「親」のとき子の一覧を書く (#218 で実装)
+children:
+  - name: watcher-pi
+    url: https://watcher-pi.tail-xxxx.ts.net:8080
+    token: <child-issued-token>
+    relation: friendly           # friendly / equally
+    max_upload_size: 100MB
+
+# 親子連携: 自分が「子」のとき親を書く (#218 で実装)
+parent:
+  name: home-server
+  url: https://home-server.tail-xxxx.ts.net:8080
+  token: <parent-issued-token>
+  relation: friendly
+  trust: true                    # 親に転送したファイルを子側で保持しない

--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -21,8 +21,8 @@ server:
   token: mytoken-for-upload      # 固定 Bearer トークン
   no-token: false                # トークン認証を無効化
 
-  # 1.6.0 PIN 強化 (#206) — 1.6.0 で実装予定。スキーマは予約
-  pin-length: 4                  # 4-8
+  # PIN 強化 (#206)
+  pin-length: 4                  # 4-8。ランダム PIN 生成時の文字数
   pin-charset: digits            # digits / alnum / alnum_symbols
 
 # メンションアクション (alias 形式) — #185 + description は @list で表示 (#224)

--- a/lib/server_service.dart
+++ b/lib/server_service.dart
@@ -1464,6 +1464,44 @@ class ServerService {
 
   // === Middleware ===
 
+  // #221: federation ループ防止
+  static const String _kFedOrigin = 'x-fed-origin';
+  static const String _kFedSeenBy = 'x-fed-seen-by';
+
+  Middleware get _federationLoopGuard => (innerHandler) {
+        return (request) {
+          final seenByRaw = request.headers[_kFedSeenBy];
+          if (seenByRaw != null && _deviceId.isNotEmpty) {
+            final ids = seenByRaw
+                .split(',')
+                .map((s) => s.trim())
+                .where((s) => s.isNotEmpty)
+                .toSet();
+            if (ids.contains(_deviceId)) {
+              final origin = request.headers[_kFedOrigin] ?? '?';
+              _log('[fed] loop-drop origin=$origin seen_by_count=${ids.length}');
+              return Response.ok(
+                json.encode({'dropped': 'loop', 'device_id': _deviceId}),
+                headers: {'Content-Type': 'application/json'},
+              );
+            }
+          }
+          return innerHandler(request);
+        };
+      };
+
+  /// #219 から使うヘルパ: federation event 転送時の seen_by 構築
+  // ignore: unused_element
+  List<String> _appendSelfToSeenBy(String? incomingHeader) {
+    final ids = (incomingHeader ?? '')
+        .split(',')
+        .map((s) => s.trim())
+        .where((s) => s.isNotEmpty)
+        .toList();
+    if (_deviceId.isNotEmpty && !ids.contains(_deviceId)) ids.add(_deviceId);
+    return ids;
+  }
+
   Middleware get _authMiddleware => (innerHandler) {
     return (request) {
       final path = request.url.path;
@@ -1664,7 +1702,7 @@ class ServerService {
           createStaticHandler(_webRootDir!.path, defaultDocument: 'index.html');
 
       final apiHandler =
-          const Pipeline().addMiddleware(_authMiddleware).addHandler(_router.call);
+          const Pipeline().addMiddleware(_federationLoopGuard).addMiddleware(_authMiddleware).addHandler(_router.call);
 
       final cascade = Cascade().add(apiHandler).add(staticHandler);
 
@@ -1745,7 +1783,7 @@ class ServerService {
           createStaticHandler(_webRootDir!.path, defaultDocument: 'index.html');
 
       final apiHandler =
-          const Pipeline().addMiddleware(_authMiddleware).addHandler(_router.call);
+          const Pipeline().addMiddleware(_federationLoopGuard).addMiddleware(_authMiddleware).addHandler(_router.call);
 
       final cascade = Cascade().add(apiHandler).add(staticHandler);
 

--- a/lib/server_service.dart
+++ b/lib/server_service.dart
@@ -77,7 +77,10 @@ class ServerService {
   // クリップボード共有用
   final List<ClipboardItem> _clipboardItems = [];
   int _clipboardLastModified = 0;
-  static const int _maxClipboardItems = 10;
+  // #227: 1.6.0 で 10 → 1000 にデフォルト値を引き上げ
+  // GUI アプリは現状 YAML config を読み込まないので hardcoded。
+  // federation (#218) で GUI 側の config 配線が入った時点で設定化される予定。
+  static const int _maxClipboardItems = 1000;
   static const int _maxTextLength = 10000;
 
   // クリップボードアイテムへの外部アクセス用ゲッター

--- a/lib/server_service.dart
+++ b/lib/server_service.dart
@@ -89,6 +89,19 @@ class ServerService {
   // クリップボード共有用
   final List<ClipboardItem> _clipboardItems = [];
   int _clipboardLastModified = 0;
+  // #228: 削除リングバッファ
+  static const int _maxDeletionLog = 200;
+  final List<({String id, int deletedAtMs})> _clipboardDeletes = [];
+
+  void _recordDeletion(String id) {
+    _clipboardDeletes.add((
+      id: id,
+      deletedAtMs: DateTime.now().millisecondsSinceEpoch,
+    ));
+    if (_clipboardDeletes.length > _maxDeletionLog) {
+      _clipboardDeletes.removeAt(0);
+    }
+  }
   // #227: 1.6.0 で 10 → 1000 にデフォルト値を引き上げ
   // GUI アプリは現状 YAML config を読み込まないので hardcoded。
   // federation (#218) で GUI 側の config 配線が入った時点で設定化される予定。
@@ -1317,14 +1330,66 @@ class ServerService {
 
   // === Clipboard Handlers ===
 
-  /// GET /api/clipboard - クリップボード履歴取得
+  /// GET /api/clipboard - クリップボード履歴取得 (#228 差分対応)
   Response _getClipboardHandler(Request request) {
-    final response = {
-      'items': _clipboardItems.map((item) => item.toJson()).toList(),
-      'lastModified': _clipboardLastModified,
-    };
+    final q = request.requestedUri.queryParameters;
+    final hasQuery = q.containsKey('since') ||
+        q.containsKey('before') ||
+        q.containsKey('limit');
+
+    if (!hasQuery) {
+      // 後方互換: 全件返す
+      return Response.ok(
+        json.encode({
+          'items': _clipboardItems.map((item) => item.toJson()).toList(),
+          'lastModified': _clipboardLastModified,
+        }),
+        headers: {'Content-Type': 'application/json'},
+      );
+    }
+
+    final since = int.tryParse(q['since'] ?? '');
+    final before = int.tryParse(q['before'] ?? '');
+    final limit = int.tryParse(q['limit'] ?? '');
+    if (limit != null && (limit < 1 || limit > 2000)) {
+      return Response.badRequest(body: 'limit must be 1..2000');
+    }
+
+    bool refresh = false;
+    List<String> deletedSince = const [];
+    if (since != null) {
+      if (_clipboardDeletes.length >= _maxDeletionLog &&
+          _clipboardDeletes.first.deletedAtMs > since) {
+        refresh = true;
+      }
+      deletedSince = _clipboardDeletes
+          .where((d) => d.deletedAtMs > since)
+          .map((d) => d.id)
+          .toList();
+    }
+
+    Iterable<ClipboardItem> filtered = _clipboardItems;
+    if (since != null) {
+      filtered = filtered
+          .where((i) => i.createdAt.millisecondsSinceEpoch > since);
+    }
+    if (before != null) {
+      filtered = filtered
+          .where((i) => i.createdAt.millisecondsSinceEpoch < before);
+    }
+    final list = filtered.toList();
+    final cap = limit ?? list.length;
+    final returned = list.length > cap ? list.sublist(0, cap) : list;
+    final hasMore = list.length > cap;
+
     return Response.ok(
-      json.encode(response),
+      json.encode({
+        'items': returned.map((i) => i.toJson()).toList(),
+        'deleted': deletedSince,
+        'lastModified': _clipboardLastModified,
+        'hasMore': hasMore,
+        'refresh': refresh,
+      }),
       headers: {'Content-Type': 'application/json'},
     );
   }
@@ -1361,9 +1426,10 @@ class ServerService {
 
       _clipboardItems.insert(0, item);
 
-      // 最大件数を超えたら古いものを削除
+      // 最大件数を超えたら古いものを削除 (#228 でリングバッファに記録)
       while (_clipboardItems.length > _maxClipboardItems) {
-        _clipboardItems.removeLast();
+        final evicted = _clipboardItems.removeLast();
+        _recordDeletion(evicted.id);
       }
 
       _clipboardLastModified = DateTime.now().millisecondsSinceEpoch;
@@ -1390,7 +1456,8 @@ class ServerService {
       );
     }
 
-    _clipboardItems.removeAt(index);
+    final removed = _clipboardItems.removeAt(index);
+    _recordDeletion(removed.id);
     _clipboardLastModified = DateTime.now().millisecondsSinceEpoch;
 
     return Response.ok(
@@ -1402,6 +1469,9 @@ class ServerService {
   /// DELETE /api/clipboard - 全アイテム削除
   Response _clearClipboardHandler(Request request) {
     final count = _clipboardItems.length;
+    for (final it in _clipboardItems) {
+      _recordDeletion(it.id);
+    }
     _clipboardItems.clear();
     _clipboardLastModified = DateTime.now().millisecondsSinceEpoch;
 
@@ -1449,7 +1519,8 @@ class ServerService {
     final index = _clipboardItems.indexWhere((item) => item.id == id);
     if (index == -1) return false;
 
-    _clipboardItems.removeAt(index);
+    final removed = _clipboardItems.removeAt(index);
+    _recordDeletion(removed.id);
     _clipboardLastModified = DateTime.now().millisecondsSinceEpoch;
     return true;
   }
@@ -1457,6 +1528,9 @@ class ServerService {
   /// クリップボードをクリア（Flutter UIから直接呼び出し用）
   int clearClipboard() {
     final count = _clipboardItems.length;
+    for (final it in _clipboardItems) {
+      _recordDeletion(it.id);
+    }
     _clipboardItems.clear();
     _clipboardLastModified = DateTime.now().millisecondsSinceEpoch;
     return count;

--- a/lib/server_service.dart
+++ b/lib/server_service.dart
@@ -876,7 +876,8 @@ class ServerService {
     return mimeTypes[extension] ?? 'application/octet-stream';
   }
 
-  Future<Response> _thumbnailHandler(Request request, String id) async {
+  Future<Response> _thumbnailHandler(Request request, String id,
+      {String? filenameHint}) async {
     final storagePath = _safDirectoryUri ?? _fallbackStoragePath;
     if (storagePath == null || _thumbnailCacheDir == null) {
       return Response.internalServerError(body: 'Server directory not initialized.');
@@ -884,9 +885,12 @@ class ServerService {
 
     try {
       final decoded = utf8.decode(base64Url.decode(id));
-      final filename = Platform.isAndroid && _safDirectoryUri != null 
-          ? Uri.parse(decoded).pathSegments.last 
-          : p.basename(decoded);
+      // #209: ネストした SAF パス由来の呼び出しでは URI 末尾に `/` が混じり得るので
+      //       呼び出し側のヒントを優先する。無ければ従来のロジック。
+      final filename = filenameHint ??
+          (Platform.isAndroid && _safDirectoryUri != null
+              ? Uri.parse(decoded).pathSegments.last
+              : p.basename(decoded));
 
       if (!_isImageFile(filename)) {
         return Response.badRequest(body: 'File is not an image.');
@@ -946,7 +950,26 @@ class ServerService {
       return Response.badRequest(body: 'Invalid path.');
     }
     if (Platform.isAndroid && _safDirectoryUri != null) {
-      return Response.notFound('Path-based access not supported on Android SAF.');
+      // #209: SAF ツリー配下の相対パスを Kotlin 側で walk して document URI を得る
+      try {
+        final resolvedUri = await _safPlatform.invokeMethod<String>(
+          'resolvePath',
+          {'uri': _safDirectoryUri, 'path': relPath},
+        );
+        if (resolvedUri == null) {
+          return Response.notFound('File not found.');
+        }
+        final id = base64Url.encode(utf8.encode(resolvedUri));
+        return _thumbnailHandler(request, id, filenameHint: p.basename(relPath));
+      } on PlatformException catch (e) {
+        if (e.code == 'NOT_FOUND' || e.code == 'NOT_FILE') {
+          return Response.notFound('File not found.');
+        }
+        if (e.code == 'INVALID_PATH') {
+          return Response.badRequest(body: 'Invalid path.');
+        }
+        return Response.internalServerError(body: 'SAF resolve failed: ${e.message}');
+      }
     }
     final canonicalRoot =
         await Directory(storagePath).resolveSymbolicLinks();

--- a/lib/server_service.dart
+++ b/lib/server_service.dart
@@ -49,6 +49,16 @@ class ClipboardItem {
   };
 }
 
+// #218: UUID v4 (random) を生成して `xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx` 形式で返す
+String _generateUuidV4() {
+  final r = Random.secure();
+  final bytes = List<int>.generate(16, (_) => r.nextInt(256));
+  bytes[6] = (bytes[6] & 0x0F) | 0x40;
+  bytes[8] = (bytes[8] & 0x3F) | 0x80;
+  final hex = bytes.map((b) => b.toRadixString(16).padLeft(2, '0')).join();
+  return '${hex.substring(0, 8)}-${hex.substring(8, 12)}-${hex.substring(12, 16)}-${hex.substring(16, 20)}-${hex.substring(20)}';
+}
+
 class ServerService {
   static const _safPlatform = MethodChannel('com.ictglab.localnode/saf_storage');
   static const _folderPlatform = MethodChannel('com.ictglab.localnode/folder');
@@ -72,6 +82,8 @@ class ServerService {
   bool _clipboardEnabled = true;
   String _serverName = 'LocalNode';
   String _appVersion = '';
+  // #218 / §1.11: 端末識別 UUID。SharedPreferences で永続化。
+  String _deviceId = '';
   int _startedAt = 0; // サーバ起動タイムスタンプ（エポックミリ秒）
 
   // クリップボード共有用
@@ -144,6 +156,17 @@ class ServerService {
     final packageInfo = await PackageInfo.fromPlatform();
     final appName = packageInfo.appName;
     _appVersion = packageInfo.version;
+
+    // #218: 端末識別 UUID を SharedPreferences から復元、無ければ生成して保存
+    final prefs = await SharedPreferences.getInstance();
+    final stored = prefs.getString('device_id');
+    if (stored != null && stored.isNotEmpty) {
+      _deviceId = stored;
+    } else {
+      _deviceId = _generateUuidV4();
+      await prefs.setString('device_id', _deviceId);
+    }
+
     final docDir = await getApplicationDocumentsDirectory();
 
     // デフォルトパスを設定
@@ -410,6 +433,8 @@ class ServerService {
       'authMode': _authMode == AuthMode.fixedPin ? 'fixedPin' : _authMode == AuthMode.noPin ? 'noPin' : 'randomPin',
       'requiresAuth': _authMode != AuthMode.noPin,
       'clipboardEnabled': _clipboardEnabled,
+      // #218: federation 識別子
+      'deviceId': _deviceId,
     };
     return Response.ok(json.encode(info),
         headers: {'Content-Type': 'application/json'});

--- a/lib/server_service.dart
+++ b/lib/server_service.dart
@@ -106,6 +106,16 @@ class ServerService {
       _clipboardDeletes.removeAt(0);
     }
   }
+
+  // #230: 件数超過時の退避。非 important から先に削る。全部 important なら最古から退避。
+  ClipboardItem _evictClipboardItem() {
+    for (var i = _clipboardItems.length - 1; i >= 0; i--) {
+      if (!_clipboardItems[i].important) {
+        return _clipboardItems.removeAt(i);
+      }
+    }
+    return _clipboardItems.removeLast();
+  }
   // #227: 1.6.0 で 10 → 1000 にデフォルト値を引き上げ
   // GUI アプリは現状 YAML config を読み込まないので hardcoded。
   // federation (#218) で GUI 側の config 配線が入った時点で設定化される予定。
@@ -1442,7 +1452,7 @@ class ServerService {
 
       // 最大件数を超えたら古いものを削除 (#228 でリングバッファに記録)
       while (_clipboardItems.length > _maxClipboardItems) {
-        final evicted = _clipboardItems.removeLast();
+        final evicted = _evictClipboardItem();
         _recordDeletion(evicted.id);
       }
 
@@ -1521,7 +1531,8 @@ class ServerService {
     _clipboardItems.insert(0, item);
 
     while (_clipboardItems.length > _maxClipboardItems) {
-      _clipboardItems.removeLast();
+      final evicted = _evictClipboardItem();
+      _recordDeletion(evicted.id);
     }
 
     _clipboardLastModified = DateTime.now().millisecondsSinceEpoch;

--- a/lib/server_service.dart
+++ b/lib/server_service.dart
@@ -462,6 +462,10 @@ class ServerService {
       'clipboardEnabled': _clipboardEnabled,
       // #218: federation 識別子
       'deviceId': _deviceId,
+      // #206: Web UI が PIN 入力モードを切り替えるためのヒント。
+      // GUI アプリは現状デフォルト固定 (CLI が --pin-length / --pin-charset を持つ)
+      'pinCharset': 'digits',
+      'pinLength': 4,
     };
     return Response.ok(json.encode(info),
         headers: {'Content-Type': 'application/json'});

--- a/lib/server_service.dart
+++ b/lib/server_service.dart
@@ -33,12 +33,15 @@ class ClipboardItem {
   final String text;
   final String? tag;
   final DateTime createdAt;
+  // #220 / #230: @up 付きで投稿された / federation 経由で「重要」マーク済み
+  final bool important;
 
   ClipboardItem({
     required this.id,
     required this.text,
     this.tag,
     required this.createdAt,
+    this.important = false,
   });
 
   Map<String, dynamic> toJson() => {
@@ -46,6 +49,7 @@ class ClipboardItem {
     'text': text,
     'tag': tag,
     'createdAt': createdAt.toUtc().toIso8601String(),
+    'important': important,
   };
 }
 
@@ -1399,7 +1403,7 @@ class ServerService {
     try {
       final body = await request.readAsString();
       final params = json.decode(body) as Map<String, dynamic>;
-      final text = (params['text'] as String?)?.trim();
+      var text = (params['text'] as String?)?.trim();
       final rawTag = (params['tag'] as String?)?.trim();
       final tag = (rawTag != null && rawTag.isNotEmpty) ? rawTag : null;
 
@@ -1417,11 +1421,21 @@ class ServerService {
         );
       }
 
+      // #220: `@up ` プレフィックスで important マーク + プレフィックス剥がし
+      bool important = false;
+      if (text == '@up' || text.startsWith('@up ')) {
+        if (text.length > 4) {
+          important = true;
+          text = text.substring(4).trimLeft();
+        }
+      }
+
       final item = ClipboardItem(
         id: _generateClipboardId(),
         text: text,
         tag: tag,
         createdAt: DateTime.now(),
+        important: important,
       );
 
       _clipboardItems.insert(0, item);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1022,7 +1022,7 @@ packages:
     source: hosted
     version: "6.6.1"
   yaml:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: yaml
       sha256: b9da305ac7c39faa3f030eccd175340f968459dae4af175130b3fc47e40d76ce

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.5.1+1
+version: 1.6.0+1
 
 environment:
   sdk: '>=3.4.3 <4.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -58,6 +58,7 @@ dependencies:
   path: ^1.9.0
   basic_utils: ^5.8.2
   window_manager: ^0.4.3
+  yaml: ^3.1.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary

LocalNode v1.6.0 — three themes:

1. **Federation** (parent-child server pairing, CLI only) — #218 #221 #222 #228 #219 #220 #230 #223 #224 #225
2. **Clipboard scalability** — #227 #228 #229 (default 10 → 1000 items, differential / paginated API, filter + search + paged render)
3. **Operational quality of life** — #185 (`--config` YAML), #206 (PIN length 4-8 / charset), #225 (mobile mention picker), #224 (`@list` descriptions), #209 (Android SAF nested-path thumbnails)

Full per-issue write-ups are in [\`work/1.6.0_release.md\`](https://github.com/koto2730/localnode/blob/version/1.6.0/work/1.6.0_release.md) (English, dev-facing) and the formal spec lives in [\`work/1.6.0_spec.md\`](https://github.com/koto2730/localnode/blob/version/1.6.0/work/1.6.0_spec.md).

## Headline changes

### Federation (parent ↔ child, CLI only)

- YAML \`children:\` / \`parent:\` config blocks, validated at startup (#218): HTTPS required, fixed Bearer token required, relation must be \`friendly\` | \`equally\`.
- Stable per-server \`device_id\` (UUID v4) persisted to user state dir (CLI) / SharedPreferences (GUI). Exposed via \`/api/info\`.
- Loop guard via \`x-fed-origin\` / \`x-fed-seen-by\` headers + middleware drop before auth (#221).
- 45 s heartbeat to each peer (\`GET /api/health\`); status \`connected\` / \`offline\` / \`paused\` surfaced via \`/api/federation/status\` and colored chips in the Web UI header (#222).
- Event forwarding (clipboard + file uploads) (#219). \`friendly\` forwards everything; \`equally\` gates on \`@up …\`. Files stream to \`/api/upload?path=children/<our-name>\`. 2-3 retries with exponential backoff. \`trust: true\` deletes locally on success. Parent enforces \`max_upload_size\` (413 + clipboard breadcrumb).
- Reserved mentions: \`@up\`, \`@to <child|all>\`, \`@run_to <child> <alias>\`, \`@list <child>\` (#220). CLI rejects \`--mention-action\` for any of these names.
- \`@up\` items survive FIFO eviction (#230): cap-enforcing eviction prefers non-important entries; falls back to oldest important only when every retained entry is already important (no hard pinning).
- Pause per peer (#223): \`POST /api/federation/peers/<name>/pause?duration=<sec>\` with 5 presets (30 min / 1 h / 3 h / 12 h / 24 h). Outbound skip + inbound 503 (\`{paused:true}\`). Heartbeat continues. Non-persistent across restart. Web UI chip-click toggles.

### Clipboard scalability

- Default \`max_items\` 10 → 1000; tunable in YAML (#227).
- Differential / paginated GET API: \`?since=<ms>\`, \`?before=<ms>\`, \`?limit=N\` with a 200-entry deletion ring buffer and \`refresh: true\` flag on overflow (#228). Web UI uses differential polling.
- Web UI clipboard panel: case-insensitive substring search + multi-select tag chips (filters compose AND), filter state in \`localStorage\`, paged rendering (100 + \`もっと見る\`), TXT export honors active filter (#229). Hidden when items < 5.

### CLI configuration

- \`--config <path>\` YAML loader (#185). CLI args override config. Reserves \`children:\` / \`parent:\` / \`clipboard:\` keys without warnings. See \`examples/config.example.yaml\`.

### PIN strengthening (#206)

- \`--pin-length N\` (4..8, default 4), \`--pin-charset digits|alnum|alnum_symbols\` (default \`digits\`). YAML equivalents under \`server.\`. \`Random.secure()\` used.
- \`/api/info\` exposes \`pinCharset\` / \`pinLength\`; Web UI PIN modal switches \`inputmode\` / \`pattern\` / autocapitalize accordingly.
- GUI server reports defaults (\`digits\` / \`4\`); no app-side settings UI in this release.

### Mention UX

- \`@list\` formats each \`mention_actions[]\` entry with its YAML \`description:\` when present: \`@run alias — <description>\` (#224).
- Web UI mention picker (\`@\` button next to clipboard input) backed by new \`GET /api/mentions\`. Tap-to-insert at caret, \`sessionStorage\` cache (5 min TTL) (#225).

## Bug fixes

- Android (SAF storage server): \`@file:<relpath>\` inline thumbnails now work for nested paths (#209). New Kotlin \`resolvePath\` MethodChannel walks the document tree via \`DocumentFile.findFile()\`; Dart side reuses the existing SAF thumbnail pipeline with a \`filenameHint\` so cache filenames don't contain \`/\` from nested document IDs.

## Wontfix / deferred

- #184 (Windows \`.ps1\` direct invocation): closed as wontfix. The \`.bat\` wrapper workaround (\`pwsh -NoProfile -File "%~dp0script.ps1" %*\`) is reliable and sidesteps Windows shell + Dart \`Process.run\` + PowerShell quoting interactions.
- #160 (Linux/WSL libEGL warnings): deferred, low priority.
- #181 (post-action wildcard mixed with specific patterns): not reproducible against current dispatcher in any tested scenario (sequential / 30-parallel / slow-script / subfolder). Listed in \`work/1.6.0_check.md\` for one real-device confirmation; close after that passes.

## Test plan

- [ ] Spec parity walk-through in [\`work/1.6.0_check.md\`](https://github.com/koto2730/localnode/blob/version/1.6.0/work/1.6.0_check.md) across CLI + each GUI target (Android, iOS, macOS).
- [ ] Federation pair smoke: parent (CLI) ↔ child (CLI), both HTTPS, fixed Bearer tokens. Round-trip clipboard, file upload, mention \`@to\`/\`@run_to\`/\`@list\`/\`@up\`, pause/resume, loop guard (self-paired).
- [ ] Clipboard at scale: post >1000 items, observe FIFO eviction; verify differential poll keeps payload small.
- [ ] Web UI clipboard filter / search / paged render on both desktop and mobile viewports.
- [ ] PIN modal input mode switch with \`--pin-charset alnum_symbols --pin-length 8\` on mobile.
- [ ] Android SAF: clipboard \`@file:photos/img.png\` (and a 2-level nested path) renders an inline thumbnail.
- [ ] CLI \`--config\` round-trip with \`examples/config.example.yaml\` derivative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)