### PR TITLE
Security: path containment on download/delete/thumbnail + unspoofable lockout key

### DIFF
--- a/bin/localnode_cli.dart
+++ b/bin/localnode_cli.dart
@@ -2098,10 +2098,16 @@ class _CliServer {
     return base64Url.encode(List.generate(8, (_) => r.nextInt(256)));
   }
 
+  // ブルートフォースのロックアウト等で使うクライアント識別子。
+  // X-Forwarded-For / X-Real-IP はクライアントが自由に詐称でき、LocalNode は
+  // 信頼できるリバースプロキシ配下にいる前提ではないため **使わない**。
+  // shelf が握っている実 TCP リモートアドレスを使う (詐称不能)。
   String _getClientIp(Request req) {
-    final fwd = req.headers['x-forwarded-for'];
-    if (fwd != null && fwd.isNotEmpty) return fwd.split(',').first.trim();
-    return req.headers['x-real-ip'] ?? 'unknown';
+    final conn = req.context['shelf.io.connection_info'];
+    if (conn is HttpConnectionInfo) {
+      return conn.remoteAddress.address;
+    }
+    return 'unknown';
   }
 
   String _getMimeType(String filename) {
@@ -2140,6 +2146,34 @@ class _CliServer {
       json.encode({'error': 'This server is in download-only mode.'}),
       headers: {'Content-Type': 'application/json'},
     );
+  }
+
+  /// id (base64url(絶対パス)) をデコードし、共有ルート配下に収まっていることを
+  /// 検証する。id はクライアント制御なので、全ての id デコード系ハンドラは
+  /// ファイルを開く/消す前にこれを通すこと (path traversal 防止)。
+  /// 正常時は解決済みの File を返し、範囲外/不正なら null + 適切な Response を返す。
+  Future<({File? file, Response? error})> _resolveSharedFile(String id) async {
+    String filePath;
+    try {
+      filePath = utf8.decode(base64Url.decode(id));
+    } catch (_) {
+      return (file: null, error: Response.badRequest(body: 'Invalid id.'));
+    }
+    final file = File(filePath);
+    if (!await file.exists()) {
+      return (file: null, error: Response.notFound('File not found.'));
+    }
+    try {
+      final canonicalRoot =
+          await Directory(_storagePath!).resolveSymbolicLinks();
+      final canonicalFile = await file.resolveSymbolicLinks();
+      if (!p.isWithin(canonicalRoot, canonicalFile)) {
+        return (file: null, error: Response.forbidden('Access denied'));
+      }
+    } catch (_) {
+      return (file: null, error: Response.forbidden('Access denied'));
+    }
+    return (file: file, error: null);
   }
 
   // --- 認証ミドルウェア ---
