### PR TITLE
v1.8.0: port v1.7.0 security hardening to GUI/mobile server + configurable upload limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,9 @@ children:
 | `@to <child\|all> <message>` | Post a message to one or all children |
 | `@run_to <child> <alias>` | Run a `@run` alias on the child; result returns to parent clipboard |
 
-> **Note**: Mention commands (`@run`, `@run_to`, etc.) can only be triggered from a browser session. Requests authenticated via Bearer token (e.g. `curl`) cannot execute mentions.
+> **Note**: Mention commands typed into the clipboard (`@run`, `@run_to`, etc.) are executed only when the clipboard item is posted from an authenticated **browser session**. Clipboard posts authenticated via Bearer token (e.g. `curl`, or forwarded federation items) do **not** execute mentions.
+>
+> **Exception (federation `@run_to`)**: a parent invokes a child's `@run` alias through the dedicated `GET /api/run/<alias>` endpoint, which **is** reachable with the child's Bearer token by design. This means a leaked Bearer token can invoke any `@run` alias registered on that node (it cannot run arbitrary commands — only the pre-registered `--mention-action` scripts). Treat the token accordingly.
 
 ## Platform Support
 

--- a/bin/localnode_cli.dart
+++ b/bin/localnode_cli.dart
@@ -26,7 +26,7 @@ import 'package:shelf_static/shelf_static.dart';
 import 'package:yaml/yaml.dart';
 
 // pubspec.yaml の version と一致させる
-const String _appVersion = '1.7.0';
+const String _appVersion = '1.8.0';
 
 // #174 + #220: 予約メンション名。ユーザーが `--mention-action <name>=...` で
 // 登録できない。

