### PR TITLE
Fix release artifact version extraction (pubspec.yaml path)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,7 +223,7 @@ jobs:
       - name: Extract version from pubspec.yaml
         id: version
         run: |
-          VERSION=$(grep '^version:' LocalNode/pubspec.yaml | sed 's/version: *//' | sed 's/+.*//' | tr -d '[:space:]')
+          VERSION=$(grep '^version:' pubspec.yaml | sed 's/version: *//' | sed 's/+.*//' | tr -d '[:space:]')
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Download all artifacts


### PR DESCRIPTION
## Summary

- Fix: `grep '^version:' LocalNode/pubspec.yaml` → `pubspec.yaml` (repo root IS the LocalNode directory)
- Previous build produced `localnode-windows-x64-v.zip` (empty version); this produces `localnode-windows-x64-v1.7.0.zip`

🤖 Generated with [Claude Code](https://claude.com/claude-code)