### PR TITLE
fix(android): SAF thumbnail white - strip path prefix from cache key

### DIFF
--- a/lib/server_service.dart
+++ b/lib/server_service.dart
@@ -925,9 +925,11 @@ class ServerService {
       final decoded = utf8.decode(base64Url.decode(id));
       // #209: ネストした SAF パス由来の呼び出しでは URI 末尾に `/` が混じり得るので
       //       呼び出し側のヒントを優先する。無ければ従来のロジック。
+      // SAF の pathSegments.last は percent-decode 後に '/' を含む場合がある
+      // (例: "primary:LocalNode/file.png")。p.basename で末尾ファイル名だけにする。
       final filename = filenameHint ??
           (Platform.isAndroid && _safDirectoryUri != null
-              ? Uri.parse(decoded).pathSegments.last
+              ? p.basename(Uri.parse(decoded).pathSegments.last)
               : p.basename(decoded));
 
       if (!_isImageFile(filename)) {


### PR DESCRIPTION
## Summary

Android SAF thumbnails showed white instead of the actual image.

Root cause: `Uri.parse(contentUri).pathSegments.last` returns a percent-decoded string like `primary:LocalNode/2024-06-30 (1).png` — containing a `/`. Using this directly as the cache filename caused `p.join(cacheDir, 'primary:LocalNode/...')` to create a subdirectory path. `writeAsBytes` failed because that subdirectory didn't exist, returning 500. Android WebView renders failed image loads as white (no broken-image icon).

Fix: wrap `pathSegments.last` with `p.basename()` to extract only the actual filename.

## Test plan

- [ ] Upload a PNG from another device to Android LocalNode → thumbnail shows correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)