### PR TITLE
fix(fed): auto-create children dir on first file upload (404 fix)

### DIFF
--- a/bin/localnode_cli.dart
+++ b/bin/localnode_cli.dart
@@ -2514,7 +2514,9 @@ class _CliServer {
     final targetDirPath = p.normalize(p.join(canonicalRoot, relPath));
     final dir = Directory(targetDirPath);
     if (!await dir.exists()) {
-      return Response.notFound('Target directory not found.');
+      // federation の children/<childname>/ は初回アップロード時に自動作成する。
+      // パストラバーサルチェック済みなので作成は安全。
+      await dir.create(recursive: true);
     }
     final canonicalTarget = await dir.resolveSymbolicLinks();
     if (canonicalTarget != canonicalRoot &&


### PR DESCRIPTION
## Summary

Federation file upload (child → parent) returned HTTP 404 because the parent's `children/<childname>/` directory did not exist before the first upload. The upload handler was checking for directory existence and returning 404 if missing.

Fix: auto-create the directory on first upload. Path traversal check already passed at this point so creation is safe.

## Test plan

- [ ] Child uploads file with `relation: friendly` → file appears in parent's `children/<childname>/` directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)