### PR TITLE
v1.7.0 device-test bugfixes: null-byte 400, PIN validation, 413 message, @-menu 404, cache-clear button, versioned artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -218,10 +218,26 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-android-apk, build-windows, build-linux, build-linux-arm64]
     steps:
+      - uses: actions/checkout@v6
+
+      - name: Extract version from pubspec.yaml
+        id: version
+        run: |
+          VERSION=$(grep '^version:' LocalNode/pubspec.yaml | sed 's/version: *//' | sed 's/+.*//' | tr -d '[:space:]')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
       - name: Download all artifacts
         uses: actions/download-artifact@v8
         with:
           path: artifacts
+
+      - name: Rename artifacts with version
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+          mv artifacts/windows-x64/localnode-windows-x64.zip artifacts/windows-x64/localnode-windows-x64-v${VERSION}.zip
+          mv artifacts/linux-x64/localnode-linux-x64.tar.gz artifacts/linux-x64/localnode-linux-x64-v${VERSION}.tar.gz
+          mv artifacts/linux-arm64/localnode-linux-arm64.tar.gz artifacts/linux-arm64/localnode-linux-arm64-v${VERSION}.tar.gz
+          mv artifacts/android-apk/localnode-android.apk artifacts/android-apk/localnode-android-v${VERSION}.apk
 
       - name: Create Draft Release
         uses: softprops/action-gh-release@v3
@@ -230,10 +246,10 @@ jobs:
           tag_name: build-${{ github.run_number }}
           name: Build ${{ github.run_number }}
           files: |
-            artifacts/windows-x64/localnode-windows-x64.zip
-            artifacts/linux-x64/localnode-linux-x64.tar.gz
-            artifacts/linux-arm64/localnode-linux-arm64.tar.gz
-            artifacts/android-apk/localnode-android.apk
+            artifacts/windows-x64/localnode-windows-x64-v${{ steps.version.outputs.version }}.zip
+            artifacts/linux-x64/localnode-linux-x64-v${{ steps.version.outputs.version }}.tar.gz
+            artifacts/linux-arm64/localnode-linux-arm64-v${{ steps.version.outputs.version }}.tar.gz
+            artifacts/android-apk/localnode-android-v${{ steps.version.outputs.version }}.apk
 
   # ============================================================
   # Google Play デプロイ (AAB)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A Flutter application that transforms your phone or computer into a secure, pers
 *   **HTTPS/TLS Support:** Enable secure connections using your own TLS certificate and private key (e.g., from Tailscale). The SAN-aware selector automatically matches certificate entries to your device's IP addresses.
 *   **Access Control:** Configure download-only mode or disable PIN authentication for trusted networks.
 *   **Easy Connection:** Connect quickly using a QR code or by manually entering the displayed IP address.
-*   **IP Address Selection:** Choose which network interface (e.g., Wi-Fi, Tailscale) to use for serving files.
+*   **IP Address Selection:** Choose which network interface (e.g., Wi-Fi, Tailscale) to use for serving files. IPv4 only; IPv6 is not yet supported (#277).
 *   **Custom Server Name:** Set a custom name displayed in the browser tab and page title.
 *   **Custom Shared Folder:** Select any folder on your device as the shared directory.
 *   **Settings Reset:** Reset all saved settings to defaults with a single button.

--- a/assets/web/index.html
+++ b/assets/web/index.html
@@ -947,8 +947,8 @@
         <div class="pin-box">
             <h2>PIN認証</h2>
             <p>サーバーに接続するにはPINコードを入力してください。</p>
-            <form id="pinForm">
-                <input type="password" id="pinInput" maxlength="20" inputmode="numeric" required autocomplete="one-time-code">
+            <form id="pinForm" novalidate>
+                <input type="password" id="pinInput" maxlength="20" inputmode="numeric" autocomplete="one-time-code">
                 <button type="submit">接続</button>
             </form>
             <div id="pinStatus" class="status"></div>
@@ -1006,6 +1006,7 @@
                     </div>
                     <div>
                         <button id="refreshBtn" title="更新">⟳</button>
+                        <button id="clearCacheBtn" title="サムネイルキャッシュをクリア" style="font-size:0.8rem;">🗑 キャッシュ</button>
                         <button id="viewerModeBtn">🖼 グリッド</button>
                     </div>
                 </div>
@@ -1221,7 +1222,7 @@
                 const length = Number.isInteger(serverInfo.pinLength) ? serverInfo.pinLength : 8;
                 if (charset === 'digits') {
                     pinInput.setAttribute('inputmode', 'numeric');
-                    pinInput.setAttribute('pattern', `[0-9]{${length}}`);
+                    pinInput.removeAttribute('pattern');
                 } else {
                     pinInput.setAttribute('inputmode', 'text');
                     pinInput.removeAttribute('pattern');
@@ -1506,7 +1507,10 @@
                             body: file
                         });
                         if (!response.ok) {
-                            throw new Error(`'${file.name}' のアップロード失敗`);
+                            if (response.status === 413) {
+                                throw new Error(`'${file.name}' はサーバのサイズ制限を超えています`);
+                            }
+                            throw new Error(`'${file.name}' のアップロード失敗 (HTTP ${response.status})`);
                         }
                     }
                     uploadStatus.style.color = 'green';
