### PR TITLE
Release 1.6.0

### DIFF
--- a/android/app/src/main/kotlin/com/ictglab/localnode/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/ictglab/localnode/MainActivity.kt
@@ -55,6 +55,51 @@ class MainActivity: FlutterActivity() {
                     }
                     result.success(fileList)
                 }
+                "listFilesAtPath" -> {
+                    // #209+ : ルートからの相対パスを辿った先のフォルダの中身を返す。
+                    //         サブフォルダ対応のため、ファイルだけでなくディレクトリも
+                    //         含め、isDirectory フラグを付ける。
+                    val uriString = call.argument<String>("uri")
+                    val relPath = call.argument<String>("path") ?: ""
+                    if (uriString == null) {
+                        result.error("ARGUMENT_ERROR", "URI is required.", null)
+                        return@setMethodCallHandler
+                    }
+                    val segments = relPath.split('/', '\\').filter { it.isNotEmpty() }
+                    if (segments.any { it == ".." || it == "." } || segments.size > 16) {
+                        result.error("INVALID_PATH", "Invalid relative path.", null)
+                        return@setMethodCallHandler
+                    }
+                    try {
+                        var current: DocumentFile? =
+                            DocumentFile.fromTreeUri(context, Uri.parse(uriString))
+                        for (seg in segments) {
+                            val next = current?.findFile(seg)
+                            if (next == null || !next.isDirectory) {
+                                result.error("NOT_FOUND", "Directory not found: $seg", null)
+                                return@setMethodCallHandler
+                            }
+                            current = next
+                        }
+                        val dir = current
+                        if (dir == null || !dir.isDirectory) {
+                            result.error("NOT_FOUND", "Target is not a directory.", null)
+                            return@setMethodCallHandler
+                        }
+                        val list = dir.listFiles().map { f ->
+                            mapOf(
+                                "name" to f.name,
+                                "uri" to f.uri.toString(),
+                                "size" to f.length(),
+                                "modified" to f.lastModified(),
+                                "isDirectory" to f.isDirectory
+                            )
+                        }
+                        result.success(list)
+                    } catch (e: Exception) {
+                        result.error("LIST_FAILED", "Failed to list: ${e.message}", null)
+                    }
+                }
                 "createFile" -> {
                     val uriString = call.argument<String>("uri")
                     val filename = call.argument<String>("filename")

--- a/bin/localnode_cli.dart
+++ b/bin/localnode_cli.dart
@@ -1378,6 +1378,7 @@ class _CliServer {
   String? _storagePath;
   Directory? _webRootDir;
   Directory? _thumbnailCacheDir;
+  late final Uint8List _placeholderThumbBytes = _buildPlaceholderJpeg();
 
   final List<_ClipboardItem> _clipboardItems = [];
   int _clipboardLastModified = 0;
@@ -2125,7 +2126,7 @@ class _CliServer {
   }
 
   bool _isImage(String filename) {
-    const exts = {'.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp'};
+    const exts = {'.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp', '.heic', '.heif'};
     return exts.contains(p.extension(filename).toLowerCase());
   }
 
@@ -2834,6 +2835,12 @@ class _CliServer {
     return _thumbnailHandler(req, id);
   }
 
+  static Uint8List _buildPlaceholderJpeg() {
+    final placeholder = img.Image(width: 120, height: 120);
+    img.fill(placeholder, color: img.ColorRgb8(180, 180, 180));
+    return Uint8List.fromList(img.encodeJpg(placeholder, quality: 70));
+  }
+
   Future<Response> _thumbnailHandler(Request req, String id) async {
     if (_thumbnailCacheDir == null) {
       return Response.internalServerError(body: 'Server not initialized.');
@@ -2857,7 +2864,8 @@ class _CliServer {
       final bytes = await src.readAsBytes();
       final image = img.decodeImage(bytes);
       if (image == null) {
-        return Response.internalServerError(body: 'Failed to decode image.');
+        return Response.ok(_placeholderThumbBytes,
+            headers: {'Content-Type': 'image/jpeg'});
       }
       final thumb = img.copyResize(image, width: 120);
       final thumbBytes = img.encodeJpg(thumb, quality: 85);

--- a/bin/localnode_cli.dart
+++ b/bin/localnode_cli.dart
@@ -1743,6 +1743,7 @@ class _CliServer {
         req.headers.set(_kFedOrigin, _deviceId);
         req.headers.set(_kFedSeenBy, _deviceId);
         req.headers.set(_kFedEvent, 'clipboard');
+        req.headers.set(_kFedRelation, peer.relation);
         req.write(json.encode({
           'text': item.text,
           // tag: 親側で「どの子から」かが分かるよう自サーバ名を入れる
@@ -1794,6 +1795,7 @@ class _CliServer {
         req.headers.set(_kFedOrigin, _deviceId);
         req.headers.set(_kFedSeenBy, _deviceId);
         req.headers.set(_kFedEvent, 'upload');
+        req.headers.set(_kFedRelation, peer.relation);
         req.contentLength = length;
         await req.addStream(file.openRead());
         final res = await req.close().timeout(const Duration(minutes: 5));
@@ -2184,6 +2186,7 @@ class _CliServer {
   // （HTTP エラー扱いにすると意味のないリトライを誘発しかねないため）。
   static const String _kFedOrigin = 'x-fed-origin';
   static const String _kFedSeenBy = 'x-fed-seen-by';
+  static const String _kFedRelation = 'x-fed-relation';
 
   Middleware get _federationLoopGuard => (inner) {
         return (req) {
@@ -2211,14 +2214,32 @@ class _CliServer {
             if (path != 'api/health' && path != 'api/info') {
               final peer = _federationPeers
                   .firstWhereOrNullExt((p) => p.learnedDeviceId == origin);
-              if (peer != null && peer.isPaused()) {
-                _log('[fed] paused-block ${peer.name} path=$path');
-                return Response(503,
-                    body: json.encode({
-                      'paused': true,
-                      'pauseUntilMs': peer.pauseUntilMs,
-                    }),
-                    headers: {'Content-Type': 'application/json'});
+              if (peer != null) {
+                if (peer.isPaused()) {
+                  _log('[fed] paused-block ${peer.name} path=$path');
+                  return Response(503,
+                      body: json.encode({
+                        'paused': true,
+                        'pauseUntilMs': peer.pauseUntilMs,
+                      }),
+                      headers: {'Content-Type': 'application/json'});
+                }
+                // spec §1.3: relation は双方一致が前提。送信元の relation が
+                // 自分の設定と異なれば連携不可。
+                final senderRelation = req.headers[_kFedRelation];
+                if (senderRelation != null &&
+                    senderRelation.isNotEmpty &&
+                    senderRelation != peer.relation) {
+                  _log('[fed] relation-mismatch ${peer.name}'
+                      ' local=${peer.relation} remote=$senderRelation');
+                  return Response(409,
+                      body: json.encode({
+                        'error': 'relation mismatch',
+                        'local': peer.relation,
+                        'remote': senderRelation,
+                      }),
+                      headers: {'Content-Type': 'application/json'});
+                }
               }
             }
           }
@@ -3200,8 +3221,8 @@ class _CliServer {
   }
 
   /// 子に `@list` を投げる。子側で `@list` の結果が自分の clipboard に
-  /// 投稿され、friendly 転送なら親へ戻ってくる (equally では戻らないので
-  /// equally 子に対しては警告として local clipboard に注記)。
+  /// 子の /api/mentions を直接 GET して結果を自分の clipboard に投稿する。
+  /// friendly/equally 問わず動作する（転送に依存しない）。
   void _dispatchListToChild(String childName) {
     final peer = _federationPeers.firstWhereOrNullExt(
         (p) => p.kind == 'child' && p.name == childName);
@@ -3209,16 +3230,33 @@ class _CliServer {
       _replyToClipboard('@list $childName: child not found');
       return;
     }
-    if (peer.relation == 'equally') {
-      _replyToClipboard(
-          '@list $childName: equally relation — result will not be auto-forwarded');
-    }
     () async {
       try {
-        await _sendBareTextToPeer(peer, '@list');
-        _log('[fed] dispatched @list -> ${peer.name}');
+        _heartbeatClient ??=
+            HttpClient()..connectionTimeout = const Duration(seconds: 10);
+        final uri = Uri.parse('${peer.url}/api/mentions');
+        final req = await _heartbeatClient!.getUrl(uri);
+        req.headers.set('Authorization', 'Bearer ${peer.token}');
+        final res = await req.close().timeout(const Duration(seconds: 10));
+        if (res.statusCode == 200) {
+          final body = await res.transform(utf8.decoder).join();
+          final data = json.decode(body) as Map<String, dynamic>;
+          final items =
+              (data['items'] as List? ?? []).cast<Map<String, dynamic>>();
+          final lines = <String>['[$childName] Mention commands:'];
+          for (final item in items) {
+            final label = item['label'] as String? ?? '';
+            final desc = item['description'] as String? ?? '';
+            lines.add(desc.isNotEmpty ? '  $label — $desc' : '  $label');
+          }
+          _replyToClipboard(lines.join('\n'));
+          _log('[fed] @list $childName ok (${items.length} items)');
+        } else {
+          await res.drain();
+          _replyToClipboard('@list $childName: failed (HTTP ${res.statusCode})');
+        }
       } catch (e) {
-        _log('[fed] @list ${peer.name} fail: $e');
+        _log('[fed] @list $childName fail: $e');
         _replyToClipboard('@list $childName: dispatch failed');
       }
     }();
@@ -3286,6 +3324,7 @@ class _CliServer {
         r.headers.set(_kFedOrigin, _deviceId);
         r.headers.set(_kFedSeenBy, _deviceId);
         r.headers.set(_kFedEvent, 'clipboard');
+        r.headers.set(_kFedRelation, peer.relation);
         r.write(json.encode({'text': text, 'tag': _serverName}));
         final res = await r.close().timeout(const Duration(seconds: 15));
         await res.drain();

--- a/lib/server_service.dart
+++ b/lib/server_service.dart
@@ -78,6 +78,7 @@ class ServerService {
   String? _displayPath; // 表示用のパス
   Directory? _webRootDir; // Webルートディレクトリのパス
   Directory? _thumbnailCacheDir; // サムネイルキャッシュディレクトリ
+  static final Uint8List _placeholderThumbBytes = _buildPlaceholderJpeg();
   String? _pin;
   final Set<String> _sessions = {};
   OperationMode _operationMode = OperationMode.normal;
@@ -907,6 +908,12 @@ class ServerService {
     return mimeTypes[extension] ?? 'application/octet-stream';
   }
 
+  static Uint8List _buildPlaceholderJpeg() {
+    final placeholder = img.Image(width: 120, height: 120);
+    img.fill(placeholder, color: img.ColorRgb8(180, 180, 180));
+    return Uint8List.fromList(img.encodeJpg(placeholder, quality: 70));
+  }
+
   Future<Response> _thumbnailHandler(Request request, String id,
       {String? filenameHint}) async {
     final storagePath = _safDirectoryUri ?? _fallbackStoragePath;
@@ -958,13 +965,18 @@ class ServerService {
 
       final thumbnailBytes = await Isolate.run(() {
         final image = img.decodeImage(imageBytes!);
-        if (image == null) throw Exception('Failed to decode image.');
+        if (image == null) return null;
         final thumb = img.copyResize(image, width: 120);
         return Uint8List.fromList(img.encodeJpg(thumb, quality: 85));
       });
 
+      if (thumbnailBytes == null) {
+        return Response.ok(_placeholderThumbBytes,
+            headers: {'Content-Type': 'image/jpeg'});
+      }
+
       await cacheFile.writeAsBytes(thumbnailBytes);
-      
+
       return Response.ok(thumbnailBytes, headers: {'Content-Type': 'image/jpeg'});
 
     } catch (e) {
@@ -1246,7 +1258,7 @@ class ServerService {
 
   bool _isImageFile(String filename) {
     final extension = p.extension(filename).toLowerCase();
-    const imageExtensions = {'.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp'};
+    const imageExtensions = {'.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp', '.heic', '.heif'};
     return imageExtensions.contains(extension);
   }
 

--- a/lib/server_service.dart
+++ b/lib/server_service.dart
@@ -483,19 +483,46 @@ class ServerService {
 
     // AndroidでSAF URIが設定されている場合は、Platform Channel経由でファイルリストを取得
     if (Platform.isAndroid && _safDirectoryUri != null) {
+      // #209+ : ?path= でサブフォルダもナビゲートできるようにする。SAF はパスでなく
+      //         tree URI ベースなので、Kotlin 側でルートから相対パスを辿って中身を返す。
+      final relPath = request.requestedUri.queryParameters['path'] ?? '';
       try {
-        final List<dynamic>? files = await _safPlatform.invokeMethod('listFiles', {'uri': _safDirectoryUri});
-        if (files == null) {
+        final List<dynamic>? entries = await _safPlatform.invokeMethod(
+          'listFilesAtPath',
+          {'uri': _safDirectoryUri, 'path': relPath},
+        );
+        if (entries == null) {
           return Response.internalServerError(body: 'Failed to list files.');
         }
-        // URIをBase64エンコードしてIDとして追加
-        final filesWithId = files.map((file) {
-          final uri = file['uri'] as String;
+        // URI を Base64 エンコードして ID に。ディレクトリには type を付与。
+        final list = entries.map((e) {
+          final m = Map<String, dynamic>.from(e as Map);
+          final uri = m['uri'] as String;
           final id = base64Url.encode(utf8.encode(uri));
-          return {...file, 'id': id};
+          if (m['isDirectory'] == true) {
+            return {'name': m['name'], 'type': 'directory', 'id': id};
+          }
+          return {
+            'name': m['name'],
+            'type': 'file',
+            'size': m['size'],
+            'modified': m['modified'],
+            'id': id,
+          };
         }).toList();
-        return Response.ok(jsonEncode(filesWithId), headers: {'Content-Type': 'application/json'});
+        // ディレクトリを先頭に、その後ファイル。各群で名前順。
+        list.sort((a, b) {
+          if (a['type'] != b['type']) return a['type'] == 'directory' ? -1 : 1;
+          return (a['name'] as String).compareTo(b['name'] as String);
+        });
+        return Response.ok(jsonEncode(list), headers: {'Content-Type': 'application/json'});
       } on PlatformException catch (e) {
+        if (e.code == 'NOT_FOUND') {
+          return Response.notFound('Directory not found.');
+        }
+        if (e.code == 'INVALID_PATH') {
+          return Response.badRequest(body: 'Invalid path.');
+        }
         return Response.internalServerError(body: "Failed to list files: ${e.message}");
       }
     }


### PR DESCRIPTION
## Summary

- Federation: enforce relation parity (spec §1.3) — reject with 409 when sender's relation doesn't match local config; add `x-fed-relation` header to all outgoing federation requests
- Federation: fix `@list <child>` — directly GET child's `/api/mentions` and post result to parent's own clipboard (no longer depends on clipboard forwarding round-trip)
- Android SAF: subfolder navigation in file listing (`listFilesAtPath`)
- Thumbnail: return 120×120 grey placeholder JPEG instead of 500 on decode failure (HEIC etc.); register `.heic`/`.heif` as image extensions
- Security: path containment on CLI download/delete/thumbnail + lockout key via `HttpConnectionInfo.remoteAddress` (not X-Forwarded-For)
- CI: disable Swift Package Manager in Xcode Cloud to restore plugin Pod install
- Various bug fixes from real-device check rounds 1 & 2

## Test plan

- [ ] Federation: configure child with `relation: equally`, parent with `relation: friendly` → connection refused with 409
- [ ] Federation: configure both as `relation: friendly` → normal operation
- [ ] `@list <child>` → result appears in parent's clipboard immediately above the command entry
- [ ] `@list` on child with parent configured → `@up` appears in the list
- [ ] `@list` on parent with child configured → `@to`, `@run_to` appear in the list
- [ ] Android SAF subfolders visible in browser
- [ ] HEIC/undecodable file thumbnail → grey placeholder shown (no error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)