### PR TITLE
Hotfix: disable Swift Package Manager in iOS/macOS CI to restore plugin Pod install

### DIFF
--- a/ios/ci_scripts/ci_post_clone.sh
+++ b/ios/ci_scripts/ci_post_clone.sh
@@ -15,6 +15,13 @@ export PATH="$PATH:$HOME/flutter/bin"
 # 2. プロジェクトルートに戻ってFlutter設定
 # ci_scripts の中から実行されるので、cd ../.. でルートに戻る
 cd ../..
+
+# Flutter 3.32+ で SPM が default ON になった。Xcode project 側に SPM の
+# 配線が無いため、SPM 対応プラグイン (device_info_plus 12.x など) が
+# Pod に取り込まれず "Module 'device_info_plus' not found" になる。
+# Pod-only モードに固定して、全プラグインを従来通り CocoaPods 経由で統合する。
+flutter config --no-enable-swift-package-manager
+
 flutter precache --ios
 flutter pub get
 

--- a/macos/ci_scripts/ci_post_clone.sh
+++ b/macos/ci_scripts/ci_post_clone.sh
@@ -16,6 +16,12 @@ export PATH="$PATH:$HOME/flutter/bin"
 # ci_scripts の中から実行されるので、cd ../.. でルートに戻る
 cd ../..
 flutter config --enable-macos-desktop
+
+# Flutter 3.32+ で SPM が default ON。Xcode project 側に SPM の配線が無いと
+# SPM 対応プラグイン (device_info_plus 12.x など) が Pod に取り込まれず
+# "Module 'XXX' not found" でビルドが落ちる。Pod-only モードに固定する。
+flutter config --no-enable-swift-package-manager
+
 flutter precache --macos
 flutter pub get
 


### PR DESCRIPTION
## Summary

Re-merge of \`version/1.6.0\` into \`main\` with the Xcode Cloud build fix on top of #244.

## Failure observed

Xcode Cloud iOS build started failing with:

\`\`\`
Module 'device_info_plus' not found
  GeneratedPluginRegistrant.m:12
\`\`\`

and \`xcodebuild archive\` then bailed with \`exit-code 65\`. The xcodebuild step is the symptom; the actual giveaway is in the preceding \`pod install\` output:

\`\`\`
This will become an error in a future version of Flutter. Please contact
the plugin maintainers to request Swift Package Manager adoption.

Installing Flutter (1.0.0)
Installing file_saver (0.0.1)
Installing permission_handler_apple (9.3.0)
... 3 dependencies from the Podfile and 3 total pods installed.
\`\`\`

Only 3 of the 10 Podfile dependencies were installed (locally the same step installs 14). The CI's stable Flutter now has \`enable-swift-package-manager\` defaulted ON, so SPM-ready plugins (\`device_info_plus\` 12.3.0, \`file_picker\`, \`network_info_plus\`, \`package_info_plus\`, \`path_provider\`, \`shared_preferences\`, \`wakelock_plus\`) get routed through SPM — but this iOS/macOS project doesn't yet have SPM wiring, so \`GeneratedPluginRegistrant.m\` imports come up empty.

## Fix

Force-disable SPM at the start of both \`ci_post_clone.sh\` scripts:

\`\`\`sh
flutter config --no-enable-swift-package-manager
\`\`\`

CocoaPods integration is fully functional on this project and every plugin is Pod-compatible. Verified locally by toggling the flag off and running \`pod install\` — 14 pods installed, identical to the long-standing working state.

Adopting SPM properly (Xcode project work + Podfile cleanup) is a separate piece of work and will be tracked separately; getting CI green takes priority.

## Test plan

- [ ] Xcode Cloud iOS Release Build succeeds end-to-end
- [ ] Xcode Cloud macOS Release Build succeeds end-to-end
- [ ] GitHub Actions \`Release Build and Deploy\` (Windows/Linux/Android) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)