### PR TITLE
Hotfix v1.6.0 — Windows build: silence experimental/coroutine deprecation

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -540,10 +540,10 @@ packages:
     dependency: "direct main"
     description:
       name: permission_handler
-      sha256: bc917da36261b00137bbc8896bf1482169cd76f866282368948f032c8c1caae1
+      sha256: fe54465bcc62a4564c6e4db337bbaded6c0c0fa6e10487414436d163114784f6
       url: "https://pub.dev"
     source: hosted
-    version: "12.0.1"
+    version: "12.0.3"
   permission_handler_android:
     dependency: transitive
     description:

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -32,6 +32,14 @@ set(CMAKE_CXX_FLAGS_PROFILE "${CMAKE_CXX_FLAGS_RELEASE}")
 # Use Unicode for all projects.
 add_definitions(-DUNICODE -D_UNICODE)
 
+# permission_handler_windows 0.2.1 (latest on pub.dev, last released 2024-01-17)
+# still includes <experimental/coroutine>, which MSVC 14.51+ (Visual Studio 18,
+# the runner image since 2026) turned from a deprecation warning into a hard
+# static_assert error. Silence it project-wide until the upstream plugin
+# migrates to <coroutine>. Tracked here, not in upstream, because the plugin
+# is unmaintained at pub.dev (no release in ~2 years).
+add_definitions(-D_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS)
+
 # Compilation settings that should be applied to most targets.
 #
 # Be cautious about adding new options here, as plugins use this function by


### PR DESCRIPTION
## Summary

Re-merge of version/1.6.0 into main with the Windows build fix on top of #231.

Windows Release Build on the runner image started failing after Visual Studio 18 (MSVC 14.51, ~2026-06) escalated the \`<experimental/coroutine>\` deprecation message into a hard \`static_assert\` error inside \`permission_handler_windows\`. The plugin is unmaintained on pub.dev (0.2.1 last released 2024-01-17), so a transitive bump is not available.

## Fix

- Defined \`_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS\` project-wide in \`windows/CMakeLists.txt\` (alongside the existing \`UNICODE\` definitions). \`add_definitions()\` propagates to plugin subprojects, so \`permission_handler_windows\` builds again.
- Bumped \`permission_handler\` 12.0.1 → 12.0.3 (patch release, no other transitive churn).

The silence macro is a workaround, not a migration; the proper fix is upstream moving to \`<coroutine>\`. Will revisit when permission_handler_windows updates.

## Test plan

- [ ] Release Build (windows-x64) succeeds end-to-end
- [ ] No regression in other targets (linux, android, macos, ios)

🤖 Generated with [Claude Code](https://claude.com/claude-code)