### PR TITLE
fix: null-safe DocumentFile.name + no-op JS cleanup (Copilot review)

### DIFF
--- a/android/app/src/main/kotlin/com/ictglab/localnode/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/ictglab/localnode/MainActivity.kt
@@ -47,7 +47,7 @@ class MainActivity: FlutterActivity() {
 
                     val fileList = documentFile.listFiles().filter { it.isFile }.map { file ->
                         mapOf(
-                            "name" to file.name,
+                            "name" to (file.name ?: ""),
                             "uri" to file.uri.toString(),
                             "size" to file.length(),
                             "modified" to file.lastModified()
@@ -88,7 +88,7 @@ class MainActivity: FlutterActivity() {
                         }
                         val list = dir.listFiles().map { f ->
                             mapOf(
-                                "name" to f.name,
+                                "name" to (f.name ?: ""),
                                 "uri" to f.uri.toString(),
                                 "size" to f.length(),
                                 "modified" to f.lastModified(),

--- a/assets/web/index.html
+++ b/assets/web/index.html
@@ -1283,7 +1283,7 @@
                     const ALLOWED_STATUS = new Set(['connected', 'offline', 'paused', 'relation-mismatch']);
                     const chips = peers.map(p => {
                         const status = ALLOWED_STATUS.has(p.status) ? p.status : 'unknown';
-                        const cls = `fed-peer fed-${status.replace('-', '-')}`;
+                        const cls = `fed-peer fed-${status}`;
                         let label = `${p.name}: ${status}`;
                         if (p.pauseUntilMs && p.pauseUntilMs > now) {
                             const remainSec = Math.round((p.pauseUntilMs - now) / 1000);

--- a/lib/server_service.dart
+++ b/lib/server_service.dart
@@ -514,7 +514,7 @@ class ServerService {
         // ディレクトリを先頭に、その後ファイル。各群で名前順。
         list.sort((a, b) {
           if (a['type'] != b['type']) return a['type'] == 'directory' ? -1 : 1;
-          return (a['name'] as String).compareTo(b['name'] as String);
+          return (a['name'] as String? ?? '').compareTo(b['name'] as String? ?? '');
         });
         return Response.ok(jsonEncode(list), headers: {'Content-Type': 'application/json'});
       } on PlatformException catch (e) {
@@ -573,7 +573,7 @@ class ServerService {
       // フォルダ先頭、名前順でソート
       results.sort((a, b) {
         if (a['type'] != b['type']) return a['type'] == 'directory' ? -1 : 1;
-        return (a['name'] as String).compareTo(b['name'] as String);
+        return (a['name'] as String? ?? '').compareTo(b['name'] as String? ?? '');
       });
       return Response.ok(jsonEncode(results), headers: {'Content-Type': 'application/json'});
     }


### PR DESCRIPTION
## Summary

Copilot review items from PR #249 and #250:

- **#249**: `DocumentFile.name` is nullable in Android SAF API — Kotlin `listFiles` and `listFilesAtPath` now return `f.name ?: ""` instead of raw nullable; Dart sort uses `(String? ?? '')` for safety
- **#250**: `status.replace('-', '-')` in federation UI was a no-op replace; simplified to use `status` directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)