@@ -2038,7 +2042,10 @@
                 const cached = loadMentionsCache();
                 if (cached) return cached;
                 const res = await safeFetch('/api/mentions');
-                if (!res.ok) throw new Error('/api/mentions HTTP ' + res.status);
+                if (!res.ok) {
+                    if (res.status === 404) return [];
+                    throw new Error('/api/mentions HTTP ' + res.status);
+                }
                 const data = await res.json();
                 const items = Array.isArray(data?.items) ? data.items : [];
                 saveMentionsCache(items);
@@ -2629,6 +2636,25 @@
             });
             document.getElementById('refreshBtn').addEventListener('click', () => {
                 fetchFiles();
+            });
+
+            document.getElementById('clearCacheBtn').addEventListener('click', async () => {
+                const btn = document.getElementById('clearCacheBtn');
+                btn.disabled = true;
+                try {
+                    const res = await safeFetch('/api/cache/thumbnails', { method: 'DELETE' });
+                    if (res.ok) {
+                        const data = await res.json();
+                        fetchFiles();
+                        const orig = btn.textContent;
+                        btn.textContent = `✓ ${data.count}件削除`;
+                        setTimeout(() => { btn.textContent = orig; btn.disabled = false; }, 2000);
+                    } else {
+                        btn.disabled = false;
+                    }
+                } catch (_) {
+                    btn.disabled = false;
+                }
             });
 
             // 初期化処理：サーバー情報を取得し、認証モードに応じてPINモーダルを表示

--- a/bin/localnode_cli.dart
+++ b/bin/localnode_cli.dart
@@ -2070,15 +2070,14 @@ class _CliServer {
     await _init(storagePath);
     await _deployAssets();
 
-    // #258: DNS rebinding — 許可する Host 値を事前収集
-    _allowedHosts = {'localhost', '127.0.0.1', '[::1]', ipAddress};
+    // #258: DNS rebinding — 許可する Host 値を事前収集（IPv4 のみ。IPv6 バインド未対応）
+    _allowedHosts = {'localhost', '127.0.0.1', ipAddress};
     try {
       final ifaces = await NetworkInterface.list(includeLoopback: true);
       for (final iface in ifaces) {
         for (final addr in iface.addresses) {
-          _allowedHosts.add(addr.address);
-          if (addr.type == InternetAddressType.IPv6) {
-            _allowedHosts.add('[${addr.address}]');
+          if (addr.type == InternetAddressType.IPv4) {
+            _allowedHosts.add(addr.address);
           }
         }
       }
@@ -2791,7 +2790,11 @@ class _CliServer {
     if (encodedName == null || encodedName.isEmpty) {
       return Response.badRequest(body: 'x-filename header is required.');
     }
-    final filename = _sanitizeFilename(p.basename(Uri.decodeComponent(encodedName)));
+    final rawName = p.basename(Uri.decodeComponent(encodedName));
+    if (rawName.codeUnits.any((c) => c < 32 || c == 127)) {
+      return Response.badRequest(body: 'Invalid filename.');
+    }
+    final filename = _sanitizeFilename(rawName);
     if (filename == null) {
       return Response.badRequest(body: 'Invalid filename.');
     }


### PR DESCRIPTION
## Summary

- **#263**: reject filenames containing control chars (incl. null byte `%00`) before sanitization → 400
- **#260**: add `novalidate` to PIN form + remove `pattern` attr so browser HTML5 validation never blocks the JS submit handler; wrong-length PINs now count toward lockout
- **#262**: show specific \"サイズ制限を超えています\" message when upload returns 413
- **#268**: `fetchMentions()` returns `[]` on 404 — GUI/mobile server has no `/api/mentions`, previously threw an unhandled error
- **#272**: add \"🗑 キャッシュ\" button in file tab toolbar that calls `DELETE /api/cache/thumbnails` (API already existed)
- **Release workflow**: checkout + extract version from `pubspec.yaml`, rename artifacts to `localnode-*-v1.7.0.*`
- **docs**: note IPv4-only in README feature list (#277)

## Test plan

- [ ] Upload file named `%00evil.sh` → 400 (not saved as `evil.sh`)
- [ ] Enter 4-digit PIN on 8-digit server → JS handler fires, \"PINが正しくありません\" shown, no browser popup
- [ ] Upload file >1M with `--max-upload-size 1M` → \"サイズ制限を超えています\" shown in UI
- [ ] On GUI/mobile server, click `@` button → no error thrown, menu closes/empty
- [ ] Click 🗑 キャッシュ → thumbnails cleared and re-generated on next view
- [ ] Release build produces `localnode-windows-x64-v1.7.0.zip` etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)