--- a/bin/localnode_cli.dart
+++ b/bin/localnode_cli.dart
@@ -2596,7 +2596,8 @@ class _CliServer {
           // 付加できるため、列挙したエンドポイント以外への昇格には使えない。
           if (_uploadToken != null) {
             final authHeader = req.headers['authorization'] ?? '';
-            if (authHeader == 'Bearer $_uploadToken') {
+            // #284: トークン比較も定数時間で（PIN と一貫性を取る）
+            if (_constantTimeEquals(authHeader, 'Bearer $_uploadToken')) {
               if ((req.method == 'POST' &&
                       (path == 'api/upload' || path == 'api/clipboard')) ||
                   (req.method == 'GET' &&

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -36,6 +36,7 @@ class ServerState {
     this.httpsHostname,
     this.certSanCandidates = const [],
     this.resolvedHttpsIp,
+    this.maxUploadMB,
   });
 
   final ServerStatus status;
@@ -56,6 +57,8 @@ class ServerState {
   final List<String> certSanCandidates;
   // ホスト名をデバイスIPに解決した結果（非nullならIPドロップダウンをロック）(#985)
   final String? resolvedHttpsIp;
+  // #285: 直接アップロードの上限 (MB)。null / 0 = 無制限。
+  final int? maxUploadMB;
 
   bool get httpsMode =>
       httpsCertPath != null &&
@@ -81,6 +84,8 @@ class ServerState {
     String? httpsHostname,
     List<String>? certSanCandidates,
     String? resolvedHttpsIp,
+    int? maxUploadMB,
+    bool clearMaxUploadMB = false,
     bool clearPin = false,
     bool clearErrorMessage = false,
     bool clearFixedPin = false,
@@ -115,6 +120,8 @@ class ServerState {
           : (certSanCandidates ?? this.certSanCandidates),
       resolvedHttpsIp:
           clearResolvedHttpsIp ? null : (resolvedHttpsIp ?? this.resolvedHttpsIp),
+      maxUploadMB:
+          clearMaxUploadMB ? null : (maxUploadMB ?? this.maxUploadMB),
     );
   }
 }
@@ -202,6 +209,8 @@ class ServerNotifier extends Notifier<ServerState> {
     final authModeStr = prefs.getString('auth_mode');
     final savedFixedPin = prefs.getString('fixed_pin');
     final savedServerName = prefs.getString('server_name') ?? 'LocalNode';
+    // #285: 0 / 未設定は無制限
+    final savedMaxUploadMB = prefs.getInt('max_upload_mb');
     final savedHttpsEnabled = prefs.getBool('https_enabled') ?? false;
     // cert/key は https_enabled が true の場合のみ読み込む (#141)
     final savedHttpsCertPath =
@@ -225,6 +234,9 @@ class ServerNotifier extends Notifier<ServerState> {
       authMode: authMode,
       fixedPin: savedFixedPin,
       serverName: savedServerName,
+      maxUploadMB: (savedMaxUploadMB != null && savedMaxUploadMB > 0)
+          ? savedMaxUploadMB
+          : null,
       httpsEnabled: savedHttpsEnabled,
       httpsCertPath: savedHttpsCertPath,
       httpsKeyPath: savedHttpsKeyPath,
@@ -285,6 +297,19 @@ class ServerNotifier extends Notifier<ServerState> {
     await prefs.setString('operation_mode',
         mode == OperationMode.downloadOnly ? 'downloadOnly' : 'normal');
     state = state.copyWith(operationMode: mode);
+  }
+
+  /// #285: 直接アップロード上限 (MB) を設定して永続化。
+  /// null / 0 以下は無制限として扱う。
+  Future<void> setMaxUploadMB(int? mb) async {
+    final prefs = await SharedPreferences.getInstance();
+    if (mb == null || mb <= 0) {
+      await prefs.remove('max_upload_mb');
+      state = state.copyWith(clearMaxUploadMB: true);
+    } else {
+      await prefs.setInt('max_upload_mb', mb);
+      state = state.copyWith(maxUploadMB: mb);
+    }
   }
 
   /// 認証モードを変更して永続化
@@ -361,6 +386,9 @@ class ServerNotifier extends Notifier<ServerState> {
         httpsCertPath: state.httpsCertPath,
         httpsKeyPath: state.httpsKeyPath,
         httpsHostname: state.httpsHostname,
+        maxUploadBytes: (state.maxUploadMB != null && state.maxUploadMB! > 0)
+            ? state.maxUploadMB! * 1024 * 1024
+            : null,
       );
 
       state = state.copyWith(
@@ -549,6 +577,7 @@ class ServerNotifier extends Notifier<ServerState> {
     await prefs.remove('https_cert_path');
     await prefs.remove('https_key_path');
     await prefs.remove('https_hostname');
+    await prefs.remove('max_upload_mb'); // #285
     await prefs.remove('saf_directory_uri');
     await prefs.remove('selected_directory_path');
     // ServerService の in-memory フォルダ状態もリセットしデフォルトに戻す
@@ -562,6 +591,7 @@ class ServerNotifier extends Notifier<ServerState> {
       clearHttpsHostname: true,
       clearCertSanCandidates: true,
       clearResolvedHttpsIp: true,
+      clearMaxUploadMB: true, // #285
       storagePath: _serverService.displayPath ?? _serverService.documentsPath,
     );
   }
@@ -735,6 +765,7 @@ class _HomePageState extends ConsumerState<HomePage> {
   late final TextEditingController _fixedPinController;
   late final TextEditingController _nameController;
   late final TextEditingController _hostnameController;
+  late final TextEditingController _maxUploadController;
   final ScrollController _scrollController = ScrollController();
   ProviderSubscription<ServerState>? _hostnameSubscription;
 
@@ -745,6 +776,7 @@ class _HomePageState extends ConsumerState<HomePage> {
     _fixedPinController = TextEditingController();
     _nameController = TextEditingController(text: 'LocalNode');
     _hostnameController = TextEditingController();
+    _maxUploadController = TextEditingController();
     // IP選択時の逆引きDNS結果をホスト名コントローラに反映
     _hostnameSubscription = ref.listenManual<ServerState>(
       serverNotifierProvider,
@@ -768,6 +800,8 @@ class _HomePageState extends ConsumerState<HomePage> {
             _fixedPinController.text = state.fixedPin!;
           }
           _nameController.text = state.serverName;
+          _maxUploadController.text =
+              state.maxUploadMB != null ? state.maxUploadMB.toString() : '';
           if (state.httpsHostname != null) {
             _hostnameController.text = state.httpsHostname!;
           }
@@ -783,6 +817,7 @@ class _HomePageState extends ConsumerState<HomePage> {
     _fixedPinController.dispose();
     _nameController.dispose();
     _hostnameController.dispose();
+    _maxUploadController.dispose();
     _scrollController.dispose();
     super.dispose();
   }
@@ -1125,6 +1160,40 @@ class _HomePageState extends ConsumerState<HomePage> {
           },
         ),
 
+        // #285: アップロードサイズ上限
+        const SizedBox(height: 20),
+        const Text('アップロード上限', style: TextStyle(fontWeight: FontWeight.bold)),
+        const SizedBox(height: 8),
+        Row(
+          children: [
+            SizedBox(
+              width: 120,
+              child: TextField(
+                controller: _maxUploadController,
+                keyboardType: TextInputType.number,
+                inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                decoration: const InputDecoration(
+                  labelText: 'MB',
+                  hintText: '無制限',
+                  border: OutlineInputBorder(),
+                  isDense: true,
+                ),
+                onChanged: (value) {
+                  final mb = int.tryParse(value.trim());
+                  notifier.setMaxUploadMB(mb);
+                },
+              ),
+            ),
+            const SizedBox(width: 12),
+            const Expanded(
+              child: Text(
+                '空欄で無制限。1ファイルあたりの最大サイズ。',
+                style: TextStyle(fontSize: 12, color: Colors.grey),
+              ),
+            ),
+          ],
+        ),
+
         // 認証モード選択
         const SizedBox(height: 20),
         const Text('認証モード', style: TextStyle(fontWeight: FontWeight.bold)),
@@ -1288,6 +1357,7 @@ class _HomePageState extends ConsumerState<HomePage> {
               _portController.text = '8080';
               _fixedPinController.clear();
               _hostnameController.clear();
+              _maxUploadController.clear();
             }
           },
         ),

--- a/lib/server_service.dart
+++ b/lib/server_service.dart
@@ -88,6 +88,8 @@ class ServerService {
   Set<String> _allowedHosts = {};
   // #6: TLS 有効時のみ Set-Cookie に Secure 属性を付ける。
   bool _httpsEnabled = false;
+  // #285: 直接アップロードの上限バイト数（null = 無制限）。ストレージ枯渇 DoS 対策。
+  int? _maxUploadBytes;
   OperationMode _operationMode = OperationMode.normal;
   AuthMode _authMode = AuthMode.randomPin;
   bool _verboseLogging = false;
@@ -618,6 +620,17 @@ class ServerService {
       return Response.badRequest(body: 'Invalid filename.');
     }
 
+    // #285: 直接アップロードのサイズ上限。content-length で早期に弾く
+    // （ヘッダを詐称された場合はストリーム中でも打ち切る）。
+    final maxBytes = _maxUploadBytes;
+    if (maxBytes != null) {
+      final clHeader = request.headers['content-length'];
+      final cl = clHeader != null ? int.tryParse(clHeader) : null;
+      if (cl != null && cl > maxBytes) {
+        return _tooLargeResponse(maxBytes);
+      }
+    }
+
     final relPath = request.requestedUri.queryParameters['path'] ?? '';
 
     // AndroidでSAF URIが設定されている場合
@@ -629,7 +642,13 @@ class ServerService {
             body: 'Subfolder upload is not supported on Android SAF.');
       }
       try {
-        final bytes = await request.read().fold<List<int>>([], (prev, chunk) => prev..addAll(chunk));
+        final bytes = <int>[];
+        await for (final chunk in request.read()) {
+          bytes.addAll(chunk);
+          if (maxBytes != null && bytes.length > maxBytes) {
+            return _tooLargeResponse(maxBytes); // #285
+          }
+        }
         final mimeType = _getMimeType(sanitizedFilename);
 
         final String? newFileUri = await _safPlatform.invokeMethod('createFile', {
@@ -683,6 +702,14 @@ class ServerService {
         int totalBytes = 0;
         await for (final chunk in request.read()) {
           totalBytes += chunk.length;
+          // #285: content-length を詐称されても書き込み途中で打ち切る
+          if (maxBytes != null && totalBytes > maxBytes) {
+            await sink.close();
+            try {
+              await file.delete();
+            } catch (_) {}
+            return _tooLargeResponse(maxBytes);
+          }
           sink.add(chunk);
         }
         await sink.close();
@@ -694,6 +721,17 @@ class ServerService {
         return Response.internalServerError(body: 'Failed to save file: $e');
       }
     }
+  }
+
+  // #285: アップロード上限超過の 413 応答。Web UI は status===413 を見て
+  // 専用メッセージを表示する（#262）。
+  Response _tooLargeResponse(int maxBytes) {
+    return Response(413,
+        body: json.encode({
+          'error': 'too-large',
+          'message': 'Upload exceeds server limit of $maxBytes bytes.',
+        }),
+        headers: {'Content-Type': 'application/json'});
   }
 
   Future<File> _getUniqueFilePath(Directory dir, String filename) async {
@@ -2039,6 +2077,7 @@ class ServerService {
     String? httpsCertPath,
     String? httpsKeyPath,
     String? httpsHostname,
+    int? maxUploadBytes,
   }) async {
     if (_server != null) return;
 
@@ -2046,6 +2085,7 @@ class ServerService {
 
     _operationMode = operationMode;
     _authMode = authMode;
+    _maxUploadBytes = maxUploadBytes; // #285
     _serverName = serverName.isNotEmpty ? serverName : 'LocalNode';
 
     // 認証モードに応じたPIN設定
@@ -2122,6 +2162,7 @@ class ServerService {
     _httpsHostname = null;
     _httpsEnabled = false;
     _allowedHosts = {};
+    _maxUploadBytes = null;
     _ipAddress = null;
     _port = null;
     _pin = null;

--- a/lib/server_service.dart
+++ b/lib/server_service.dart
@@ -80,7 +80,14 @@ class ServerService {
   Directory? _thumbnailCacheDir; // サムネイルキャッシュディレクトリ
   static final Uint8List _placeholderThumbBytes = _buildPlaceholderJpeg();
   String? _pin;
-  final Set<String> _sessions = {};
+  // #261: セッショントークン -> 失効エポックミリ秒。TTL 超過で無効化する。
+  final Map<String, int> _sessions = {};
+  static const Duration _sessionTtl = Duration(hours: 24);
+  static const int _maxNoPinSessions = 1000;
+  // #258: DNS rebinding 対策で許可する Host 値（IP / localhost）。空なら無効。
+  Set<String> _allowedHosts = {};
+  // #6: TLS 有効時のみ Set-Cookie に Secure 属性を付ける。
+  bool _httpsEnabled = false;
   OperationMode _operationMode = OperationMode.normal;
   AuthMode _authMode = AuthMode.randomPin;
   bool _verboseLogging = false;
@@ -313,6 +320,7 @@ class ServerService {
       if (!await _thumbnailCacheDir!.exists()) {
         await _thumbnailCacheDir!.create(recursive: true);
       }
+      _chmodDir(_thumbnailCacheDir!); // #269: 共有 temp のデスクトップ環境向けに 700 制限
     }
   }
 
@@ -330,6 +338,7 @@ class ServerService {
       await _webRootDir!.delete(recursive: true);
     }
     await _webRootDir!.create(recursive: true);
+    _chmodDir(_webRootDir!); // #269
 
     try {
       // index.htmlを直接読み込んで一時ディレクトリにコピーする
@@ -358,11 +367,11 @@ class ServerService {
   Future<Response> _authHandler(Request request) async {
     // PINなしモードでは自動認証
     if (_authMode == AuthMode.noPin) {
-      final token = _generateSessionToken();
-      _sessions.add(token);
-      final cookie = 'localnode_session=$token; Path=/; HttpOnly; SameSite=Strict';
-      return Response.ok(json.encode({'status': 'success'}),
-          headers: {'Content-Type': 'application/json', 'Set-Cookie': cookie});
+      final token = _issueSession();
+      return Response.ok(json.encode({'status': 'success'}), headers: {
+        'Content-Type': 'application/json',
+        'Set-Cookie': _buildSessionCookie(token),
+      });
     }
 
     // クライアントIPを取得
@@ -382,25 +391,22 @@ class ServerService {
     final body = await request.readAsString();
     try {
       final params = json.decode(body) as Map<String, dynamic>;
-      final submittedPin = params['pin'];
+      final submittedPin = params['pin'] as String? ?? '';
 
-      if (submittedPin == _pin) {
+      // #260: 定数時間比較でタイミング攻撃を防ぐ
+      if (_pin != null && _constantTimeEquals(submittedPin, _pin!)) {
         // 認証成功: 失敗カウントをリセット
         _failedAttempts.remove(clientIp);
         _lockoutUntil.remove(clientIp);
 
-        final token = _generateSessionToken();
-        _sessions.add(token);
+        final token = _issueSession();
 
         _log('Auth success. Active sessions: ${_sessions.length}');
 
-        final cookie = 'localnode_session=$token; Path=/; HttpOnly; SameSite=Strict';
-        final headers = {
+        return Response.ok(json.encode({'status': 'success'}), headers: {
           'Content-Type': 'application/json',
-          'Set-Cookie': cookie,
-        };
-
-        return Response.ok(json.encode({'status': 'success'}), headers: headers);
+          'Set-Cookie': _buildSessionCookie(token),
+        });
       } else {
         // 認証失敗: 失敗カウントを増加
         final attempts = (_failedAttempts[clientIp] ?? 0) + 1;
@@ -465,13 +471,15 @@ class ServerService {
       'authMode': _authMode == AuthMode.fixedPin ? 'fixedPin' : _authMode == AuthMode.noPin ? 'noPin' : 'randomPin',
       'requiresAuth': _authMode != AuthMode.noPin,
       'clipboardEnabled': _clipboardEnabled,
-      // #218: federation 識別子
-      'deviceId': _deviceId,
       // #206: Web UI が PIN 入力モードを切り替えるためのヒント。
       // GUI アプリは現状デフォルト固定 (CLI が --pin-length / --pin-charset を持つ)
       'pinCharset': 'digits',
       'pinLength': 4,
     };
+    // #265: 端末識別子は認証済みリクエストにのみ返す（未認証への情報漏洩を防ぐ）。
+    if (_isAuthenticatedRequest(request)) {
+      info['deviceId'] = _deviceId;
+    }
     return Response.ok(json.encode(info),
         headers: {'Content-Type': 'application/json'});
   }
@@ -600,8 +608,15 @@ class ServerService {
     if (encodedFilename == null || encodedFilename.isEmpty) {
       return Response.badRequest(body: 'x-filename header is required.');
     }
-    final filename = Uri.decodeComponent(encodedFilename);
-    final sanitizedFilename = p.basename(filename);
+    final rawName = p.basename(Uri.decodeComponent(encodedFilename));
+    // #263: null バイト/制御文字を含む名前はサニタイズ前に拒否
+    if (rawName.codeUnits.any((c) => c < 32 || c == 127)) {
+      return Response.badRequest(body: 'Invalid filename.');
+    }
+    final sanitizedFilename = _sanitizeFilename(rawName);
+    if (sanitizedFilename == null) {
+      return Response.badRequest(body: 'Invalid filename.');
+    }
 
     final relPath = request.requestedUri.queryParameters['path'] ?? '';
 
@@ -986,6 +1001,7 @@ class ServerService {
       }
 
       await cacheFile.writeAsBytes(thumbnailBytes);
+      _chmodFile(cacheFile); // #269
 
       return Response.ok(thumbnailBytes, headers: {'Content-Type': 'image/jpeg'});
 
@@ -1788,7 +1804,6 @@ class ServerService {
       }
 
       final cookieHeader = request.headers['cookie'];
-      _log('Auth middleware: Received cookie header: $cookieHeader');
       String? token;
 
       if (cookieHeader != null) {
@@ -1805,10 +1820,11 @@ class ServerService {
         }
       }
 
-      _log('Auth middleware: Parsed token: $token');
+      // #282: verbose ログでもトークン全体は出さない（漏洩でセッション乗っ取り可能なため）
+      _log('Auth middleware: session token ${token == null ? 'absent' : 'present'}');
 
-      // トークンを検証
-      if (token != null && _sessions.contains(token)) {
+      // #261: トークンを TTL 込みで検証
+      if (token != null && _isValidSession(token)) {
         return innerHandler(request); // 認証成功
       }
 
@@ -1839,13 +1855,16 @@ class ServerService {
     }
 
     // サムネイルキャッシュディレクトリの初期化
+    // #264/#269/#271: 共有 /tmp では固定名だと symlink poisoning / 情報漏洩の恐れ。
+    // PID + OS ランダムサフィックスで分離し 700 に制限、死んだ PID の残骸は掃除する。
     final tempPath = Platform.environment['TMPDIR'] ??
         Platform.environment['TEMP'] ??
         '/tmp';
-    _thumbnailCacheDir = Directory(p.join(tempPath, 'localnode_thumbnails'));
-    if (!await _thumbnailCacheDir!.exists()) {
-      await _thumbnailCacheDir!.create(recursive: true);
-    }
+    const thumbPrefix = 'localnode_thumbnails_';
+    _reapStaleWebDirs(Directory(tempPath), thumbPrefix);
+    _thumbnailCacheDir =
+        await Directory(tempPath).createTemp('$thumbPrefix${pid}_');
+    _chmodDir(_thumbnailCacheDir!);
   }
 
   /// CLI用のアセット展開（Flutterプラグインを使用しない）
@@ -1863,6 +1882,7 @@ class ServerService {
       await _webRootDir!.delete(recursive: true);
     }
     await _webRootDir!.create(recursive: true);
+    _chmodDir(_webRootDir!); // #269
 
     // CLIモードでは実行ファイルのバンドル/ディレクトリからassetsを探索
     final executablePath = Platform.resolvedExecutable;
@@ -1971,12 +1991,17 @@ class ServerService {
       _httpsCertPath = httpsCertPath;
       _httpsKeyPath = httpsKeyPath;
       _httpsHostname = null; // CLI経由ではホスト名指定なし
+      _httpsEnabled = isHttpsMode; // #6
+      await _buildAllowedHosts(ipAddress); // #258
 
       final staticHandler =
           createStaticHandler(_webRootDir!.path, defaultDocument: 'index.html');
 
-      final apiHandler =
-          const Pipeline().addMiddleware(_federationLoopGuard).addMiddleware(_authMiddleware).addHandler(_router.call);
+      final apiHandler = const Pipeline()
+          .addMiddleware(_hostGuardMiddleware) // #258
+          .addMiddleware(_federationLoopGuard)
+          .addMiddleware(_authMiddleware)
+          .addHandler(_router.call);
 
       final cascade = Cascade().add(apiHandler).add(staticHandler);
 
@@ -2052,12 +2077,17 @@ class ServerService {
       _httpsCertPath = httpsCertPath;
       _httpsKeyPath = httpsKeyPath;
       _httpsHostname = httpsHostname;
+      _httpsEnabled = isHttpsMode; // #6
+      await _buildAllowedHosts(ipAddress); // #258
 
       final staticHandler =
           createStaticHandler(_webRootDir!.path, defaultDocument: 'index.html');
 
-      final apiHandler =
-          const Pipeline().addMiddleware(_federationLoopGuard).addMiddleware(_authMiddleware).addHandler(_router.call);
+      final apiHandler = const Pipeline()
+          .addMiddleware(_hostGuardMiddleware) // #258
+          .addMiddleware(_federationLoopGuard)
+          .addMiddleware(_authMiddleware)
+          .addHandler(_router.call);
 
       final cascade = Cascade().add(apiHandler).add(staticHandler);
 
@@ -2090,6 +2120,8 @@ class ServerService {
     _httpsCertPath = null;
     _httpsKeyPath = null;
     _httpsHostname = null;
+    _httpsEnabled = false;
+    _allowedHosts = {};
     _ipAddress = null;
     _port = null;
     _pin = null;
@@ -2124,7 +2156,8 @@ class ServerService {
       if (entry is! Directory) continue;
       final name = p.basename(entry.path);
       if (!name.startsWith(prefix)) continue;
-      final pidStr = name.substring(prefix.length);
+      // <prefix><pid> と <prefix><pid>_<random> (createTemp) の両形式に対応
+      final pidStr = name.substring(prefix.length).split('_').first;
       final otherPid = int.tryParse(pidStr);
       if (otherPid == null || otherPid == myPid) continue;
       if (_isProcessAlive(otherPid)) continue;
@@ -2159,6 +2192,138 @@ class ServerService {
     } catch (_) {
       return true;
     }
+  }
+
+  // #269: Unix のみ、ディレクトリ/ファイルのパーミッションを制限。
+  // モバイル (Android/iOS) は temp が app サンドボックス内なので不要 & chmod 不可。
+  void _chmodDir(Directory dir) {
+    if (Platform.isWindows || Platform.isAndroid || Platform.isIOS) return;
+    try {
+      Process.runSync('chmod', ['700', dir.path], runInShell: false);
+    } catch (_) {}
+  }
+
+  void _chmodFile(File file) {
+    if (Platform.isWindows || Platform.isAndroid || Platform.isIOS) return;
+    try {
+      Process.runSync('chmod', ['600', file.path], runInShell: false);
+    } catch (_) {}
+  }
+
+  // #261: セッションの有効性を TTL 込みで判定。失効していたら破棄して false。
+  bool _isValidSession(String token) {
+    final expiry = _sessions[token];
+    if (expiry == null) return false;
+    if (DateTime.now().millisecondsSinceEpoch > expiry) {
+      _sessions.remove(token);
+      return false;
+    }
+    return true;
+  }
+
+  void _pruneExpiredSessions() {
+    final now = DateTime.now().millisecondsSinceEpoch;
+    _sessions.removeWhere((_, expiry) => expiry < now);
+  }
+
+  // #261: 新しいセッションを発行して失効時刻付きで登録。
+  // no-pin モードは上限を設けて最古から追い出し、メモリ枯渇を防ぐ。
+  String _issueSession() {
+    final token = _generateSessionToken();
+    if (_authMode == AuthMode.noPin) {
+      _pruneExpiredSessions();
+      if (_sessions.length >= _maxNoPinSessions) {
+        final oldest =
+            _sessions.entries.reduce((a, b) => a.value < b.value ? a : b);
+        _sessions.remove(oldest.key);
+      }
+    }
+    _sessions[token] =
+        DateTime.now().add(_sessionTtl).millisecondsSinceEpoch;
+    return token;
+  }
+
+  // #6: 認証モードと TLS 状態に応じた Set-Cookie 値を組み立てる。
+  String _buildSessionCookie(String token) {
+    return 'localnode_session=$token; Path=/; HttpOnly; SameSite=Strict'
+        '${_httpsEnabled ? '; Secure' : ''}';
+  }
+
+  // #260: タイミング攻撃を防ぐ定数時間文字列比較。
+  bool _constantTimeEquals(String a, String b) {
+    if (a.length != b.length) return false;
+    var result = 0;
+    for (var i = 0; i < a.length; i++) {
+      result |= a.codeUnitAt(i) ^ b.codeUnitAt(i);
+    }
+    return result == 0;
+  }
+
+  // #263: アップロードファイル名のサニタイズ。空になった場合は null を返す。
+  String? _sanitizeFilename(String name) {
+    var s = name.replaceAll(RegExp(r'[\x00-\x1F\x7F]'), '');
+    s = s.replaceAll(RegExp(r'[\\/:*?"<>|]'), '_');
+    s = s.replaceAll(RegExp(r'^[.\s]+|[.\s]+$'), '');
+    if (RegExp(r'^(CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])(\..+)?$',
+            caseSensitive: false)
+        .hasMatch(s)) {
+      s = '_$s';
+    }
+    return s.isEmpty ? null : s;
+  }
+
+  // #265: セッション Cookie または Bearer が有効なリクエストか判定。
+  bool _isAuthenticatedRequest(Request request) {
+    if (_authMode == AuthMode.noPin) return true;
+    final cookie = request.headers['cookie'] ?? '';
+    for (final c in cookie.split(';')) {
+      final t = c.trim();
+      if (t.startsWith('localnode_session=')) {
+        final token = t.substring(t.indexOf('=') + 1);
+        if (_isValidSession(token)) return true;
+      }
+    }
+    return false;
+  }
+
+  // #258: DNS rebinding 対策 — Host ヘッダが既知の IP/localhost と一致しなければ拒否。
+  Middleware get _hostGuardMiddleware => (inner) {
+        return (req) {
+          if (_allowedHosts.isEmpty) return inner(req);
+          final host = req.headers['host'];
+          // #275: Host 欠落は fail-closed（正規クライアントは必ず付与する）。
+          if (host == null) {
+            return Response(421,
+                body: 'Missing Host header',
+                headers: {'Content-Type': 'text/plain'});
+          }
+          final hostWithoutPort = host.replaceFirst(RegExp(r':\d+$'), '');
+          if (!_allowedHosts.contains(hostWithoutPort)) {
+            return Response(421,
+                body: 'Misdirected Request',
+                headers: {'Content-Type': 'text/plain'});
+          }
+          return inner(req);
+        };
+      };
+
+  // #258: 起動時に許可 Host 集合を構築（localhost + 広告 IP + 全 IPv4 NIC）。
+  Future<void> _buildAllowedHosts(String ipAddress) async {
+    _allowedHosts = {'localhost', '127.0.0.1', ipAddress};
+    // HTTPS 証明書のホスト名でアクセスする場合も許可（#275）。
+    if (_httpsHostname != null && _httpsHostname!.isNotEmpty) {
+      _allowedHosts.add(_httpsHostname!);
+    }
+    try {
+      final ifaces = await NetworkInterface.list(includeLoopback: true);
+      for (final iface in ifaces) {
+        for (final addr in iface.addresses) {
+          if (addr.type == InternetAddressType.IPv4) {
+            _allowedHosts.add(addr.address);
+          }
+        }
+      }
+    } catch (_) {}
   }
 
   // SAF ディレクトリを選択するメソッド

--- a/lib/server_service.dart
+++ b/lib/server_service.dart
@@ -2030,6 +2030,9 @@ class ServerService {
       _httpsKeyPath = httpsKeyPath;
       _httpsHostname = null; // CLI経由ではホスト名指定なし
       _httpsEnabled = isHttpsMode; // #6
+      // 注: cli_runner は現状 HTTPS 未対応 (httpsCert/Key は常に null, #98)。
+      //     将来 #98 で HTTPS + 証明書ホスト名を配線する際は、cert の SAN を
+      //     _allowedHosts に加えないと Host ガードで 421 になる点に注意。
       await _buildAllowedHosts(ipAddress); // #258
 
       final staticHandler =
@@ -2313,7 +2316,8 @@ class ServerService {
     return s.isEmpty ? null : s;
   }
 
-  // #265: セッション Cookie または Bearer が有効なリクエストか判定。
+  // #265: 有効なセッション Cookie を持つリクエストか判定。
+  // GUI サーバは CLI と違い Bearer/upload-token 認証を持たないため Cookie のみ見る。
   bool _isAuthenticatedRequest(Request request) {
     if (_authMode == AuthMode.noPin) return true;
     final cookie = request.headers['cookie'] ?? '';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.7.0+1
+version: 1.8.0+1
 
 environment:
   sdk: '>=3.4.3 <4.0.0'


### PR DESCRIPTION
## Summary

v1.7.0 shipped security hardening in the standalone CLI only; the GUI/mobile server (`lib/server_service.dart`) — which also backs macOS `localnode --cli` via `cli_runner.dart` — did not receive it. v1.8.0 ports that hardening across, plus a few smaller items. Public-key auth (#267) is **not** in this release (deferred to 1.9.0/2.0.0).

## Security (#281 / #282)

GUI/mobile server, ported from the CLI:
- **#258** DNS-rebinding guard: Host-header middleware rejects mismatched/missing Host with `421`; allowed set = localhost + advertised IP + IPv4 NICs + TLS cert hostname
- **#261** Session TTL: `Map<token,expiryMs>`, 24h expiry; no-pin mode caps sessions at 1,000 (evict oldest) to prevent memory DoS
- **#260** Constant-time PIN comparison
- **#263** Reject control-char/null-byte filenames (400) + sanitize (path separators, Windows reserved names, trailing dots)
- **#265** `/api/info` returns `deviceId` only to authenticated requests
- **#6** `Secure` cookie attribute under HTTPS
- **#264/#269/#271** macOS `--cli` thumbnail cache: PID+random temp dir, `700`/`600` perms, stale-PID reaping (closes symlink/info-disclosure on shared `/tmp`)
- **#282** Stop logging the session token verbatim (present/absent only)

## Other

- **#285** GUI configurable upload size limit (Settings → MB, empty = unlimited); 413 via content-length pre-check + mid-stream cutoff that deletes the partial file. Web UI already surfaces the 413 (#262)
- **#284** CLI: constant-time Bearer token comparison (consistent with PIN)
- **#283** Docs: clarify README mention/Bearer note (clipboard mentions need a browser session; `@run_to` uses a dedicated Bearer-reachable `/api/run/<alias>`)

## Notes / follow-ups

- Version bumped to 1.8.0
- `flutter analyze` clean on `lib/` and `bin/`
- Not yet device-tested (see `work/1.8.0_check.md`)
- #267 (public-key auth) deferred to 1.9.0/2.0.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)