### PR TITLE
v1.9.0 device-test fixes: header encoding, marker spaces, post-action ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,10 @@ A single upload request can also post a clipboard message, so an automation (e.g
 
 `x-clipboard-text` takes precedence over `x-clipboard-link`. Nothing is posted when neither is present, or when clipboard sharing is disabled (`--no-clipboard`).
 
+> **Header encoding:** percent-encoding the text/tag is recommended (it is the only way HTTP headers can carry non-ASCII reliably). Raw UTF-8 bytes are also accepted and repaired server-side, so both forms display correctly.
+>
+> **Spaces in `@file:` / `@path:` markers:** a marker ends at the first whitespace, so a path containing spaces must be percent-encoded — e.g. `@file:my%20photo.jpg`. `x-clipboard-link` does this automatically (important because duplicate uploads are renamed to `name (1).ext`, which contains a space).
+
 ```bash
 # Upload and notify in one request
 curl -H "Authorization: Bearer <token>" \

--- a/assets/web/index.html
+++ b/assets/web/index.html
@@ -1961,7 +1961,11 @@
                         parts.push(escapeHtml(text.substring(lastIndex, m.index)));
                     }
                     const marker = m[1];
-                    const path = m[2];
+                    // #214: マーカーは空白で切れるため、スペースを含むパスは
+                    // percent-encode されて届く（サーバの自動生成もそうする）。
+                    // 検証の前にデコードする（%2e%2e で .. を潜り抜けさせない）。
+                    let path = m[2];
+                    try { path = decodeURIComponent(path); } catch (_) { /* 不正な%はそのまま */ }
                     const invalid = path.includes('..') ||
                         path.startsWith('/') ||
                         path.startsWith('\\') ||

--- a/bin/localnode_cli.dart
+++ b/bin/localnode_cli.dart
@@ -2950,19 +2950,25 @@ class _CliServer {
         .hasMatch(filename);
   }
 
+  // #181: post-action は「サーバ全体で1本のキュー」に直列化する。
+  // 元は各アクションを await せず並列起動していたため、同一ファイルに複数
+  // マッチすると実行順が不定になり、先行アクションがファイルを移動/削除
+  // すると後続が不定に失敗していた。ファイル内を逐次化しただけでは複数
+  // ファイルを同時アップロードしたときにファイル間で混ざる
+  // (move(A),move(B),move(C) -> notify(A),notify(C),notify(B)) ため、
+  // キュー全体を直列にして「A:move -> A:notify -> B:move -> ...」と
+  // 完全に予測可能な順序にする。post-action スクリプトは同時実行を想定して
+  // いないことが多いので、その点でも安全。
+  // アップロード応答はブロックしない（fire-and-forget のまま）。
+  Future<void> _postActionQueue = Future.value();
+
   void _runPostActions(String filePath) {
     final filename = p.basename(filePath);
-    // #181: マッチするアクションを登録順に「逐次」実行する。
-    // 以前は各アクションを await せず並列起動していたため、同一ファイルに
-    // 複数マッチ（例: `*.png=move.sh` と `*=notify.sh`）した場合に実行順が
-    // 不定になり、先行アクションがファイルを移動/削除すると後続が不定に
-    // 失敗していた。1 ファイルにつき 1 本の async チェーンにまとめ、
-    // アップロード応答はブロックしない（fire-and-forget のまま）。
     final matched = _postActions
         .where((a) => _globMatch(a.pattern, filename))
         .toList();
     if (matched.isEmpty) return;
-    () async {
+    _postActionQueue = _postActionQueue.then((_) async {
       for (final action in matched) {
         try {
           final cmd = _buildCommand(action.script, [filePath]);
@@ -2983,7 +2989,7 @@ class _CliServer {
           stderr.writeln('[post-action] Failed to run "${action.script}": $e');
         }
       }
-    }();
+    });
   }
 
   String _buildMentionList() {
@@ -3067,20 +3073,38 @@ class _CliServer {
     } else if (link == '1') {
       final saved = p.basename(file.path);
       final rel = relPath.isEmpty ? saved : '$relPath/$saved';
-      msg = '@file:$rel';
+      // #214: マーカーは空白で切れる (`@file:(\S+)`) ので percent-encode する。
+      // 重複時のリネームが "name (1).ext" とスペースを含むため必須。
+      // '/' は区切りとして残すためセグメント単位でエンコードする。
+      final encoded = rel.split('/').map(Uri.encodeComponent).join('/');
+      msg = '@file:$encoded';
     }
     if (msg == null || msg.isEmpty) return;
     if (msg.length > _maxTextLength) msg = msg.substring(0, _maxTextLength);
     _appendClipboard(msg, tag: tag);
   }
 
+  // #214: HTTP ヘッダは仕様上 latin1 なので、値の受け取り方が2通りある。
+  //   (a) percent-encoded (推奨・x-filename と同じ) -> decodeComponent で復元
+  //   (b) 生の UTF-8 バイト列 -> latin1 として読まれ文字化けするので、
+  //       latin1 に戻してから UTF-8 として解釈し直す
+  // どちらでも正しく読めるように両方試す。
   String? _decodeHeader(String? raw) {
     if (raw == null) return null;
+    var s = raw;
     try {
-      return Uri.decodeComponent(raw);
+      s = Uri.decodeComponent(s);
     } catch (_) {
-      return raw; // percent-encode されていない値はそのまま扱う
+      // percent-encode されていない値はそのまま
     }
+    try {
+      // s が既に正しい多バイト文字なら latin1.encode が投げるので何もしない。
+      // latin1 で潰れた UTF-8 のときだけ復元される。
+      s = utf8.decode(latin1.encode(s));
+    } catch (_) {
+      // UTF-8 として不正 or もともと正しい文字列 -> そのまま
+    }
+    return s;
   }
 
   void _runMentionAction(String alias, String script) {

--- a/lib/server_service.dart
+++ b/lib/server_service.dart
@@ -1726,20 +1726,38 @@ class ServerService {
       msg = text;
     } else if (link == '1') {
       final rel = relPath.isEmpty ? savedName : '$relPath/$savedName';
-      msg = '@file:$rel';
+      // #214: マーカーは空白で切れる (`@file:(\S+)`) ので percent-encode する。
+      // 重複時のリネームが "name (1).ext" とスペースを含むため必須。
+      // '/' は区切りとして残すためセグメント単位でエンコードする。
+      final encoded = rel.split('/').map(Uri.encodeComponent).join('/');
+      msg = '@file:$encoded';
     }
     if (msg == null || msg.isEmpty) return;
     if (msg.length > _maxTextLength) msg = msg.substring(0, _maxTextLength);
     _appendClipboard(msg, tag: tag);
   }
 
+  // #214: HTTP ヘッダは仕様上 latin1 なので、値の受け取り方が2通りある。
+  //   (a) percent-encoded (推奨・x-filename と同じ) -> decodeComponent で復元
+  //   (b) 生の UTF-8 バイト列 -> latin1 として読まれ文字化けするので、
+  //       latin1 に戻してから UTF-8 として解釈し直す
+  // どちらでも正しく読めるように両方試す。
   String? _decodeHeader(String? raw) {
     if (raw == null) return null;
+    var s = raw;
     try {
-      return Uri.decodeComponent(raw);
+      s = Uri.decodeComponent(s);
     } catch (_) {
-      return raw; // percent-encode されていない値はそのまま扱う
+      // percent-encode されていない値はそのまま
     }
+    try {
+      // s が既に正しい多バイト文字なら latin1.encode が投げるので何もしない。
+      // latin1 で潰れた UTF-8 のときだけ復元される。
+      s = utf8.decode(latin1.encode(s));
+    } catch (_) {
+      // UTF-8 として不正 or もともと正しい文字列 -> そのまま
+    }
+    return s;
   }
 
   /// DELETE /api/clipboard/<id> - 個別アイテム削除


### PR DESCRIPTION
## Summary

Follow-up to #288 — fixes found during the v1.9.0 real-device pass (`work/1.9.0_checked.md`).

## Fixes

**1. #214 — non-ASCII clipboard text was garbled**
HTTP headers are latin1 by spec, so raw UTF-8 sent in `x-clipboard-text` was read as latin1 and came out mojibake. `_decodeHeader` now also repairs latin1-mangled UTF-8 (`latin1.encode` → `utf8.decode`, a no-op when the string is already correct). Both percent-encoded and raw-UTF-8 headers now display correctly. Applied to both the CLI and GUI servers.

**2. #214 / #198 / #210 — markers broke on paths containing spaces**
The marker regex `@(file|path):(\S+)` stops at whitespace, and duplicate uploads are renamed to `name (1).ext` — so an auto-generated `@file:` chip only rendered the part before the space. Now:
- the server percent-encodes the generated marker path per segment (keeping `/`)
- the Web UI decodes the captured path **before** validating and rendering, so `%2e%2e` can't slip past the `..`/absolute-path checks

This also fixes spaces for hand-written `@file:` (#198) and `@path:` (#210) markers.

**3. #181 — post-action ordering across files**
Actions were serialized per file but files ran concurrently, so uploading A,B,C produced `move(A),move(B),move(C) → notify(...)` instead of grouping per file. They now run through one server-wide serial queue: `A:move → A:notify → B:move → …`. Post-action scripts generally aren't written for concurrent invocation, so this is also safer. Still fire-and-forget with respect to the upload response.

**4. Docs** — `work/1.9.0_check.md`: Android/iOS GUI servers have no Bearer/upload token (cookie-session auth only), so token-based curl automation doesn't apply there; #214's use case targets the standalone CLI / `localnode --cli`. README documents the header encoding and the percent-encoding rule for markers.

## Verification

`flutter analyze`, JS parse, `dart compile exe`, `flutter build macos` all pass. End-to-end on the standalone CLI:
- raw-UTF-8 and percent-encoded headers both render correctly
- `@file:orig%20(1).txt` generated for renamed uploads
- A/B/C uploads run move/notify grouped per file, in order

🤖 Generated with [Claude Code](https://claude.com/claude-code)