### PR TITLE
v1.9.0: Web UI polish + CLI/API quality-of-life

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ localnode-cli --config /etc/localnode/config.yaml
 
 > **Note (`--post-action` / `--mention-action`):** The `script` value must be a path to an executable file only — passing arguments inline (e.g. `script=./notify.sh arg1`) is not supported. For `--post-action`, the uploaded file path is automatically passed as the first argument to the script.
 >
+> When several `--post-action` patterns match the same uploaded file (e.g. `*.png=./move.sh` and `*=./notify.sh`), the matching scripts run **sequentially in the order they were registered**, not in parallel. If an earlier script moves or deletes the file, later scripts receive the original (now-missing) path — order your actions accordingly.
+>
 > ```bash
 > # Valid: executable path only; the uploaded file path is passed automatically
 > localnode-cli --post-action "*.jpg=./process-image.sh"

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ localnode --cli [options]
 | `--pin-length` | PIN length for random generation: 8..16 (default 8) |
 | `--pin-charset` | PIN character set for random generation: `digits` (default), `alnum`, or `alnum_symbols` |
 | `--dir`, `-d` | Shared directory path |
-| `--cache-dir` | Base directory for cache/temp data (thumbnails, deployed web assets, zip staging). Default: the system temp directory (`$TMPDIR`/`$TEMP`/`/tmp`). Falls back to the system temp with a warning if the path is not writable |
+| `--cache-dir` | Base directory for cache/temp data (thumbnails, deployed web assets, zip staging). Default: the system temp directory (`$TMPDIR`/`$TEMP`/`/tmp`). Falls back to the system temp with a warning if the path is not writable. **macOS (`localnode --cli`):** the app is sandboxed, so paths outside its container are denied and it falls back to the system temp — use the standalone `localnode-cli` (Windows/Linux) if you need an arbitrary location |
 | `--mode`, `-m` | Operation mode: `normal` or `download-only` |
 | `--https-cert` | Path to TLS certificate file (cert.pem) |
 | `--https-key` | Path to TLS private key file (key.pem) |

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ localnode --cli [options]
 | `--pin-length` | PIN length for random generation: 8..16 (default 8) |
 | `--pin-charset` | PIN character set for random generation: `digits` (default), `alnum`, or `alnum_symbols` |
 | `--dir`, `-d` | Shared directory path |
+| `--cache-dir` | Base directory for cache/temp data (thumbnails, deployed web assets, zip staging). Default: the system temp directory (`$TMPDIR`/`$TEMP`/`/tmp`). Falls back to the system temp with a warning if the path is not writable |
 | `--mode`, `-m` | Operation mode: `normal` or `download-only` |
 | `--https-cert` | Path to TLS certificate file (cert.pem) |
 | `--https-key` | Path to TLS private key file (key.pem) |

--- a/README.md
+++ b/README.md
@@ -165,6 +165,35 @@ localnode-cli --config /etc/localnode/config.yaml
 
 To stop the server: **Ctrl+C**.
 
+#### Upload with a clipboard notification (`POST /api/upload`)
+
+A single upload request can also post a clipboard message, so an automation (e.g. a camera/watcher script) delivers a file and notifies viewers in one call. After the file is saved, these optional request headers append one clipboard item:
+
+| Header | Description |
+|--------|-------------|
+| `x-clipboard-text` | Message body. Percent-encoded (like `x-filename`), so non-ASCII text is supported. |
+| `x-clipboard-tag` | Optional tag/label for the clipboard item (like the web UI's sender name). Percent-encoded. |
+| `x-clipboard-link` | If set to `1` and `x-clipboard-text` is absent, auto-composes the body as an `@file:<relpath>/<filename>` marker pointing at the just-saved file, so it renders as a thumbnail/chip. |
+
+`x-clipboard-text` takes precedence over `x-clipboard-link`. Nothing is posted when neither is present, or when clipboard sharing is disabled (`--no-clipboard`).
+
+```bash
+# Upload and notify in one request
+curl -H "Authorization: Bearer <token>" \
+     -H "x-filename: picture1.jpg" \
+     -H "x-clipboard-text: motion%20detected" \
+     -H "x-clipboard-tag: watcher-pi" \
+     --data-binary @picture1.jpg \
+     "http://host:8080/api/upload?path=triggers"
+
+# Auto-compose an @file: chip for the uploaded file
+curl -H "Authorization: Bearer <token>" \
+     -H "x-filename: picture1.jpg" \
+     -H "x-clipboard-link: 1" \
+     --data-binary @picture1.jpg \
+     "http://host:8080/api/upload?path=triggers"
+```
+
 #### State file (federation `device_id`)
 
 For federation (parent/child pairing introduced in v1.6.0), the CLI persists a stable per-server identity to a small JSON state file. The path follows the XDG Base Directory specification on POSIX so it sits alongside other tools that already follow XDG (and gets picked up by backup tools that target XDG dirs):

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -44,5 +44,15 @@
             <action android:name="android.intent.action.PROCESS_TEXT"/>
             <data android:mimeType="text/plain"/>
         </intent>
+        <!-- #239: url_launcher でブラウザ (http/https) を開くため。
+             Android 11+ の package visibility で必要。 -->
+        <intent>
+            <action android:name="android.intent.action.VIEW"/>
+            <data android:scheme="http"/>
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW"/>
+            <data android:scheme="https"/>
+        </intent>
     </queries>
 </manifest>

--- a/android/app/src/main/kotlin/com/ictglab/localnode/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/ictglab/localnode/MainActivity.kt
@@ -148,24 +148,48 @@ class MainActivity: FlutterActivity() {
                         result.error("READ_FAILED", "Failed to read file: ${e.message}", null)
                     }
                 }
-                "getFileSize" -> {
-                    // #244 review: sniff の前にサイズだけ問い合わせるため。
-                    // 巨大ファイルで readFile (= 全読み) に到達させない。
+                "readFileRange" -> {
+                    // #245: 先頭 N バイトだけ読む範囲読み。text-preview の sniff が
+                    // 全ファイル読み (readFile) を経由しないようにするため。
+                    // POSIX 側の RandomAccessFile.read(n) と対称。
                     val uriString = call.argument<String>("uri")
+                    val offset = (call.argument<Number>("offset") ?: 0).toLong()
+                    val length = (call.argument<Number>("length") ?: 0).toInt()
                     if (uriString == null) {
                         result.error("ARGUMENT_ERROR", "URI is required.", null)
                         return@setMethodCallHandler
                     }
+                    if (offset < 0 || length <= 0) {
+                        result.error("ARGUMENT_ERROR", "offset must be >= 0 and length > 0.", null)
+                        return@setMethodCallHandler
+                    }
+
                     try {
                         val fileUri = Uri.parse(uriString)
-                        val df = DocumentFile.fromSingleUri(context, fileUri)
-                        if (df == null || !df.exists()) {
-                            result.error("FILE_NOT_FOUND", "File not found.", null)
-                            return@setMethodCallHandler
-                        }
-                        result.success(df.length())
+                        context.contentResolver.openInputStream(fileUri)?.use { inputStream ->
+                            // offset まで読み飛ばす (skip は要求量より少なく進むことがある)
+                            var skipped = 0L
+                            while (skipped < offset) {
+                                val n = inputStream.skip(offset - skipped)
+                                if (n <= 0) break
+                                skipped += n
+                            }
+                            if (skipped < offset) {
+                                // offset がファイル末尾を超えている -> 空を返す
+                                result.success(ByteArray(0))
+                                return@use
+                            }
+                            val buf = ByteArray(length)
+                            var read = 0
+                            while (read < length) {
+                                val n = inputStream.read(buf, read, length - read)
+                                if (n < 0) break // EOF
+                                read += n
+                            }
+                            result.success(if (read == length) buf else buf.copyOf(read))
+                        } ?: result.error("READ_FAILED", "Failed to open input stream.", null)
                     } catch (e: Exception) {
-                        result.error("SIZE_FAILED", "Failed to get size: ${e.message}", null)
+                        result.error("READ_FAILED", "Failed to read range: ${e.message}", null)
                     }
                 }
                 "resolvePath" -> {

--- a/assets/web/index.html
+++ b/assets/web/index.html
@@ -759,6 +759,18 @@
             color: rgba(255,255,255,0.5);
             font-size: 0.75rem;
         }
+        /* #280: モバイルでは左右中央の ‹ › が画像に重なって押しづらいので、
+           画像の上（左上）にまとめて出す。close は右上のまま。 */
+        @media (max-width: 600px) {
+            .lightbox-nav {
+                top: 1rem;
+                transform: none;
+                font-size: 1.8rem;
+                padding: 0.3rem 0.9rem;
+            }
+            #lightbox-prev { left: 1rem; right: auto; }
+            #lightbox-next { left: 4.75rem; right: auto; }
+        }
 
         /* 比較ビュー */
         #video-player-overlay {
@@ -1454,7 +1466,10 @@
             };
 
             // 全ファイルダウンロード処理（現在フォルダのみ）
-            downloadAllBtn.addEventListener('click', () => {
+            downloadAllBtn.addEventListener('click', (e) => {
+                // #205: zip 生成は重いので連打で多重リクエストにならないよう
+                // 少し長めのクールダウンを掛ける。
+                if (!disableWithCooldown(e.currentTarget, 3000)) return;
                 const url = currentPath
                     ? `/api/download-all?path=${encodeURIComponent(currentPath)}`
                     : '/api/download-all';
@@ -1523,7 +1538,19 @@
                 }
             });
 
-            window.downloadFile = async (id, filename) => {
+            // #205: 大きい/多数のファイルで DL ボタンを連打すると多重ダウンロードに
+            // なるのを防ぐ。クリック直後にボタンを無効化し、一定時間後に戻す。
+            const disableWithCooldown = (btn, ms = 1200) => {
+                if (!btn) return true;
+                if (btn.disabled) return false;
+                btn.disabled = true;
+                setTimeout(() => { btn.disabled = false; }, ms);
+                return true;
+            };
+
+            window.downloadFile = async (id, filename, btn) => {
+                // #205: 連打ガード（既に押下中なら無視）
+                if (!disableWithCooldown(btn)) return;
                 // #201: 直接 anchor 起動だとセッション期限切れ時に 401 JSON が
                 // ダウンロードされてしまうので、事前に check-auth で確認する。
                 try {
@@ -1919,25 +1946,33 @@
             });
 
             // #198: @file:<relpath> をサムネイル/チップに変換（メッセージあたり最大5個）
+            // #210: @path:<relfolder> をフォルダチップに変換（クリックでそのフォルダへ移動）。
+            //       サムネイル不要なので SAF (#209) など backend を問わず動く。file と枠を共有。
             const renderClipboardText = (text) => {
                 const MAX_FILES = 5;
                 const IMAGE_EXTS_FOR_FILE = new Set(['png','jpg','jpeg','gif','webp','bmp']);
                 let fileCount = 0;
                 const parts = [];
                 let lastIndex = 0;
-                const re = /@file:(\S+)/g;
+                const re = /@(file|path):(\S+)/g;
                 let m;
                 while ((m = re.exec(text)) !== null) {
                     if (m.index > lastIndex) {
                         parts.push(escapeHtml(text.substring(lastIndex, m.index)));
                     }
-                    const path = m[1];
+                    const marker = m[1];
+                    const path = m[2];
                     const invalid = path.includes('..') ||
                         path.startsWith('/') ||
                         path.startsWith('\\') ||
                         path.includes(':');
                     if (invalid || fileCount >= MAX_FILES) {
                         parts.push(escapeHtml(m[0]));
+                    } else if (marker === 'path') {
+                        // #210: フォルダチップ。data-folder はそのフォルダ自身。
+                        fileCount++;
+                        const folderAttr = escapeHtml(path);
+                        parts.push(`<span class="clipboard-file-chip" data-folder="${folderAttr}" title="${escapeHtml(path)}">📂 ${escapeHtml(path)}</span>`);
                     } else {
                         fileCount++;
                         const slash = path.lastIndexOf('/');
@@ -2295,7 +2330,7 @@
                         const dlBtn = document.createElement('button');
                         dlBtn.className = 'btn-download';
                         dlBtn.textContent = 'DL';
-                        dlBtn.addEventListener('click', () => downloadFile(item.id, item.name));
+                        dlBtn.addEventListener('click', () => downloadFile(item.id, item.name, dlBtn));
                         tdActions.appendChild(dlBtn);
                         if (!isDownloadOnly) {
                             const delBtn = document.createElement('button');
@@ -2475,9 +2510,9 @@
 
             document.getElementById('lightbox-close').addEventListener('click', closeLightbox);
             lightboxEl.addEventListener('click', (e) => { if (e.target === lightboxEl) closeLightbox(); });
-            document.getElementById('lightbox-save').addEventListener('click', () => {
+            document.getElementById('lightbox-save').addEventListener('click', (e) => {
                 const item = lightboxImageList[lightboxIndex];
-                if (item) downloadFile(item.id, item.name);
+                if (item) downloadFile(item.id, item.name, e.currentTarget);
             });
 
             // #189: 動画プレイヤー
@@ -2507,9 +2542,9 @@
             videoPlayerOverlay.addEventListener('click', (e) => {
                 if (e.target === videoPlayerOverlay) closeVideoPlayer();
             });
-            document.getElementById('video-player-download').addEventListener('click', () => {
+            document.getElementById('video-player-download').addEventListener('click', (e) => {
                 if (videoPlayerState.id && videoPlayerState.name) {
-                    downloadFile(videoPlayerState.id, videoPlayerState.name);
+                    downloadFile(videoPlayerState.id, videoPlayerState.name, e.currentTarget);
                 }
             });
 
@@ -2573,9 +2608,9 @@
             });
             document.getElementById('text-preview-reload').addEventListener('click', loadTextPreview);
             textPreviewMode.addEventListener('change', loadTextPreview);
-            document.getElementById('text-preview-download').addEventListener('click', () => {
+            document.getElementById('text-preview-download').addEventListener('click', (e) => {
                 if (textPreviewState.id && textPreviewState.name) {
-                    downloadFile(textPreviewState.id, textPreviewState.name);
+                    downloadFile(textPreviewState.id, textPreviewState.name, e.currentTarget);
                 }
             });
 

--- a/bin/localnode_cli.dart
+++ b/bin/localnode_cli.dart
@@ -2950,9 +2950,18 @@ class _CliServer {
 
   void _runPostActions(String filePath) {
     final filename = p.basename(filePath);
-    for (final action in _postActions) {
-      if (!_globMatch(action.pattern, filename)) continue;
-      () async {
+    // #181: マッチするアクションを登録順に「逐次」実行する。
+    // 以前は各アクションを await せず並列起動していたため、同一ファイルに
+    // 複数マッチ（例: `*.png=move.sh` と `*=notify.sh`）した場合に実行順が
+    // 不定になり、先行アクションがファイルを移動/削除すると後続が不定に
+    // 失敗していた。1 ファイルにつき 1 本の async チェーンにまとめ、
+    // アップロード応答はブロックしない（fire-and-forget のまま）。
+    final matched = _postActions
+        .where((a) => _globMatch(a.pattern, filename))
+        .toList();
+    if (matched.isEmpty) return;
+    () async {
+      for (final action in matched) {
         try {
           final cmd = _buildCommand(action.script, [filePath]);
           final result = await Process.run(
@@ -2971,8 +2980,8 @@ class _CliServer {
         } catch (e) {
           stderr.writeln('[post-action] Failed to run "${action.script}": $e');
         }
-      }();
-    }
+      }
+    }();
   }
 
   String _buildMentionList() {

--- a/bin/localnode_cli.dart
+++ b/bin/localnode_cli.dart
@@ -26,7 +26,7 @@ import 'package:shelf_static/shelf_static.dart';
 import 'package:yaml/yaml.dart';
 
 // pubspec.yaml の version と一致させる
-const String _appVersion = '1.8.0';
+const String _appVersion = '1.9.0';
 
 // #174 + #220: 予約メンション名。ユーザーが `--mention-action <name>=...` で
 // 登録できない。

--- a/bin/localnode_cli.dart
+++ b/bin/localnode_cli.dart
@@ -2911,6 +2911,8 @@ class _CliServer {
       if (_postActions.isNotEmpty) {
         _runPostActions(file.path);
       }
+      // #214: x-clipboard-text / x-clipboard-link 指定時はクリップボードにも通知
+      _maybePostUploadClipboard(req, file, relPath);
       // #219: 親への転送 (自分が子のとき、かつ受信が federation 由来でない場合)
       _forwardFileToParents(file, req);
       return Response.ok('File uploaded: ${p.basename(file.path)}');
@@ -3028,12 +3030,17 @@ class _CliServer {
     return lines.join('\n');
   }
 
-  void _replyToClipboard(String text) {
+  void _replyToClipboard(String text) =>
+      _appendClipboard(text, tag: 'mention-result');
+
+  // クリップボードに1件追加して lastModified を更新する共通処理。
+  void _appendClipboard(String text, {String? tag, bool important = false}) {
     final item = _ClipboardItem(
       id: _generateId(),
       text: text,
-      tag: 'mention-result',
+      tag: tag,
       createdAt: DateTime.now(),
+      important: important,
     );
     _clipboardItems.insert(0, item);
     while (_clipboardItems.length > _maxClipboardItems) {
@@ -3041,6 +3048,39 @@ class _CliServer {
       _recordDeletion(evicted.id);
     }
     _clipboardLastModified = DateTime.now().millisecondsSinceEpoch;
+  }
+
+  // #214: アップロードと同時にクリップボード通知を1件投稿する。
+  // x-clipboard-text（本文）/ x-clipboard-tag（タグ）は x-filename と同様に
+  // percent-encoded で受け取り decode する。x-clipboard-link: 1 のときは本文が
+  // 無くても保存済みファイルへの @file:<relpath> マーカーを自動生成する。
+  void _maybePostUploadClipboard(Request req, File file, String relPath) {
+    if (!_clipboardEnabled) return;
+    final text = _decodeHeader(req.headers['x-clipboard-text'])?.trim();
+    final rawTag = _decodeHeader(req.headers['x-clipboard-tag'])?.trim();
+    final link = req.headers['x-clipboard-link']?.trim();
+    final tag = (rawTag != null && rawTag.isNotEmpty) ? rawTag : null;
+
+    String? msg;
+    if (text != null && text.isNotEmpty) {
+      msg = text;
+    } else if (link == '1') {
+      final saved = p.basename(file.path);
+      final rel = relPath.isEmpty ? saved : '$relPath/$saved';
+      msg = '@file:$rel';
+    }
+    if (msg == null || msg.isEmpty) return;
+    if (msg.length > _maxTextLength) msg = msg.substring(0, _maxTextLength);
+    _appendClipboard(msg, tag: tag);
+  }
+
+  String? _decodeHeader(String? raw) {
+    if (raw == null) return null;
+    try {
+      return Uri.decodeComponent(raw);
+    } catch (_) {
+      return raw; // percent-encode されていない値はそのまま扱う
+    }
   }
 
   void _runMentionAction(String alias, String script) {

--- a/bin/localnode_cli.dart
+++ b/bin/localnode_cli.dart
@@ -111,6 +111,8 @@ class _LoadedConfig {
   String? dir;
   String? mode;
   String? name;
+  // #287
+  String? cacheDir;
   String? httpsCert;
   String? httpsKey;
   String? token;
@@ -190,6 +192,7 @@ _LoadedConfig _loadConfig(String path) {
     cfg.pinLength = _yamlInt(server, 'pin-length');
     cfg.pinCharset = _yamlString(server, 'pin-charset');
     cfg.maxUploadSize = _yamlString(server, 'max-upload-size');
+    cfg.cacheDir = _yamlString(server, 'cache-dir');     // #287
     cfg.stateFile = _yamlString(server, 'state-file');   // #237
     cfg.pinFile = _yamlString(server, 'pin-file');       // #208
     cfg.tokenFile = _yamlString(server, 'token-file');   // #208
@@ -355,6 +358,9 @@ Future<void> main(List<String> args) async {
     stderr.writeln('Error: Directory does not exist: $dir');
     exit(1);
   }
+
+  // #287: キャッシュ/一時データの基点（CLI arg > YAML）。存在検証は起動時に行う。
+  final cacheDir = results['cache-dir'] as String? ?? cfg?.cacheDir;
 
   final specifiedIp = results.wasParsed('ip')
       ? results['ip'] as String?
@@ -644,6 +650,7 @@ Future<void> main(List<String> args) async {
       ipAddress: ipAddress,
       port: port,
       storagePath: dir,
+      cacheDir: cacheDir,           // #287
       downloadOnly: downloadOnly,
       authMode: authMode,
       fixedPin: fixedPin,
@@ -815,6 +822,9 @@ ArgParser _buildParser() {
         allowed: ['digits', 'alnum', 'alnum_symbols'],
         defaultsTo: 'digits')
     ..addOption('dir', abbr: 'd', help: 'Shared directory path')
+    ..addOption('cache-dir',
+        help: 'Base directory for cache/temp data (thumbnails, web assets, '
+            'zip staging). Default: the system temp directory')
     ..addOption('mode',
         abbr: 'm',
         help: 'Operation mode',
@@ -1469,6 +1479,8 @@ class _CliServer {
   int _startedAt = 0;
 
   String? _storagePath;
+  // #287: キャッシュ/一時データの基点。null なら OS の一時ディレクトリ。
+  String? _cacheDir;
   Directory? _webRootDir;
   Directory? _thumbnailCacheDir;
   late final Uint8List _placeholderThumbBytes = _buildPlaceholderJpeg();
@@ -2031,6 +2043,7 @@ class _CliServer {
     required String ipAddress,
     required int port,
     String? storagePath,
+    String? cacheDir,             // #287
     bool downloadOnly = false,
     _AuthMode authMode = _AuthMode.randomPin,
     String? fixedPin,
@@ -2056,6 +2069,7 @@ class _CliServer {
     _pinLength = pinLength;       // #206
     _pinCharset = pinCharset;     // #206
     _maxDirectUploadBytes = maxDirectUploadBytes; // #262
+    _cacheDir = cacheDir;         // #287
     _startedAt = DateTime.now().millisecondsSinceEpoch;
 
     switch (authMode) {
@@ -2214,6 +2228,31 @@ class _CliServer {
 
   // --- 初期化 ---
 
+  // #287: キャッシュ/一時データの基点ディレクトリ。
+  // --cache-dir 指定時はそこを、なければ OS の一時ディレクトリを使う。
+  Directory _cacheBaseDir() =>
+      (_cacheDir != null && _cacheDir!.isNotEmpty)
+          ? Directory(_cacheDir!)
+          : Directory.systemTemp;
+
+  // #287: --cache-dir を検証。作成できなければ警告して OS 一時ディレクトリに
+  // フォールバックする（サーバは起動し続ける）。
+  Future<void> _validateCacheDir() async {
+    if (_cacheDir == null || _cacheDir!.isEmpty) return;
+    final dir = Directory(_cacheDir!);
+    try {
+      if (!await dir.exists()) await dir.create(recursive: true);
+      // 書き込み可否を実際に createTemp して確認（失敗すれば catch へ）
+      final probe = await dir.createTemp('localnode_cli_probe_');
+      await probe.delete();
+    } catch (e) {
+      stderr.writeln(
+          'Warning: --cache-dir "$_cacheDir" is not usable ($e); '
+          'falling back to the system temp directory.');
+      _cacheDir = null;
+    }
+  }
+
   Future<void> _init(String? storagePath) async {
     if (storagePath != null) {
       _storagePath = storagePath;
@@ -2224,20 +2263,21 @@ class _CliServer {
     final dir = Directory(_storagePath!);
     if (!await dir.exists()) await dir.create(recursive: true);
 
+    await _validateCacheDir(); // #287
+    final cacheBase = _cacheBaseDir();
+
     // #271/#264: PID + OS ランダムサフィックスでインスタンス分離かつ symlink poisoning を防ぐ
     const thumbPrefix = 'localnode_cli_thumbnails_';
-    _reapStaleDeployDirs(Directory.systemTemp, thumbPrefix);
+    _reapStaleDeployDirs(cacheBase, thumbPrefix);
     // #264: createTemp で OS がアトミックにディレクトリを生成 → パスが推測不能
     _thumbnailCacheDir =
-        await Directory.systemTemp.createTemp('${thumbPrefix}${pid}_');
+        await cacheBase.createTemp('${thumbPrefix}${pid}_');
     // #269: 他ユーザーから読めないようにパーミッションを制限
     _chmodDir(_thumbnailCacheDir!);
   }
 
   Future<void> _deployAssets() async {
-    final tmpBase = Platform.environment['TMPDIR'] ??
-        Platform.environment['TEMP'] ??
-        '/tmp';
+    final tmpBase = _cacheBaseDir().path; // #287
     // #242: 同一ホストでの複数 LocalNode 共存を許す。
     // 固定パスだと後発の起動が先発の serving content を上書きするため
     // PID を混ぜたユニーク dir に展開する。
@@ -3306,7 +3346,8 @@ class _CliServer {
     }
 
     // #195: ZIP を一時ファイルへストリーミング書き出ししてレスポンスとして流す
-    final tempDir = await Directory.systemTemp.createTemp('localnode_zip_');
+    // #287: --cache-dir 指定時はそこに置く（zip も大きくなり得るため）
+    final tempDir = await _cacheBaseDir().createTemp('localnode_zip_');
     final zipPath = p.join(tempDir.path, 'localnode_files.zip');
     try {
       final zipEncoder = ZipFileEncoder()..create(zipPath);

--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -11,6 +11,7 @@ server:
   ip: 192.168.1.100              # 省略可（自動選択）
   name: home-server              # ブラウザタブに表示する名前
   dir: /srv/share                # 共有フォルダ
+  cache-dir: /var/cache/localnode # キャッシュ/一時データ置き場 (#287)。省略時は OS の一時ディレクトリ
   pin: "1234"                    # 固定 PIN（省略するとランダム生成）
   mode: normal                   # normal / download-only
   no-pin: false                  # PIN 認証を無効化（信頼ネットワーク用）

--- a/lib/cli_runner.dart
+++ b/lib/cli_runner.dart
@@ -28,6 +28,9 @@ class CliRunner {
       ..addOption('ip', help: 'IP address to advertise (skip auto-detection)')
       ..addOption('pin', help: 'Fixed PIN (random if not specified)')
       ..addOption('dir', abbr: 'd', help: 'Shared directory path')
+      ..addOption('cache-dir',
+          help: 'Base directory for cache/temp data (thumbnails, web assets, '
+              'zip staging). Default: the system temp directory')
       ..addOption('mode',
           abbr: 'm',
           help: 'Operation mode (normal/download-only)',
@@ -78,6 +81,7 @@ class CliRunner {
     final fixedPin = results['pin'] as String?;
     final dir = results['dir'] as String?;
     final specifiedIp = results['ip'] as String?;
+    final cacheDir = results['cache-dir'] as String?; // #287
     final noClipboard = results['no-clipboard'] as bool;
     final verbose = results['verbose'] as bool;
     final serverName = results['name'] as String;
@@ -129,6 +133,7 @@ class CliRunner {
         port: port,
         fixedPin: fixedPin,
         storagePath: dir,
+        cacheDir: cacheDir, // #287
         operationMode: operationMode,
         authMode: authMode,
         verboseLogging: verbose,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,6 +10,7 @@ import 'package:localnode/server_service.dart';
 import 'package:qr_flutter/qr_flutter.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:url_launcher/url_launcher.dart';
 import 'package:window_manager/window_manager.dart';
 
 // サーバーの状態を表すenum
@@ -1704,8 +1705,63 @@ class _HomePageState extends ConsumerState<HomePage> {
                   },
                 ),
               ),
+
+            // #239: 検索 / タグフィルタ / ページングは Web UI 側に集約する。
+            // アプリ内で二重実装せず、ブラウザで開いてもらう導線を置く。
+            const SizedBox(height: 4),
+            Align(
+              alignment: Alignment.centerRight,
+              child: TextButton.icon(
+                icon: const Icon(Icons.open_in_new, size: 18),
+                label: const Text('ブラウザで開く（検索・フィルタ）'),
+                onPressed: () => _openWebUi(context),
+                style: TextButton.styleFrom(foregroundColor: Colors.teal[700]),
+              ),
+            ),
           ],
         ),
+      ),
+    );
+  }
+
+  /// #239: サーバ自身の Web UI をブラウザで開く。
+  /// HTTP のときは localhost を使う（セキュアコンテキスト扱いなので
+  /// Web UI 側の navigator.clipboard が動く。Host ガード(#258)も許可済み）。
+  /// HTTPS のときは証明書のホスト名と一致させるため qrUrl をそのまま使う。
+  Future<void> _openWebUi(BuildContext context) async {
+    final serverState = ref.read(serverNotifierProvider);
+    final notifier = ref.read(serverNotifierProvider.notifier);
+    final port = serverState.port;
+    final target = serverState.httpsMode
+        ? notifier.qrUrl
+        : (port != null ? 'http://localhost:$port' : null);
+
+    if (target == null) {
+      _showSnack(context, 'サーバーが起動していません。', isError: true);
+      return;
+    }
+    try {
+      final ok = await launchUrl(
+        Uri.parse(target),
+        mode: LaunchMode.externalApplication,
+      );
+      if (!ok && context.mounted) {
+        _showSnack(context, 'ブラウザを開けませんでした: $target', isError: true);
+      }
+    } catch (e) {
+      if (context.mounted) {
+        _showSnack(context, 'ブラウザを開けませんでした: $e', isError: true);
+      }
+    }
+  }
+
+  void _showSnack(BuildContext context, String message, {bool isError = false}) {
+    if (!context.mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(message),
+        backgroundColor: isError ? Colors.red : null,
+        duration: const Duration(seconds: 2),
       ),
     );
   }

--- a/lib/server_service.dart
+++ b/lib/server_service.dart
@@ -661,6 +661,8 @@ class ServerService {
         });
 
         if (newFileUri != null) {
+          // #214: SAF はサブフォルダ非対応なので relPath は空。
+          _maybePostUploadClipboard(request, sanitizedFilename, '');
           return Response.ok('File uploaded successfully: $sanitizedFilename');
         } else {
           return Response.internalServerError(body: 'Failed to create file via SAF.');
@@ -716,6 +718,8 @@ class ServerService {
         }
         await sink.close();
         _log('Upload success: ${p.basename(file.path)} bytes=$totalBytes');
+        // #214: x-clipboard-text / x-clipboard-link 指定時はクリップボードにも通知
+        _maybePostUploadClipboard(request, p.basename(file.path), relPath);
         return Response.ok('File uploaded successfully: ${p.basename(file.path)}');
       } catch (e, st) {
         await sink.close();
@@ -1685,6 +1689,56 @@ class ServerService {
         body: json.encode({'error': 'Invalid request body.'}),
         headers: {'Content-Type': 'application/json'},
       );
+    }
+  }
+
+  // クリップボードに1件追加して lastModified を更新する共通処理。
+  void _appendClipboard(String text, {String? tag, bool important = false}) {
+    final item = ClipboardItem(
+      id: _generateClipboardId(),
+      text: text,
+      tag: tag,
+      createdAt: DateTime.now(),
+      important: important,
+    );
+    _clipboardItems.insert(0, item);
+    while (_clipboardItems.length > _maxClipboardItems) {
+      final evicted = _evictClipboardItem();
+      _recordDeletion(evicted.id);
+    }
+    _clipboardLastModified = DateTime.now().millisecondsSinceEpoch;
+  }
+
+  // #214: アップロードと同時にクリップボード通知を1件投稿する。
+  // x-clipboard-text（本文）/ x-clipboard-tag（タグ）は x-filename と同様に
+  // percent-encoded で受け取り decode する。x-clipboard-link: 1 のときは本文が
+  // 無くても保存済みファイルへの @file:<relpath> マーカーを自動生成する。
+  void _maybePostUploadClipboard(
+      Request request, String savedName, String relPath) {
+    if (!_clipboardEnabled) return;
+    final text = _decodeHeader(request.headers['x-clipboard-text'])?.trim();
+    final rawTag = _decodeHeader(request.headers['x-clipboard-tag'])?.trim();
+    final link = request.headers['x-clipboard-link']?.trim();
+    final tag = (rawTag != null && rawTag.isNotEmpty) ? rawTag : null;
+
+    String? msg;
+    if (text != null && text.isNotEmpty) {
+      msg = text;
+    } else if (link == '1') {
+      final rel = relPath.isEmpty ? savedName : '$relPath/$savedName';
+      msg = '@file:$rel';
+    }
+    if (msg == null || msg.isEmpty) return;
+    if (msg.length > _maxTextLength) msg = msg.substring(0, _maxTextLength);
+    _appendClipboard(msg, tag: tag);
+  }
+
+  String? _decodeHeader(String? raw) {
+    if (raw == null) return null;
+    try {
+      return Uri.decodeComponent(raw);
+    } catch (_) {
+      return raw; // percent-encode されていない値はそのまま扱う
     }
   }
 

--- a/lib/server_service.dart
+++ b/lib/server_service.dart
@@ -1106,30 +1106,19 @@ class ServerService {
   //       (#244 review)
   //       - 末尾でマルチバイト境界をまたいだだけの偽陰性は最大 3 バイト
   //         までトリムして再試行することで吸収する。
-  //       - SAF 経路は現状の readFile が「全ファイル読み」のため、
-  //         巨大ファイルに到達する前にサイズを問い合わせ、5MB を超える
-  //         なら sniff 自体スキップして not-text 扱いで返す
-  //         (preview の maxFullBytes と整合)。巨大バイナリで「TXT として
-  //         開く」誤クリックされても OOM やハングに至らないためのガード。
-  //         本物の範囲読み実装は別 issue (1.7.0+) に切り出す。
+  //       - #245: SAF 経路も範囲読み (readFileRange) で先頭 8KB だけ取得する。
+  //         以前は readFile が「全ファイル読み」だったため 5MB のサイズ上限で
+  //         ガードしていたが、範囲読みなら sniff はファイルサイズに依存しない。
+  //         (実プレビュー側の maxFullBytes 上限は従来どおり有効)
   Future<bool> _sniffTextLike(String decoded) async {
     try {
       const sniffBytes = 8 * 1024;
-      const maxFullBytes = 5 * 1024 * 1024;
       Uint8List buf;
       if (Platform.isAndroid && _safDirectoryUri != null) {
-        try {
-          final size = await _safPlatform
-              .invokeMethod<int>('getFileSize', {'uri': decoded});
-          if (size != null && size > maxFullBytes) return false;
-        } catch (_) {
-          // size 取得失敗時は readFile に委ねる (compatibility)
-        }
-        final bytes = await _safPlatform.invokeMethod('readFile', {'uri': decoded});
+        final bytes = await _safPlatform.invokeMethod(
+            'readFileRange', {'uri': decoded, 'offset': 0, 'length': sniffBytes});
         if (bytes == null) return false;
-        final all = bytes as Uint8List;
-        final n = all.length < sniffBytes ? all.length : sniffBytes;
-        buf = Uint8List.sublistView(all, 0, n);
+        buf = bytes as Uint8List;
       } else {
         final file = File(decoded);
         final raf = await file.open();

--- a/lib/server_service.dart
+++ b/lib/server_service.dart
@@ -78,6 +78,8 @@ class ServerService {
   String? _displayPath; // 表示用のパス
   Directory? _webRootDir; // Webルートディレクトリのパス
   Directory? _thumbnailCacheDir; // サムネイルキャッシュディレクトリ
+  // #287: CLI (`localnode --cli`) の --cache-dir。null なら OS の一時ディレクトリ。
+  String? _cacheDir;
   static final Uint8List _placeholderThumbBytes = _buildPlaceholderJpeg();
   String? _pin;
   // #261: セッショントークン -> 失効エポックミリ秒。TTL 超過で無効化する。
@@ -1457,7 +1459,8 @@ class ServerService {
 
     // #195: ZIP を一時ファイルへストリーミングして書き出し、レスポンスとして
     // 流す。これによりサーバ側でも巨大ファイル × 多数を扱える。
-    final tempDir = await Directory.systemTemp.createTemp('localnode_zip_');
+    // #287: CLI の --cache-dir 指定時はその配下に置く（GUI では null → systemTemp）。
+    final tempDir = await _cliCacheBaseDir().createTemp('localnode_zip_');
     final zipPath = p.join(tempDir.path, 'archive.zip');
     // ステージング用サブディレクトリ (Copilot #199 review):
     // ユーザのファイル名と zip 出力名/パス・パス区切り文字の衝突を避ける
@@ -1884,21 +1887,18 @@ class ServerService {
     // サムネイルキャッシュディレクトリの初期化
     // #264/#269/#271: 共有 /tmp では固定名だと symlink poisoning / 情報漏洩の恐れ。
     // PID + OS ランダムサフィックスで分離し 700 に制限、死んだ PID の残骸は掃除する。
-    final tempPath = Platform.environment['TMPDIR'] ??
-        Platform.environment['TEMP'] ??
-        '/tmp';
+    // #287: --cache-dir 指定時はその配下に置く。
+    final cacheBase = _cliCacheBaseDir();
     const thumbPrefix = 'localnode_thumbnails_';
-    _reapStaleWebDirs(Directory(tempPath), thumbPrefix);
+    _reapStaleWebDirs(cacheBase, thumbPrefix);
     _thumbnailCacheDir =
-        await Directory(tempPath).createTemp('$thumbPrefix${pid}_');
+        await cacheBase.createTemp('$thumbPrefix${pid}_');
     _chmodDir(_thumbnailCacheDir!);
   }
 
   /// CLI用のアセット展開（Flutterプラグインを使用しない）
   Future<void> _deployAssetsCli() async {
-    final tempPath = Platform.environment['TMPDIR'] ??
-        Platform.environment['TEMP'] ??
-        '/tmp';
+    final tempPath = _cliCacheBaseDir().path; // #287
     // #242: 同ホストで他 LocalNode と共存しても上書きしないよう PID 別
     const prefix = 'localnode_web_';
     _reapStaleWebDirs(Directory(tempPath), prefix);
@@ -1977,6 +1977,7 @@ class ServerService {
     required int port,
     String? fixedPin,
     String? storagePath,
+    String? cacheDir, // #287
     OperationMode operationMode = OperationMode.normal,
     AuthMode authMode = AuthMode.randomPin,
     bool verboseLogging = false,
@@ -1994,6 +1995,8 @@ class ServerService {
     _serverName = serverName.isNotEmpty ? serverName : 'LocalNode';
     _operationMode = operationMode;
     _authMode = authMode;
+    _cacheDir = cacheDir; // #287
+    await _validateCacheDir(); // #287
 
     // 認証モードに応じたPIN設定
     switch (authMode) {
@@ -2155,6 +2158,7 @@ class ServerService {
     _httpsEnabled = false;
     _allowedHosts = {};
     _maxUploadBytes = null;
+    _cacheDir = null; // #287
     _ipAddress = null;
     _port = null;
     _pin = null;
@@ -2224,6 +2228,34 @@ class ServerService {
       return r.exitCode == 0;
     } catch (_) {
       return true;
+    }
+  }
+
+  // #287: CLI の --cache-dir が指定されていればそこを、なければ OS の一時
+  // ディレクトリを基点にする。GUI 経路 (startServer) は _cacheDir を設定しない
+  // ので従来どおり systemTemp / getTemporaryDirectory のまま。
+  Directory _cliCacheBaseDir() =>
+      (_cacheDir != null && _cacheDir!.isNotEmpty)
+          ? Directory(_cacheDir!)
+          : Directory.systemTemp;
+
+  // #287: --cache-dir を検証。作成できなければ警告して OS 一時ディレクトリに
+  // フォールバックする（サーバは起動し続ける）。macOS はサンドボックスにより
+  // コンテナ外パスが拒否され得るが、その場合もここでフォールバックする。
+  Future<void> _validateCacheDir() async {
+    if (_cacheDir == null || _cacheDir!.isEmpty) return;
+    final dir = Directory(_cacheDir!);
+    try {
+      if (!await dir.exists()) await dir.create(recursive: true);
+      final probe = await dir.createTemp('localnode_cli_probe_');
+      await probe.delete();
+    } catch (e) {
+      _log('Warning: --cache-dir "$_cacheDir" is not usable ($e); '
+          'falling back to the system temp directory.');
+      // フォールバックは verbose 以外でも見えるよう stderr にも出す
+      stderr.writeln('Warning: --cache-dir "$_cacheDir" is not usable ($e); '
+          'falling back to the system temp directory.');
+      _cacheDir = null;
     }
   }
 

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -8,6 +8,7 @@
 
 #include <file_saver/file_saver_plugin.h>
 #include <screen_retriever_linux/screen_retriever_linux_plugin.h>
+#include <url_launcher_linux/url_launcher_plugin.h>
 #include <window_manager/window_manager_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
@@ -17,6 +18,9 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) screen_retriever_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "ScreenRetrieverLinuxPlugin");
   screen_retriever_linux_plugin_register_with_registrar(screen_retriever_linux_registrar);
+  g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
+  url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);
   g_autoptr(FlPluginRegistrar) window_manager_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "WindowManagerPlugin");
   window_manager_plugin_register_with_registrar(window_manager_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -5,6 +5,7 @@
 list(APPEND FLUTTER_PLUGIN_LIST
   file_saver
   screen_retriever_linux
+  url_launcher_linux
   window_manager
 )
 

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -13,6 +13,7 @@ import package_info_plus
 import path_provider_foundation
 import screen_retriever_macos
 import shared_preferences_foundation
+import url_launcher_macos
 import wakelock_plus
 import window_manager
 
@@ -25,6 +26,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   ScreenRetrieverMacosPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverMacosPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
+  UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
   WakelockPlusMacosPlugin.register(with: registry.registrar(forPlugin: "WakelockPlusMacosPlugin"))
   WindowManagerPlugin.register(with: registry.registrar(forPlugin: "WindowManagerPlugin"))
 }

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -13,10 +13,16 @@ PODS:
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
+  - screen_retriever_macos (0.0.1):
+    - FlutterMacOS
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
+  - url_launcher_macos (0.0.1):
+    - FlutterMacOS
   - wakelock_plus (0.0.1):
+    - FlutterMacOS
+  - window_manager (0.2.0):
     - FlutterMacOS
 
 DEPENDENCIES:
@@ -27,8 +33,11 @@ DEPENDENCIES:
   - network_info_plus (from `Flutter/ephemeral/.symlinks/plugins/network_info_plus/macos`)
   - package_info_plus (from `Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos`)
   - path_provider_foundation (from `Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin`)
+  - screen_retriever_macos (from `Flutter/ephemeral/.symlinks/plugins/screen_retriever_macos/macos`)
   - shared_preferences_foundation (from `Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin`)
+  - url_launcher_macos (from `Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos`)
   - wakelock_plus (from `Flutter/ephemeral/.symlinks/plugins/wakelock_plus/macos`)
+  - window_manager (from `Flutter/ephemeral/.symlinks/plugins/window_manager/macos`)
 
 EXTERNAL SOURCES:
   device_info_plus:
@@ -45,10 +54,16 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos
   path_provider_foundation:
     :path: Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin
+  screen_retriever_macos:
+    :path: Flutter/ephemeral/.symlinks/plugins/screen_retriever_macos/macos
   shared_preferences_foundation:
     :path: Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin
+  url_launcher_macos:
+    :path: Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos
   wakelock_plus:
     :path: Flutter/ephemeral/.symlinks/plugins/wakelock_plus/macos
+  window_manager:
+    :path: Flutter/ephemeral/.symlinks/plugins/window_manager/macos
 
 SPEC CHECKSUMS:
   device_info_plus: 4fb280989f669696856f8b129e4a5e3cd6c48f76
@@ -58,8 +73,11 @@ SPEC CHECKSUMS:
   network_info_plus: 21d1cd6a015ccb2fdff06a1fbfa88d54b4e92f61
   package_info_plus: f0052d280d17aa382b932f399edf32507174e870
   path_provider_foundation: bb55f6dbba17d0dccd6737fe6f7f34fbd0376880
+  screen_retriever_macos: 452e51764a9e1cdb74b3c541238795849f21557f
   shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
+  url_launcher_macos: f87a979182d112f911de6820aefddaf56ee9fbfd
   wakelock_plus: 917609be14d812ddd9e9528876538b2263aaa03b
+  window_manager: 1d01fa7ac65a6e6f83b965471b1a7fdd3f06166c
 
 PODFILE CHECKSUM: 54d867c82ac51cbd61b565781b9fada492027009
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -909,6 +909,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.0"
+  url_launcher:
+    dependency: "direct main"
+    description:
+      name: url_launcher
+      sha256: f6a7e5c4835bb4e3026a04793a4199ca2d14c739ec378fdfe23fc8075d0439f8
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.2"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      sha256: "17bc677f0b301615530dd1d67e0a9828cafa2d0b6b6eae4cd3679b7eac4a273c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.30"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      sha256: "580fe5dfb51671ae38191d316e027f6b76272b026370708c2d898799750a02b0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.4.1"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      sha256: d5e14138b3bc193a0f63c10a53c94b91d399df0512b1f29b94a043db7482384a
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.2"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      sha256: "368adf46f71ad3c21b8f06614adb38346f193f3a59ba8fe9a2fd74133070ba18"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.5"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      sha256: "85c81589622fbc87c1c683aaea164d3604a7777495a79d91e39ffcdec39ddb34"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.3"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      sha256: "712c70ab1b99744ff066053cbe3e80c73332b38d46e5e945c98689b2e66fc15f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.5"
   vector_math:
     dependency: transitive
     description:
@@ -1030,5 +1094,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.9.0 <4.0.0"
-  flutter: ">=3.35.0"
+  dart: ">=3.10.0 <4.0.0"
+  flutter: ">=3.38.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -53,6 +53,8 @@ dependencies:
   archive: ^4.0.7
   shared_preferences: ^2.2.0
   unorm_dart: ^0.2.0
+  # #239: クリップボードの検索/フィルタは Web UI に集約し、アプリからはブラウザを開く
+  url_launcher: ^6.3.0
   args: ^2.4.2
   qr: ^3.0.1
   path: ^1.9.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.8.0+1
+version: 1.9.0+1
 
 environment:
   sdk: '>=3.4.3 <4.0.0'

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -9,6 +9,7 @@
 #include <file_saver/file_saver_plugin.h>
 #include <permission_handler_windows/permission_handler_windows_plugin.h>
 #include <screen_retriever_windows/screen_retriever_windows_plugin_c_api.h>
+#include <url_launcher_windows/url_launcher_windows.h>
 #include <window_manager/window_manager_plugin.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
@@ -18,6 +19,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("PermissionHandlerWindowsPlugin"));
   ScreenRetrieverWindowsPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("ScreenRetrieverWindowsPluginCApi"));
+  UrlLauncherWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("UrlLauncherWindows"));
   WindowManagerPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("WindowManagerPlugin"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -6,6 +6,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   file_saver
   permission_handler_windows
   screen_retriever_windows
+  url_launcher_windows
   window_manager
 )
 


### PR DESCRIPTION
## Summary

A quality-of-life release: browser (Web UI) improvements plus several CLI/API additions. No breaking changes. (Public-key auth / Tailscale Funnel mode is deferred to 1.10.0, see #267.)

## Web UI

- **#205** Guard the download buttons (per-file DL, "download folder as zip", lightbox / video / text-preview save) against click-spam — a button is disabled for a short cooldown after a click (1.2s; 3s for the heavier zip download) so repeated clicks no longer start duplicate parallel transfers
- **#210** Add a `@path:<relative-folder>` clipboard marker rendered as a clickable 📂 folder chip; clicking switches to the files tab and navigates there. Shares `@file:`'s path validation and 5-marker cap, needs no thumbnail so it works on the Android SAF app server too
- **#280** On mobile (viewport ≤ 600px) the lightbox `‹`/`›` nav buttons move to the top-left (above the image) instead of the vertically-centered sides where they overlapped the image and were hard to tap
- **#236** (already shipped in v1.8.0 CSS — `clamp(300px, 60vh, 80vh)`; closed alongside this release)

## App (GUI)

- **#239** Clipboard section gains an "open in browser" action. Search / tag filter / paged rendering stay in the Web UI only; the app keeps its quick in-app list and links out for anything more. HTTP → `http://localhost:<port>` (secure context, so copy works); HTTPS → the cert hostname URL

