### PR TITLE
v1.6.0: federation features + security hardening

### DIFF
--- a/bin/localnode_cli.dart
+++ b/bin/localnode_cli.dart
@@ -363,10 +363,10 @@ Future<void> main(List<String> args) async {
     final raw = results.wasParsed('pin-length')
         ? results['pin-length'] as String?
         : (cfg?.pinLength?.toString());
-    if (raw == null) return 4;
+    if (raw == null) return 8;
     final n = int.tryParse(raw);
-    if (n == null || n < 4 || n > 8) {
-      stderr.writeln('Error: --pin-length must be an integer 4..8 (got "$raw").');
+    if (n == null || n < 8 || n > 16) {
+      stderr.writeln('Error: --pin-length must be an integer 8..16 (got "$raw").');
       exit(1);
     }
     return n;
@@ -561,8 +561,9 @@ Future<void> main(List<String> args) async {
   stdout.writeln('LocalNode CLI Server');
   stdout.writeln('=' * 40);
 
-  // #173: アップロードトークンの決定（download-only モードでは不要）
-  final String? uploadToken = (!noToken && !downloadOnly)
+  // #173: アップロードトークンの決定（download-only / no-pin モードでは不要）
+  // no-pin では認証がないためトークンを発行しても意味がなく、逆に誤った安心感を与える
+  final String? uploadToken = (!noToken && !downloadOnly && !noPin)
       ? (fixedToken ?? _generateUploadToken())
       : null;
 
@@ -2357,6 +2358,18 @@ class _CliServer {
                   (req.method == 'GET' &&
                       (path == 'api/mentions' ||
                           path.startsWith('api/run/')))) {
+                // F10: x-fed-origin が存在する場合、既知の peer の deviceId と一致するか検証。
+                // 存在しない場合は通常の Bearer 利用（curl 等）として許可。
+                // 一致しない deviceId を使った peer 偽装を防ぐ。
+                final origin = req.headers[_kFedOrigin];
+                if (origin != null &&
+                    !_federationPeers
+                        .any((p) => p.learnedDeviceId == origin)) {
+                  return Response.forbidden(
+                    json.encode({'error': 'Unknown federation origin.'}),
+                    headers: {'Content-Type': 'application/json'},
+                  );
+                }
                 return inner(req);
               }
             }
@@ -2377,7 +2390,7 @@ class _CliServer {
       _sessions.add(token);
       return Response.ok(json.encode({'status': 'success'}), headers: {
         'Content-Type': 'application/json',
-        'Set-Cookie': 'localnode_session=$token; Path=/; HttpOnly',
+        'Set-Cookie': 'localnode_session=$token; Path=/; HttpOnly; SameSite=Strict',
       });
     }
 
@@ -2401,7 +2414,7 @@ class _CliServer {
         _sessions.add(token);
         return Response.ok(json.encode({'status': 'success'}), headers: {
           'Content-Type': 'application/json',
-          'Set-Cookie': 'localnode_session=$token; Path=/; HttpOnly',
+          'Set-Cookie': 'localnode_session=$token; Path=/; HttpOnly; SameSite=Strict',
         });
       } else {
         final attempts = (_failedAttempts[clientIp] ?? 0) + 1;
@@ -2599,13 +2612,18 @@ class _CliServer {
   (String executable, List<String> args) _buildCommand(
       String script, List<String> extraArgs) {
     if (Platform.isWindows) {
+      // cmd.exe メタ文字（& | ^ < > ( ) % ! ;）をアンダースコアに置換して
+      // ファイル名経由のコマンドインジェクションを防ぐ
+      final safeArgs = extraArgs
+          .map((a) => a.replaceAll(RegExp(r'[&|^<>()\%;!]'), '_'))
+          .toList();
       if (script.toLowerCase().endsWith('.ps1')) {
         return (
           'cmd',
-          ['/c', 'powershell.exe', '-ExecutionPolicy', 'Bypass', '-File', script, ...extraArgs]
+          ['/c', 'powershell.exe', '-ExecutionPolicy', 'Bypass', '-File', script, ...safeArgs]
         );
       }
-      return ('cmd', ['/c', script, ...extraArgs]);
+      return ('cmd', ['/c', script, ...safeArgs]);
     }
     return (script, extraArgs);
   }
@@ -3247,10 +3265,11 @@ class _CliServer {
       _forwardClipboardItemWithImportance(item, req, important);
 
       // #174 / #220: メンションコマンド検出
-      // 重要フラグで剥がした text はもうコマンドではないので、元の text で判定する
-      // ためここで再度組み立てる必要はなく、剥がし前の text を扱うべき。
-      // → 改修簡素化のため: important なら mention 検出はスキップ
-      if (!important) {
+      // F11: Bearer トークン経由（federation / curl）からは mention を実行しない。
+      //      ブラウザのセッション Cookie 経由のローカル操作のみ許可。
+      final isBearerRequest =
+          (req.headers['authorization'] ?? '').startsWith('Bearer ');
+      if (!important && !isBearerRequest) {
         await _handleMentionInClipboard(text);
       }
 

--- a/bin/localnode_cli.dart
+++ b/bin/localnode_cli.dart
@@ -1454,6 +1454,7 @@ class _CliServer {
       ..post('/api/files/delete-batch', _deleteBatchHandler)
       ..get('/api/clipboard', _getClipboardHandler)
       ..get('/api/mentions', _mentionsHandler)  // #225
+      ..get('/api/run/<alias>', _runActionHandler)  // #220 @run_to result
       ..post('/api/clipboard', _postClipboardHandler)
       ..delete('/api/clipboard/<id>', _deleteClipboardItemHandler)
       ..delete('/api/clipboard', _clearClipboardHandler)
@@ -1515,6 +1516,41 @@ class _CliServer {
       json.encode({'items': items}),
       headers: {'Content-Type': 'application/json'},
     );
+  }
+
+  /// #220 @run_to: child 側でエイリアスを実行して結果を返す
+  Future<Response> _runActionHandler(Request req, String alias) async {
+    final entry = _mentionActions[alias];
+    if (entry == null) {
+      return Response.notFound(
+        json.encode({'error': 'alias not found: $alias'}),
+        headers: {'Content-Type': 'application/json'},
+      );
+    }
+    try {
+      final cmd = _buildCommand(entry.script, []);
+      final result = await Process.run(
+        cmd.$1, cmd.$2,
+        runInShell: !Platform.isWindows,
+      ).timeout(const Duration(seconds: 30));
+      final ok = result.exitCode == 0;
+      final resultText =
+          ok ? '@run $alias: OK' : '@run $alias: FAILED (exit ${result.exitCode})';
+      if (!ok && (result.stderr as String).isNotEmpty) {
+        stderr.writeln('[mention-action] "$alias" stderr: ${result.stderr}');
+      }
+      _replyToClipboard(resultText);
+      _log('[mention-action] "$alias" via federation -> $resultText');
+      return Response.ok(
+        json.encode({'ok': ok, 'result': resultText}),
+        headers: {'Content-Type': 'application/json'},
+      );
+    } catch (e) {
+      return Response(500,
+        body: json.encode({'error': '$e'}),
+        headers: {'Content-Type': 'application/json'},
+      );
+    }
   }
 
   Response _federationStatusHandler(Request _) => Response.ok(
@@ -2318,7 +2354,9 @@ class _CliServer {
             if (authHeader == 'Bearer $_uploadToken') {
               if ((req.method == 'POST' &&
                       (path == 'api/upload' || path == 'api/clipboard')) ||
-                  (req.method == 'GET' && path == 'api/mentions')) {
+                  (req.method == 'GET' &&
+                      (path == 'api/mentions' ||
+                          path.startsWith('api/run/')))) {
                 return inner(req);
               }
             }
@@ -3318,6 +3356,10 @@ class _CliServer {
             lines.add(desc.isNotEmpty ? '  $label — $desc' : '  $label');
           }
           _replyToClipboard(lines.join('\n'));
+          if (peer.relation == 'equally') {
+            _replyToClipboard(
+                '[$childName] Note: @run_to results will not be forwarded from equally-relation child');
+          }
           _log('[fed] @list $childName ok (${items.length} items)');
         } else {
           await res.drain();
@@ -3356,7 +3398,7 @@ class _CliServer {
     }
   }
 
-  /// `@run_to <name> <alias>` を解決して `@run <alias>` を送信
+  /// `@run_to <name> <alias>` を解決して子の /api/run/<alias> を直接 GET し結果を自分の clipboard に投稿する
   void _dispatchRunToChild(String childName, String alias) {
     final peer = _federationPeers.firstWhereOrNullExt(
         (p) => p.kind == 'child' && p.name == childName);
@@ -3366,8 +3408,27 @@ class _CliServer {
     }
     () async {
       try {
-        await _sendBareTextToPeer(peer, '@run $alias');
-        _log('[fed] @run_to ${peer.name} $alias dispatched');
+        _heartbeatClient ??=
+            HttpClient()..connectionTimeout = const Duration(seconds: 10);
+        final uri = Uri.parse(
+            '${peer.url}/api/run/${Uri.encodeComponent(alias)}');
+        final req = await _heartbeatClient!.getUrl(uri);
+        req.headers.set('Authorization', 'Bearer ${peer.token}');
+        req.headers.set(_kFedRelation, peer.relation);
+        final res =
+            await req.close().timeout(const Duration(seconds: 35));
+        if (res.statusCode == 200) {
+          final body = await res.transform(utf8.decoder).join();
+          final data = json.decode(body) as Map<String, dynamic>;
+          final resultText =
+              data['result'] as String? ?? '@run_to $childName $alias: ok';
+          _replyToClipboard('[$childName] $resultText');
+          _log('[fed] @run_to ${peer.name} $alias ok');
+        } else {
+          await res.drain();
+          _replyToClipboard(
+              '@run_to $childName $alias: failed (HTTP ${res.statusCode})');
+        }
       } catch (e) {
         _log('[fed] @run_to ${peer.name} fail: $e');
         _replyToClipboard('@run_to $childName: dispatch failed');

--- a/lib/server_service.dart
+++ b/lib/server_service.dart
@@ -346,7 +346,7 @@ class ServerService {
   // === Handlers ===
 
   String _generatePin() {
-    return (1000 + Random().nextInt(9000)).toString();
+    return (1000 + Random.secure().nextInt(9000)).toString();
   }
 
   String _generateSessionToken() {
@@ -360,7 +360,7 @@ class ServerService {
     if (_authMode == AuthMode.noPin) {
       final token = _generateSessionToken();
       _sessions.add(token);
-      final cookie = 'localnode_session=$token; Path=/; HttpOnly';
+      final cookie = 'localnode_session=$token; Path=/; HttpOnly; SameSite=Strict';
       return Response.ok(json.encode({'status': 'success'}),
           headers: {'Content-Type': 'application/json', 'Set-Cookie': cookie});
     }
@@ -392,9 +392,9 @@ class ServerService {
         final token = _generateSessionToken();
         _sessions.add(token);
 
-        _log('Auth success: Generated token $token. Current sessions: $_sessions');
+        _log('Auth success. Active sessions: ${_sessions.length}');
 
-        final cookie = 'localnode_session=$token; Path=/; HttpOnly';
+        final cookie = 'localnode_session=$token; Path=/; HttpOnly; SameSite=Strict';
         final headers = {
           'Content-Type': 'application/json',
           'Set-Cookie': cookie,
@@ -713,6 +713,10 @@ class ServerService {
 
       // AndroidでSAF URIが設定されている場合
       if (Platform.isAndroid && _safDirectoryUri != null) {
+        // F1: SAF ツリー外のファイルへのアクセスを拒否
+        if (!decoded.startsWith(_safDirectoryUri!)) {
+          return Response.forbidden('Access denied');
+        }
         final fileUri = decoded;
         final Uint8List? bytes = await _safPlatform.invokeMethod('readFile', {'uri': fileUri});
 
@@ -945,6 +949,10 @@ class ServerService {
       Uint8List? imageBytes;
 
       if (Platform.isAndroid && _safDirectoryUri != null) {
+        // F1: SAF ツリー外のファイルへのアクセスを拒否
+        if (!decoded.startsWith(_safDirectoryUri!)) {
+          return Response.forbidden('Access denied');
+        }
         imageBytes = await _safPlatform.invokeMethod('readFile', {'uri': decoded});
       } else {
         final file = File(decoded);
@@ -1279,6 +1287,10 @@ class ServerService {
 
       // AndroidでSAF URIが設定されている場合
       if (Platform.isAndroid && _safDirectoryUri != null) {
+        // F1: SAF ツリー外のファイルへのアクセスを拒否
+        if (!decoded.startsWith(_safDirectoryUri!)) {
+          return Response.forbidden('Access denied');
+        }
         final fileUri = decoded;
         deleted = await _safPlatform.invokeMethod('deleteFile', {'uri': fileUri});
       } 
@@ -2024,7 +2036,7 @@ class ServerService {
     _failedAttempts.clear();
     _lockoutUntil.clear();
     _startedAt = DateTime.now().millisecondsSinceEpoch;
-    _log('Your PIN is: $_pin');
+    _log('Server starting (auth: ${_authMode.name}).');
 
     try {
       await _init();


### PR DESCRIPTION
## Summary

- Federation: parent/child relation check (409 on mismatch), heartbeat relation sync, relation-mismatch UI
- Federation: @list <child> via direct GET /api/mentions; equally-relation warning
- Federation: @run_to <child> <alias> result returned to parent via /api/run/<alias>
- Federation: UTF-8 body encoding fix for multibyte clipboard posts
- Federation: upload folder derived from parent config (not child-supplied path)
- Android SAF: thumbnail fix (p.basename for pathSegments.last)
- Security hardening (F1/F3/F4/F6/F8/F10/F11/F12): PIN min 8 digits, no-pin drops token, SameSite=Strict cookie, Random.secure() for GUI PIN, Bearer cannot trigger mentions, Windows cmd metachar sanitization, SAF tree-scope checks in download/thumbnail/delete

## Test plan

- [ ] Federation relation mismatch → 409, UI shows red
- [ ] @list <child> returns child mention list; equally child shows forwarding warning
- [ ] @run_to <child> <alias> result appears on parent clipboard
- [ ] Japanese text via @to / @up sends correctly
- [ ] Android SAF thumbnail displays correctly
- [ ] Federation file upload lands in children/<name>/ folder
- [ ] --no-pin mode: no upload token generated
- [ ] PIN length defaults to 8 digits
- [ ] curl @run via Bearer token is ignored (no command execution)

🤖 Generated with [Claude Code](https://claude.com/claude-code)