### PR TITLE
fix(fed): UTF-8 encode clipboard body + SAF thumbnail cache path

### DIFF
--- a/bin/localnode_cli.dart
+++ b/bin/localnode_cli.dart
@@ -1767,11 +1767,11 @@ class _CliServer {
         req.headers.set(_kFedSeenBy, _deviceId);
         req.headers.set(_kFedEvent, 'clipboard');
         req.headers.set(_kFedRelation, peer.relation);
-        req.write(json.encode({
+        req.add(utf8.encode(json.encode({
           'text': item.text,
           // tag: 親側で「どの子から」かが分かるよう自サーバ名を入れる
           'tag': _serverName,
-        }));
+        })));
         final res = await req.close().timeout(const Duration(seconds: 15));
         await res.drain();
 
@@ -3379,7 +3379,7 @@ class _CliServer {
         r.headers.set(_kFedSeenBy, _deviceId);
         r.headers.set(_kFedEvent, 'clipboard');
         r.headers.set(_kFedRelation, peer.relation);
-        r.write(json.encode({'text': text, 'tag': _serverName}));
+        r.add(utf8.encode(json.encode({'text': text, 'tag': _serverName})));
         final res = await r.close().timeout(const Duration(seconds: 15));
         await res.drain();
         if (res.statusCode >= 200 && res.statusCode < 300) return;


### PR DESCRIPTION
## Summary

- **UTF-8 fix**: `HttpClient.write()` uses Latin-1 by default — Japanese and other multibyte text in `@up` / `@to` forwarding failed with "Contains invalid characters". Changed to `req.add(utf8.encode(...))` in `_sendClipboardToPeer` and `_sendBareTextToPeer`
- **SAF thumbnail fix**: `Uri.pathSegments.last` decodes `%2F` to `/`, creating a subdirectory path in the thumbnail cache. Wrapped with `p.basename()` to extract filename only — fixes white thumbnails on Android

## Test plan

- [ ] `@up` with Japanese text from child → forwarded to parent correctly
- [ ] `@to <child>` with Japanese text from parent → delivered to child correctly
- [ ] Upload PNG to Android LocalNode → thumbnail shows correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)