### PR TITLE
security: narrow Bearer token scope to explicit endpoint list

### DIFF
--- a/bin/localnode_cli.dart
+++ b/bin/localnode_cli.dart
@@ -2307,17 +2307,18 @@ class _CliServer {
           }
           if (token != null && _sessions.contains(token)) return inner(req);
 
-          // #173/#188: Bearer トークンによる API 認証
-          //   - POST /api/upload / POST /api/clipboard … 既存の外部ツール向け
-          //   - federation peer (x-fed-origin あり) は任意の API エンドポイントに
-          //     アクセス可能（@list <child> の GET /api/mentions 等に対応）
+          // #173/#188: Bearer トークンによる API 認証（スコープ限定）
+          //   - POST /api/upload      … ファイルアップロード（#173）
+          //   - POST /api/clipboard   … クリップボードへの送信（#188）
+          //   - GET  /api/mentions    … federation @list <child> 用（#220）
+          // x-fed-origin の有無でスコープを広げない。ヘッダは任意クライアントが
+          // 付加できるため、列挙したエンドポイント以外への昇格には使えない。
           if (_uploadToken != null) {
             final authHeader = req.headers['authorization'] ?? '';
             if (authHeader == 'Bearer $_uploadToken') {
-              final isFedPeer = req.headers[_kFedOrigin] != null;
-              if (isFedPeer ||
-                  (req.method == 'POST' &&
-                      (path == 'api/upload' || path == 'api/clipboard'))) {
+              if ((req.method == 'POST' &&
+                      (path == 'api/upload' || path == 'api/clipboard')) ||
+                  (req.method == 'GET' && path == 'api/mentions')) {
                 return inner(req);
               }
             }


### PR DESCRIPTION
## Summary

Fix security issue introduced in PR #250: Bearer token + `x-fed-origin` header granted access to all API endpoints, but `x-fed-origin` is a client-controlled header — any client with the token could add it to escalate privileges (delete files, delete clipboard, pause peers, etc.).

Reverted to explicit allowlist:
- `POST /api/upload`
- `POST /api/clipboard`
- `GET /api/mentions` ← new (needed for @list \<child\>)

## Impact

PR #250 shipped this vulnerability to main. This PR fixes it immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)