@@ -2574,9 +2608,11 @@ class _CliServer {
 
   Future<Response> _downloadHandler(Request req, String id) async {
     try {
-      final filePath = utf8.decode(base64Url.decode(id));
-      final file = File(filePath);
-      if (!await file.exists()) return Response.notFound('File not found.');
+      // path traversal 防止: 共有ルート配下のファイルだけ許可
+      final resolved = await _resolveSharedFile(id);
+      if (resolved.error != null) return resolved.error!;
+      final file = resolved.file!;
+      final filePath = file.path;
       final mimeType = _getMimeType(p.basename(filePath));
       final length = await file.length();
       // #200: Range リクエスト対応 (動画サムネ生成等で部分取得を可能に)
@@ -2803,7 +2839,12 @@ class _CliServer {
       return Response.internalServerError(body: 'Server not initialized.');
     }
     try {
-      final filePath = utf8.decode(base64Url.decode(id));
+      // path traversal 防止: 共有ルート配下のファイルだけ許可。
+      // (キャッシュ参照より先に検証する — 範囲外パスのキャッシュ汚染も防ぐ)
+      final resolved = await _resolveSharedFile(id);
+      if (resolved.error != null) return resolved.error!;
+      final src = resolved.file!;
+      final filePath = src.path;
       final filename = p.basename(filePath);
       if (!_isImage(filename)) {
         return Response.badRequest(body: 'Not an image.');
@@ -2813,8 +2854,6 @@ class _CliServer {
         return Response.ok(cache.openRead(),
             headers: {'Content-Type': 'image/jpeg'});
       }
-      final src = File(filePath);
-      if (!await src.exists()) return Response.notFound('File not found.');
       final bytes = await src.readAsBytes();
       final image = img.decodeImage(bytes);
       if (image == null) {
@@ -2888,16 +2927,16 @@ class _CliServer {
     final guard = _guardDownloadOnly();
     if (guard != null) return guard;
     try {
-      final filePath = utf8.decode(base64Url.decode(id));
-      final file = File(filePath);
-      if (await file.exists()) {
-        await file.delete();
-        final cache = File(
-            p.join(_thumbnailCacheDir!.path, '${p.basename(filePath)}.jpg'));
-        if (await cache.exists()) await cache.delete();
-        return Response.ok('File deleted.');
-      }
-      return Response.internalServerError(body: 'File not found.');
+      // path traversal 防止: 共有ルート配下のファイルだけ削除を許可
+      final resolved = await _resolveSharedFile(id);
+      if (resolved.error != null) return resolved.error!;
+      final file = resolved.file!;
+      final filePath = file.path;
+      await file.delete();
+      final cache = File(
+          p.join(_thumbnailCacheDir!.path, '${p.basename(filePath)}.jpg'));
+      if (await cache.exists()) await cache.delete();
+      return Response.ok('File deleted.');
     } catch (e) {
       return Response.internalServerError(body: 'Delete failed: $e');
     }

--- a/lib/server_service.dart
+++ b/lib/server_service.dart
@@ -429,16 +429,16 @@ class ServerService {
     }
   }
 
+  // ブルートフォースのロックアウト等で使うクライアント識別子。
+  // X-Forwarded-For / X-Real-IP はクライアントが自由に詐称でき、LocalNode は
+  // 信頼できるリバースプロキシ配下にいる前提ではないため **使わない**。
+  // shelf が握っている実 TCP リモートアドレスを使う (詐称不能)。
   String _getClientIp(Request request) {
-    // X-Forwarded-For ヘッダーがあれば使用（プロキシ経由の場合）
-    final forwarded = request.headers['x-forwarded-for'];
-    if (forwarded != null && forwarded.isNotEmpty) {
-      return forwarded.split(',').first.trim();
+    final conn = request.context['shelf.io.connection_info'];
+    if (conn is HttpConnectionInfo) {
+      return conn.remoteAddress.address;
     }
-    // 直接接続の場合はコンテキストから取得を試みる
-    // shelf ではリクエストコンテキストからIPを取得できないため、
-    // デフォルトでは 'unknown' を返す
-    return request.headers['x-real-ip'] ?? 'unknown';
+    return 'unknown';
   }
 
   /// ヘルスチェック: 認証不要。クライアントがサーバ再起動を検知するために使用
@@ -915,6 +915,13 @@ class ServerService {
         if (!await file.exists()) {
           return Response.notFound('File not found: $filename');
         }
+        // path traversal 防止: 共有ルート配下のファイルだけ許可
+        final canonicalRoot =
+            await Directory(storagePath).resolveSymbolicLinks();
+        final canonicalFile = await file.resolveSymbolicLinks();
+        if (!p.isWithin(canonicalRoot, canonicalFile)) {
+          return Response.forbidden('Access denied');
+        }
         imageBytes = await file.readAsBytes();
       }
 
@@ -1239,6 +1246,14 @@ class ServerService {
         final filePath = decoded;
         final file = File(filePath);
         if (await file.exists()) {
+          // path traversal 防止: 共有ルート配下のファイルだけ削除を許可。
+          // (id はクライアント制御なので、download ハンドラと同じ検証を行う)
+          final canonicalRoot =
+              await Directory(storagePath).resolveSymbolicLinks();
+          final canonicalFile = await file.resolveSymbolicLinks();
+          if (!p.isWithin(canonicalRoot, canonicalFile)) {
+            return Response.forbidden('Access denied');
+          }
           await file.delete();
           deleted = true;
         }


### PR DESCRIPTION
## Summary

Fixes the High-severity findings from the v1.6.0 static security review (`work/1.6.0_security_report.md`). Re-merge of `version/1.6.0` into `main`.

A path-traversal containment check (`resolveSymbolicLinks` + `p.isWithin`) was present on most file handlers but **missing on the single-file download, delete, and thumbnail handlers**. Because the file id is `base64url(absolute path)` and fully client-controlled, a forged id allowed reading or deleting files outside the shared folder. These checks had been added reactively per Copilot review over time, never systematically, so the unflagged handlers stayed vulnerable since 1.0.0.

## Findings fixed

- **#1 (High)** — Arbitrary file **read** via `GET /api/download/<id>` (CLI). No containment check. Confirmed: `/etc/hosts` and an out-of-share file were both served.
- **#2 (High)** — Arbitrary file **delete** via `DELETE /api/files/<id>` (CLI). Confirmed: an out-of-share file was deleted.
- **#3 (High)** — Same arbitrary delete on the GUI desktop (non-SAF) `_deleteFileHandler`.
- **#4 (High)** — Brute-force **lockout bypass**: the 5-attempt PIN lockout was keyed on the spoofable `X-Forwarded-For` / `X-Real-IP` headers. An attacker rotating XFF got a fresh bucket per request. LocalNode isn't behind a trusted proxy.
- **#5 (Medium)** — Arbitrary image read via `GET /api/thumbnail/<id>` (CLI + GUI desktop).

In `--no-pin` mode #1/#2/#5 were unauthenticated; with a PIN they were reachable by any authenticated client (and the PIN was brute-forceable via #4).

## Fixes

1. New CLI helper `_resolveSharedFile(id)` — decodes the id, verifies existence + containment within the canonical storage root, returns the validated `File` or an error `Response`. Applied to download, delete, thumbnail (thumbnail validates before cache lookup so an out-of-root path can't poison the cache).
2. GUI server: same `p.isWithin` guard added to the desktop branch of `_deleteFileHandler` and `_thumbnailHandler`. Download already had it; Android SAF is constrained by the granted-tree permission scope.
3. `_getClientIp` (CLI + GUI): stop trusting `X-Forwarded-For` / `X-Real-IP`; key the lockout on shelf's real TCP `connection_info.remoteAddress`, which the client can't spoof.

## Verification (empirical, pre/post)

| attack | before | after |
|--------|--------|-------|
| download out-of-share / `/etc/hosts` | served | **403 Access denied** |
| delete out-of-share | deleted | **403, file intact** |
| in-share download / delete (legit) | — | **200, works** |
| 5 wrong PINs with rotating X-Forwarded-For | never locked | **locked out; correct PIN also rejected during window** |

## Deferred (Low, tracked in #247 for 1.7.0)

SameSite/Secure cookie (#6), timing-safe PIN compare (#7), default-HTTP doc (#8), post/mention-action shell-exec audit (#9). Lower severity, and the Tailnet-centric usage narrows the surface further.

## Test plan

- [ ] Build (Windows/Linux/Android via Actions; iOS/macOS via Xcode Cloud) succeeds
- [ ] Real-device: file download/delete still work for in-share files
- [ ] Real-device: federation unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)