## Android

- **#245** The text-preview text/binary sniff now reads only the first 8 KB via a new `readFileRange` SAF MethodChannel instead of loading the whole file through `readFile`. SAF text files larger than 5 MB now preview correctly (the old 5 MB sniff cap and double-read are gone). The unused `getFileSize` guard is removed

## CLI / API

- **#214** `POST /api/upload` can post a clipboard notification in the same request via optional headers: `x-clipboard-text` (percent-encoded body), `x-clipboard-tag` (percent-encoded tag), `x-clipboard-link: 1` (auto-compose an `@file:<relpath>/<filename>` marker for the saved file). Works on both the standalone CLI and the GUI server (incl. macOS `localnode --cli`); no-op when clipboard sharing is off
- **#287** `--cache-dir <path>` (and `server.cache-dir` in YAML) relocates cache/temp data (thumbnails, web assets, zip staging) off the system temp. Available for the standalone `localnode-cli` and `localnode --cli`; on macOS the app sandbox denies out-of-container paths and falls back to the system temp with a warning
- **#181** (bug) When several `--post-action` patterns matched one uploaded file (e.g. `*.png=move.sh` + `*=notify.sh`), the actions ran in parallel in nondeterministic order and could race (one moving the file out from under another). Matching actions now run sequentially in registration order

## Notes

- Version bumped to 1.9.0
- `flutter analyze` clean; standalone CLI verified end-to-end for #214/#181/#287; `flutter build apk`/`macos` pass. macOS `localnode --cli` runtime for #214/#239 is a manual/device-test item (see `work/1.9.0_check.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)