### PR TITLE
v1.10.0: passkey account login + self-hosting polish + hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ localnode --cli [options]
 | `--https-cert` | Path to TLS certificate file (cert.pem) |
 | `--https-key` | Path to TLS private key file (key.pem) |
 | `--post-action` | Script to execute on matching uploads: `pattern=script` (repeatable, glob pattern) |
+| `--post-action-timeout` | Timeout in seconds for each post-action script; the process is killed if it exceeds this. `0` disables the timeout. Default: `300`. Prevents one hung script from blocking all later post-actions |
 | `--mention-action` | Register clipboard mention command: `alias=script` (repeatable) |
 | `--token` | Fixed Bearer token for upload and clipboard POST (random if not specified) |
 | `--no-token` | Disable token-based authentication for upload and clipboard POST |

--- a/README.md
+++ b/README.md
@@ -212,7 +212,22 @@ The file currently contains a single `device_id` UUID generated on first start. 
 localnode-cli --config /mnt/usb/localnode.yaml --state-file /mnt/usb/state.json
 ```
 
-> The state file path is currently a CLI flag only — it is not yet exposed as a YAML config key.
+> The state file path can also be set via `server.state-file` in the YAML config (the CLI arg overrides it).
+
+#### Running as a service (systemd / launchd)
+
+To run the CLI as a background service that starts on boot and restarts on failure, use the templates under [`examples/`](examples/):
+
+- **Linux (systemd):** [`examples/systemd/localnode.service`](examples/systemd/localnode.service) — a unit that runs `localnode-cli --config /etc/localnode/config.yaml` as a dedicated non-root user with filesystem hardening. The header comments list the exact install steps, or use the transparent helper:
+  ```bash
+  sudo examples/systemd/install-localnode.sh /path/to/localnode-cli
+  # then edit /etc/localnode/config.yaml and:
+  sudo systemctl enable --now localnode
+  journalctl -u localnode -f
+  ```
+- **macOS (launchd):** [`examples/launchd/com.ictglab.localnode.plist`](examples/launchd/com.ictglab.localnode.plist) — a LaunchDaemon/LaunchAgent template. Use a self-built / non-App-Store `localnode-cli` binary: the Mac App Store build is sandboxed and cannot run reliably as a daemon writing to arbitrary paths.
+
+Both point at `/etc/localnode/config.yaml` — see [`examples/config.example.yaml`](examples/config.example.yaml) for the full annotated config. Post-action / mention-action scripts run as the service user, so keep them minimal and trusted.
 
 ## Federation (v1.6.0+)
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ localnode --cli [options]
 | `--https-key` | Path to TLS private key file (key.pem) |
 | `--post-action` | Script to execute on matching uploads: `pattern=script` (repeatable, glob pattern) |
 | `--post-action-timeout` | Timeout in seconds for each post-action script; the process is killed if it exceeds this. `0` disables the timeout. Default: `300`. Prevents one hung script from blocking all later post-actions |
+| `--accounts-file` | Path to a YAML passkey accounts file (WebAuthn login). Enables per-user passkey login alongside the PIN. Requires HTTPS + a hostname (or `localhost`) — see [Passkey login](#passkey-login-webauthn) |
 | `--mention-action` | Register clipboard mention command: `alias=script` (repeatable) |
 | `--token` | Fixed Bearer token for upload and clipboard POST (random if not specified) |
 | `--no-token` | Disable token-based authentication for upload and clipboard POST |
@@ -228,6 +229,36 @@ To run the CLI as a background service that starts on boot and restarts on failu
 - **macOS (launchd):** [`examples/launchd/com.ictglab.localnode.plist`](examples/launchd/com.ictglab.localnode.plist) — a LaunchDaemon/LaunchAgent template. Use a self-built / non-App-Store `localnode-cli` binary: the Mac App Store build is sandboxed and cannot run reliably as a daemon writing to arbitrary paths.
 
 Both point at `/etc/localnode/config.yaml` — see [`examples/config.example.yaml`](examples/config.example.yaml) for the full annotated config. Post-action / mention-action scripts run as the service user, so keep them minimal and trusted.
+
+## Passkey login (WebAuthn)
+
+Passkey login lets multiple people sign in with their own passkey instead of sharing one PIN — the SSH `authorized_keys` model applied to passkeys. It coexists with the PIN (the PIN stays available; a PIN session is an anonymous "guest").
+
+**Requirement:** WebAuthn only works over a **secure context with a hostname** — an HTTPS origin (e.g. a Tailscale Funnel / cert hostname) or `http://localhost`. It does **not** work over a bare LAN IP (`http://192.168.x`). So passkey login targets public/HTTPS-hostname access; keep the PIN for plain-IP LAN use.
+
+**Setup**
+
+1. Start the server with an accounts file (created empty or non-existent is fine — you bootstrap the first account from the browser):
+   ```bash
+   localnode-cli --https-cert cert.pem --https-key key.pem \
+                 --accounts-file /etc/localnode/accounts.yaml
+   ```
+   (or `server.accounts-file` in the YAML config)
+2. Open the Web UI over the HTTPS hostname (or `https://localhost`), click **パスキーを登録 (register)** on the PIN screen, enter an account name, and create the passkey on your device.
+3. The page shows a YAML snippet — paste it under `accounts:` in the accounts file and restart the server. See [`examples/accounts.example.yaml`](examples/accounts.example.yaml).
+4. From then on, **🔑 パスキーでログイン** logs that account in.
+
+Each account is one entry:
+```yaml
+accounts:
+  - name: shiba
+    credential_id: <base64url>   # shown by the register page
+    public_key: <base64 SPKI>    # shown by the register page
+```
+
+**Attribution:** clipboard posts from a passkey session are auto-tagged with the account name (unless a tag is given), so the shared clipboard reads like a lightweight multi-person chat. Remove one line from the accounts file to revoke one person.
+
+> Only ES256 (ECDSA P-256) passkeys are supported. Enrollment and login must be served from the same hostname.
 
 ## Federation (v1.6.0+)
 

--- a/android/app/src/main/kotlin/com/ictglab/localnode/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/ictglab/localnode/MainActivity.kt
@@ -16,6 +16,8 @@ class MainActivity: FlutterActivity() {
     private val CHANNEL = "com.ictglab.localnode/saf_storage"
     private val FOLDER_CHANNEL = "com.ictglab.localnode/folder"
     private val REQUEST_CODE_OPEN_DOCUMENT_TREE = 42
+    // #291(L1): readFileRange の 1 回あたりの読み取り上限 (defense-in-depth)
+    private val MAX_READ_RANGE_BYTES = 1 * 1024 * 1024
     private var pendingResult: MethodChannel.Result? = null // Dart側への結果を保持するため
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
@@ -161,6 +163,12 @@ class MainActivity: FlutterActivity() {
                     }
                     if (offset < 0 || length <= 0) {
                         result.error("ARGUMENT_ERROR", "offset must be >= 0 and length > 0.", null)
+                        return@setMethodCallHandler
+                    }
+                    // #291(L1): 多層防御。呼び出し元は先頭 8KB しか要求しないが、
+                    // 将来この channel を別用途で使ったときの無制限確保を防ぐ上限。
+                    if (length > MAX_READ_RANGE_BYTES) {
+                        result.error("ARGUMENT_ERROR", "length exceeds the maximum of $MAX_READ_RANGE_BYTES bytes.", null)
                         return@setMethodCallHandler
                     }
 

--- a/assets/web/index.html
+++ b/assets/web/index.html
@@ -964,6 +964,34 @@
                 <button type="submit">接続</button>
             </form>
             <div id="pinStatus" class="status"></div>
+            <!-- #267: passkey (WebAuthn) ログイン。HTTPS+ホスト名 or localhost でのみ動作。 -->
+            <div id="passkeyArea" style="display:none; margin-top:1rem; border-top:1px solid #eee; padding-top:0.75rem;">
+                <button type="button" id="passkeyLoginBtn" style="width:100%;">🔑 パスキーでログイン</button>
+                <div style="text-align:center; margin-top:0.5rem;">
+                    <a href="#" id="passkeyEnrollLink" style="font-size:0.8rem; color:#00796b;">パスキーを登録（初回セットアップ）</a>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- #267: パスキー登録（enroll）補助モーダル -->
+    <div id="enroll-modal" style="display:none; position:fixed; inset:0; background:rgba(0,0,0,0.6); z-index:300; justify-content:center; align-items:center;">
+        <div style="background:#fff; padding:1.5rem; border-radius:8px; max-width:560px; width:92%; max-height:88vh; overflow:auto;">
+            <h2 style="margin-top:0;">パスキーを登録</h2>
+            <p style="font-size:0.9rem; color:#555;">この端末でパスキーを作成し、下に表示される内容をサーバの credentials ファイルに貼り付けてください（authorized_keys 方式）。</p>
+            <label style="font-size:0.9rem;">アカウント名<br>
+                <input type="text" id="enrollName" placeholder="例: shiba" maxlength="40" style="width:100%; padding:0.4rem; margin-top:0.2rem;">
+            </label>
+            <div style="margin-top:0.75rem;">
+                <button type="button" id="enrollCreateBtn">この端末でパスキーを作成</button>
+                <button type="button" id="enrollCloseBtn" style="margin-left:0.5rem;">閉じる</button>
+            </div>
+            <div id="enrollStatus" class="status" style="margin-top:0.5rem;"></div>
+            <div id="enrollResult" style="display:none; margin-top:0.75rem;">
+                <p style="font-size:0.85rem; margin-bottom:0.3rem;">↓ この YAML を credentials ファイルの <code>accounts:</code> リストに追記して、サーバを再起動:</p>
+                <textarea id="enrollYaml" readonly rows="6" style="width:100%; font-family:monospace; font-size:0.8rem;"></textarea>
+                <button type="button" id="enrollCopyBtn" style="margin-top:0.4rem;">YAML をコピー</button>
+            </div>
         </div>
     </div>
 
@@ -1146,6 +1174,13 @@
 
             // サーバー情報（モード等）
             let serverInfo = {};
+            // #267: /api/info を取り直して serverInfo を更新（ログイン後にアカウント名を反映）
+            const refreshServerInfo = async () => {
+                try {
+                    const r = await fetch('/api/info');
+                    if (r.ok) serverInfo = await r.json();
+                } catch (_) {}
+            };
             // 現在表示中のフォルダパス（ルートは空文字）
             let currentPath = '';
 
@@ -1246,6 +1281,12 @@
                 mainContent.style.display = 'none';
                 pinModal.style.display = 'flex';
                 pinInput.focus();
+                // #267: passkey が使えるサーバ かつ WebAuthn 対応ブラウザでのみ表示。
+                // WebAuthn はセキュアコンテキスト（HTTPS or localhost）が必須。
+                const canPasskey = serverInfo.passkeyEnabled &&
+                    window.PublicKeyCredential && window.isSecureContext;
+                document.getElementById('passkeyArea').style.display =
+                    canPasskey ? 'block' : 'none';
             };
 
             const showMainContent = () => {
@@ -1419,6 +1460,124 @@
                     pinStatus.style.color = 'red';
                     pinInput.value = '';
                 }
+            });
+
+            // #267: passkey (WebAuthn) ログイン / 登録 ================================
+            // base64url <-> bytes ヘルパ
+            const b64urlToBytes = (s) => {
+                s = s.replace(/-/g, '+').replace(/_/g, '/');
+                while (s.length % 4) s += '=';
+                const bin = atob(s);
+                const arr = new Uint8Array(bin.length);
+                for (let i = 0; i < bin.length; i++) arr[i] = bin.charCodeAt(i);
+                return arr;
+            };
+            const bytesToB64url = (buf) => {
+                const arr = new Uint8Array(buf);
+                let bin = '';
+                for (let i = 0; i < arr.length; i++) bin += String.fromCharCode(arr[i]);
+                return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+            };
+            const bytesToB64 = (buf) => {
+                const arr = new Uint8Array(buf);
+                let bin = '';
+                for (let i = 0; i < arr.length; i++) bin += String.fromCharCode(arr[i]);
+                return btoa(bin);
+            };
+
+            const passkeyLogin = async () => {
+                pinStatus.style.color = '#333';
+                pinStatus.textContent = 'パスキーで認証中...';
+                try {
+                    const chRes = await fetch('/api/webauthn/challenge', { method: 'POST' });
+                    if (!chRes.ok) throw new Error('パスキーログインは利用できません。');
+                    const { challenge } = await chRes.json();
+                    const assertion = await navigator.credentials.get({
+                        publicKey: {
+                            challenge: b64urlToBytes(challenge),
+                            userVerification: 'preferred',
+                            timeout: 60000,
+                        }
+                    });
+                    if (!assertion) throw new Error('パスキーがキャンセルされました。');
+                    const r = assertion.response;
+                    const verifyRes = await fetch('/api/webauthn/verify', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({
+                            credentialId: bytesToB64url(assertion.rawId),
+                            authenticatorData: bytesToB64url(r.authenticatorData),
+                            clientDataJSON: bytesToB64url(r.clientDataJSON),
+                            signature: bytesToB64url(r.signature),
+                        })
+                    });
+                    if (!verifyRes.ok) {
+                        const e = await verifyRes.json().catch(() => ({}));
+                        throw new Error(e.error || 'パスキー認証に失敗しました。');
+                    }
+                    // 認証済み。serverInfo を取り直してアカウント名を反映してから表示。
+                    await refreshServerInfo();
+                    showMainContent();
+                } catch (error) {
+                    pinStatus.style.color = 'red';
+                    pinStatus.textContent = error.message || 'パスキー認証に失敗しました。';
+                }
+            };
+            document.getElementById('passkeyLoginBtn').addEventListener('click', passkeyLogin);
+
+            // --- enroll（登録補助）---
+            const enrollModal = document.getElementById('enroll-modal');
+            document.getElementById('passkeyEnrollLink').addEventListener('click', (e) => {
+                e.preventDefault();
+                document.getElementById('enrollStatus').textContent = '';
+                document.getElementById('enrollResult').style.display = 'none';
+                enrollModal.style.display = 'flex';
+            });
+            document.getElementById('enrollCloseBtn').addEventListener('click', () => {
+                enrollModal.style.display = 'none';
+            });
+            document.getElementById('enrollCreateBtn').addEventListener('click', async () => {
+                const st = document.getElementById('enrollStatus');
+                const name = (document.getElementById('enrollName').value || '').trim();
+                if (!name) { st.style.color = 'red'; st.textContent = 'アカウント名を入力してください。'; return; }
+                st.style.color = '#333'; st.textContent = 'パスキーを作成中...';
+                try {
+                    const rnd = new Uint8Array(32); crypto.getRandomValues(rnd);
+                    const uid = new Uint8Array(16); crypto.getRandomValues(uid);
+                    const cred = await navigator.credentials.create({
+                        publicKey: {
+                            challenge: rnd,
+                            rp: { name: serverInfo.serverName || 'LocalNode' },
+                            user: { id: uid, name: name, displayName: name },
+                            pubKeyCredParams: [{ type: 'public-key', alg: -7 }], // ES256
+                            authenticatorSelection: { residentKey: 'preferred', userVerification: 'preferred' },
+                            timeout: 60000,
+                        }
+                    });
+                    const resp = cred.response;
+                    if (resp.getPublicKeyAlgorithm && resp.getPublicKeyAlgorithm() !== -7) {
+                        throw new Error('この認証器は ES256 非対応です（サーバは ES256 のみ対応）。');
+                    }
+                    const spki = resp.getPublicKey(); // SubjectPublicKeyInfo (DER)
+                    if (!spki) throw new Error('公開鍵を取得できませんでした（ブラウザ非対応）。');
+                    const credId = bytesToB64url(cred.rawId);
+                    const pubB64 = bytesToB64(spki);
+                    const yaml =
+                        '  - name: ' + name + '\n' +
+                        '    credential_id: ' + credId + '\n' +
+                        '    public_key: ' + pubB64 + '\n';
+                    document.getElementById('enrollYaml').value = yaml;
+                    document.getElementById('enrollResult').style.display = 'block';
+                    st.style.color = 'green'; st.textContent = 'パスキーを作成しました。下の YAML を保存してください。';
+                } catch (error) {
+                    st.style.color = 'red';
+                    st.textContent = error.message || 'パスキーの作成に失敗しました。';
+                }
+            });
+            document.getElementById('enrollCopyBtn').addEventListener('click', () => {
+                const ta = document.getElementById('enrollYaml');
+                ta.select();
+                try { navigator.clipboard.writeText(ta.value); } catch (_) { document.execCommand('copy'); }
             });
 
             const getFilePreview = (file) => {

--- a/assets/web/index.html
+++ b/assets/web/index.html
@@ -1281,12 +1281,16 @@
                 mainContent.style.display = 'none';
                 pinModal.style.display = 'flex';
                 pinInput.focus();
-                // #267: passkey が使えるサーバ かつ WebAuthn 対応ブラウザでのみ表示。
-                // WebAuthn はセキュアコンテキスト（HTTPS or localhost）が必須。
-                const canPasskey = serverInfo.passkeyEnabled &&
-                    window.PublicKeyCredential && window.isSecureContext;
+                // #267: WebAuthn 対応ブラウザ かつ セキュアコンテキスト（HTTPS or
+                // localhost）で、accounts ファイルが設定されているサーバなら表示。
+                // 登録(enroll)はアカウント0件でも必要（初回ブートストラップ）なので
+                // passkeyConfigured で出す。ログインボタンは登録済み時のみ。
+                const webauthnOk = window.PublicKeyCredential && window.isSecureContext;
+                const showArea = webauthnOk && serverInfo.passkeyConfigured;
                 document.getElementById('passkeyArea').style.display =
-                    canPasskey ? 'block' : 'none';
+                    showArea ? 'block' : 'none';
+                document.getElementById('passkeyLoginBtn').style.display =
+                    (showArea && serverInfo.passkeyEnabled) ? 'block' : 'none';
             };
 
             const showMainContent = () => {
@@ -1562,8 +1566,10 @@
                     if (!spki) throw new Error('公開鍵を取得できませんでした（ブラウザ非対応）。');
                     const credId = bytesToB64url(cred.rawId);
                     const pubB64 = bytesToB64(spki);
+                    // 名前に : や # や空白が入っても壊れないよう YAML ダブルクオート文字列で出す
+                    const nameYaml = '"' + name.replace(/\\/g, '\\\\').replace(/"/g, '\\"') + '"';
                     const yaml =
-                        '  - name: ' + name + '\n' +
+                        '  - name: ' + nameYaml + '\n' +
                         '    credential_id: ' + credId + '\n' +
                         '    public_key: ' + pubB64 + '\n';
                     document.getElementById('enrollYaml').value = yaml;

--- a/bin/localnode_cli.dart
+++ b/bin/localnode_cli.dart
@@ -125,6 +125,8 @@ class _LoadedConfig {
   String? pinCharset;
   // #262
   String? maxUploadSize;
+  // #290
+  int? postActionTimeout;
   // #237
   String? stateFile;
   // #208
@@ -192,6 +194,7 @@ _LoadedConfig _loadConfig(String path) {
     cfg.pinLength = _yamlInt(server, 'pin-length');
     cfg.pinCharset = _yamlString(server, 'pin-charset');
     cfg.maxUploadSize = _yamlString(server, 'max-upload-size');
+    cfg.postActionTimeout = _yamlInt(server, 'post-action-timeout'); // #290
     cfg.cacheDir = _yamlString(server, 'cache-dir');     // #287
     cfg.stateFile = _yamlString(server, 'state-file');   // #237
     cfg.pinFile = _yamlString(server, 'pin-file');       // #208
@@ -424,6 +427,11 @@ Future<void> main(List<String> args) async {
       ? results['max-upload-size'] as String?
       : (cfg?.maxUploadSize ?? results['max-upload-size'] as String?);
   final int? maxDirectUploadBytes = _parseSizeBytes(maxUploadSizeStr);
+  // #290: post-action タイムアウト秒（CLI > YAML > デフォルト300）。0 で無制限。
+  final postActionTimeoutSeconds = int.tryParse(
+          results['post-action-timeout'] as String? ?? '') ??
+      cfg?.postActionTimeout ??
+      300;
 
   // #208: CLI > YAML config
   final String? pinFile = results.wasParsed('pin-file')
@@ -664,6 +672,7 @@ Future<void> main(List<String> args) async {
       postActions: postActions,
       mentionActions: mentionActions,
       maxDirectUploadBytes: maxDirectUploadBytes, // #262
+      postActionTimeoutSeconds: postActionTimeoutSeconds, // #290
       extraAllowedHosts: extraAllowedHosts,       // #275
     );
   } catch (e) {
@@ -847,6 +856,10 @@ ArgParser _buildParser() {
             'Use only on trusted networks. If running as a systemd service, set User= to a '
             'low-privilege account.',
         valueHelp: 'pattern=script')
+    ..addOption('post-action-timeout',
+        help: 'Timeout in seconds for each post-action script; the process is '
+            'killed if it exceeds this. 0 disables the timeout. (default: 300)',
+        valueHelp: 'SECONDS')
     ..addMultiOption('mention-action',
         help:
             'Register a clipboard mention command: <alias>=<script>. '
@@ -2058,6 +2071,7 @@ class _CliServer {
     Map<String, ({String script, String? description})> mentionActions = const {},
     int? maxDirectUploadBytes,    // #262
     List<String> extraAllowedHosts = const [],   // #275
+    int postActionTimeoutSeconds = 300,          // #290 (0 = 無制限)
   }) async {
     _authMode = authMode;
     _downloadOnly = downloadOnly;
@@ -2070,6 +2084,10 @@ class _CliServer {
     _pinCharset = pinCharset;     // #206
     _maxDirectUploadBytes = maxDirectUploadBytes; // #262
     _cacheDir = cacheDir;         // #287
+    // #290: post-action のタイムアウト。0 以下は無制限（従来動作）。
+    _postActionTimeout = postActionTimeoutSeconds > 0
+        ? Duration(seconds: postActionTimeoutSeconds)
+        : null;
     _startedAt = DateTime.now().millisecondsSinceEpoch;
 
     switch (authMode) {
@@ -2961,6 +2979,44 @@ class _CliServer {
   // いないことが多いので、その点でも安全。
   // アップロード応答はブロックしない（fire-and-forget のまま）。
   Future<void> _postActionQueue = Future.value();
+  // #290: 1本ハングするとキュー全体が止まるので、各アクションにタイムアウトを
+  // 設ける。null なら無制限（従来動作）。
+  Duration? _postActionTimeout = const Duration(seconds: 300);
+
+  // #290: スクリプトをタイムアウト付きで実行。時間超過時はプロセスを kill する。
+  // 注意: 出力ストリームは await せず listen で消費する。runInShell 経由だと
+  // タイムアウトで殺したシェルの子プロセスが stdout パイプを握ったまま残ることが
+  // あり、drain/join を await するとそこで固まってキュー全体が止まるため。
+  // プロセス終了とタイムアウトを Completer で競わせ、どちらか早い方で返す。
+  // （スクリプトがさらに子プロセスを detach した場合、その孫までは確実には
+  //   刈り取れない。ここで保証するのは「キューを二度と詰まらせない」こと。）
+  Future<({int exitCode, bool timedOut, String stderr})> _runScript(
+      String exe, List<String> args, Duration? timeout) async {
+    final proc = await Process.start(exe, args, runInShell: !Platform.isWindows);
+    final errBuf = StringBuffer();
+    proc.stdout.listen((_) {}, onError: (_) {});
+    proc.stderr.transform(utf8.decoder).listen(errBuf.write, onError: (_) {});
+
+    if (timeout == null) {
+      final code = await proc.exitCode;
+      return (exitCode: code, timedOut: false, stderr: errBuf.toString());
+    }
+    final completer =
+        Completer<({int exitCode, bool timedOut, String stderr})>();
+    final timer = Timer(timeout, () {
+      if (completer.isCompleted) return;
+      proc.kill(ProcessSignal.sigkill);
+      completer
+          .complete((exitCode: -1, timedOut: true, stderr: errBuf.toString()));
+    });
+    unawaited(proc.exitCode.then((code) {
+      if (completer.isCompleted) return;
+      timer.cancel();
+      completer.complete(
+          (exitCode: code, timedOut: false, stderr: errBuf.toString()));
+    }));
+    return completer.future;
+  }
 
   void _runPostActions(String filePath) {
     final filename = p.basename(filePath);
@@ -2972,16 +3028,14 @@ class _CliServer {
       for (final action in matched) {
         try {
           final cmd = _buildCommand(action.script, [filePath]);
-          final result = await Process.run(
-            cmd.$1, cmd.$2,
-            runInShell: !Platform.isWindows,
-          );
-          if (result.exitCode != 0) {
+          final r = await _runScript(cmd.$1, cmd.$2, _postActionTimeout);
+          if (r.timedOut) {
+            stderr.writeln('[post-action] "${action.script}" timed out after '
+                '${_postActionTimeout!.inSeconds}s (killed) for $filename');
+          } else if (r.exitCode != 0) {
             stderr.writeln(
-                '[post-action] "${action.script}" exited ${result.exitCode}');
-            if ((result.stderr as String).isNotEmpty) {
-              stderr.writeln(result.stderr);
-            }
+                '[post-action] "${action.script}" exited ${r.exitCode}');
+            if (r.stderr.isNotEmpty) stderr.writeln(r.stderr);
           } else {
             _log('[post-action] "${action.script}" completed for $filename');
           }

--- a/bin/localnode_cli.dart
+++ b/bin/localnode_cli.dart
@@ -1563,6 +1563,7 @@ class _CliServer {
   // #267: 発行済み WebAuthn チャレンジ（base64url） → 失効エポック ms。リプレイ防止に消費する。
   final Map<String, int> _webauthnChallenges = {};
   static const Duration _webauthnChallengeTtl = Duration(minutes: 2);
+  static const int _maxWebauthnChallenges = 4096;
   // #258: DNS rebinding 対策 — 許可する Host 値のセット
   Set<String> _allowedHosts = {};
   // #6: HTTPS 起動時は Secure 属性を付与
@@ -2921,6 +2922,13 @@ class _CliServer {
       );
     }
     _pruneWebauthnChallenges();
+    // 未認証エンドポイントなので、TTL 内スパムでのメモリ肥大を上限で抑える
+    // （超過時は最古を1件退避）。
+    if (_webauthnChallenges.length >= _maxWebauthnChallenges) {
+      final oldest =
+          _webauthnChallenges.entries.reduce((a, b) => a.value < b.value ? a : b);
+      _webauthnChallenges.remove(oldest.key);
+    }
     final r = Random.secure();
     final challenge =
         _b64urlNoPad(List<int>.generate(32, (_) => r.nextInt(256)));

--- a/bin/localnode_cli.dart
+++ b/bin/localnode_cli.dart
@@ -3108,8 +3108,11 @@ class _CliServer {
                 : 'randomPin',
         'requiresAuth': _authMode != _AuthMode.noPin,
         'clipboardEnabled': _clipboardEnabled,
-        // #267: passkey ログインが使えるか（accounts が1件以上）。Web UI がボタン表示に使う。
+        // #267: passkey ログインが使えるか（accounts が1件以上）。ログインボタン表示に使う。
         'passkeyEnabled': _accounts.isNotEmpty,
+        // #267: accounts ファイルが指定されているか（0件でも true）。enroll 導線の表示に使う。
+        // これが無いと「空ファイルから初回パスキーを登録」するブートストラップができない。
+        'passkeyConfigured': _accountsFile != null,
         // #267: ログイン中のアカウント名（passkey セッションのみ。未ログイン/guest は null）
         if (authed) 'account': _sessionAccountOf(req),
         // #265: deviceId は認証済みリクエストにのみ返す

--- a/bin/localnode_cli.dart
+++ b/bin/localnode_cli.dart
@@ -103,6 +103,16 @@ class _LoadedPostAction {
   _LoadedPostAction(this.pattern, this.script);
 }
 
+// #267: passkey (WebAuthn) アカウント。credentials ファイルの 1 エントリ。
+// SSH の authorized_keys 相当。label=アカウント名, credentialId=base64url(rawId),
+// publicKeySpki=登録時に取得した公開鍵 (SPKI DER)。
+class _PasskeyAccount {
+  final String name;
+  final String credentialId; // base64url (パディング無し) の rawId
+  final Uint8List publicKeySpki; // SubjectPublicKeyInfo (DER)
+  _PasskeyAccount(this.name, this.credentialId, this.publicKeySpki);
+}
+
 class _LoadedConfig {
   // server section
   int? port;
@@ -127,6 +137,8 @@ class _LoadedConfig {
   String? maxUploadSize;
   // #290
   int? postActionTimeout;
+  // #267
+  String? accountsFile;
   // #237
   String? stateFile;
   // #208
@@ -195,6 +207,7 @@ _LoadedConfig _loadConfig(String path) {
     cfg.pinCharset = _yamlString(server, 'pin-charset');
     cfg.maxUploadSize = _yamlString(server, 'max-upload-size');
     cfg.postActionTimeout = _yamlInt(server, 'post-action-timeout'); // #290
+    cfg.accountsFile = _yamlString(server, 'accounts-file');         // #267
     cfg.cacheDir = _yamlString(server, 'cache-dir');     // #287
     cfg.stateFile = _yamlString(server, 'state-file');   // #237
     cfg.pinFile = _yamlString(server, 'pin-file');       // #208
@@ -432,6 +445,8 @@ Future<void> main(List<String> args) async {
           results['post-action-timeout'] as String? ?? '') ??
       cfg?.postActionTimeout ??
       300;
+  // #267: passkey アカウントファイル（CLI > YAML）
+  final accountsFile = results['accounts-file'] as String? ?? cfg?.accountsFile;
 
   // #208: CLI > YAML config
   final String? pinFile = results.wasParsed('pin-file')
@@ -673,6 +688,7 @@ Future<void> main(List<String> args) async {
       mentionActions: mentionActions,
       maxDirectUploadBytes: maxDirectUploadBytes, // #262
       postActionTimeoutSeconds: postActionTimeoutSeconds, // #290
+      accountsFile: accountsFile, // #267
       extraAllowedHosts: extraAllowedHosts,       // #275
     );
   } catch (e) {
@@ -860,6 +876,11 @@ ArgParser _buildParser() {
         help: 'Timeout in seconds for each post-action script; the process is '
             'killed if it exceeds this. 0 disables the timeout. (default: 300)',
         valueHelp: 'SECONDS')
+    ..addOption('accounts-file',
+        help: 'Path to a YAML passkey accounts file for WebAuthn login (#267). '
+            'Enables per-user passkey login alongside the PIN. Requires HTTPS + '
+            'a hostname (or localhost); does not work over a bare LAN IP.',
+        valueHelp: 'PATH')
     ..addMultiOption('mention-action',
         help:
             'Register a clipboard mention command: <alias>=<script>. '
@@ -1534,6 +1555,14 @@ class _CliServer {
   final Map<String, int> _sessions = {};
   static const Duration _sessionTtl = Duration(hours: 24);
   static const int _maxNoPinSessions = 1000;
+  // #267: セッション → アカウント名（passkey ログイン時のみ。PIN/no-pin は未設定=guest）
+  final Map<String, String> _sessionAccounts = {};
+  // #267: passkey アカウント（credentials ファイルから読み込む）
+  List<_PasskeyAccount> _accounts = [];
+  String? _accountsFile;
+  // #267: 発行済み WebAuthn チャレンジ（base64url） → 失効エポック ms。リプレイ防止に消費する。
+  final Map<String, int> _webauthnChallenges = {};
+  static const Duration _webauthnChallengeTtl = Duration(minutes: 2);
   // #258: DNS rebinding 対策 — 許可する Host 値のセット
   Set<String> _allowedHosts = {};
   // #6: HTTPS 起動時は Secure 属性を付与
@@ -1564,6 +1593,8 @@ class _CliServer {
         _deviceId = deviceId ?? '' {
     _router = Router()
       ..post('/api/auth', _authHandler)
+      ..post('/api/webauthn/challenge', _webauthnChallengeHandler)  // #267
+      ..post('/api/webauthn/verify', _webauthnVerifyHandler)        // #267
       ..get('/api/health', _healthHandler)
       ..get('/api/info', _infoHandler)
       ..get('/api/check-auth', _checkAuthHandler)
@@ -2072,6 +2103,7 @@ class _CliServer {
     int? maxDirectUploadBytes,    // #262
     List<String> extraAllowedHosts = const [],   // #275
     int postActionTimeoutSeconds = 300,          // #290 (0 = 無制限)
+    String? accountsFile,                         // #267
   }) async {
     _authMode = authMode;
     _downloadOnly = downloadOnly;
@@ -2088,6 +2120,9 @@ class _CliServer {
     _postActionTimeout = postActionTimeoutSeconds > 0
         ? Duration(seconds: postActionTimeoutSeconds)
         : null;
+    // #267: passkey アカウント読み込み（指定時のみ）
+    _accountsFile = accountsFile;
+    if (accountsFile != null) _loadAccounts(accountsFile);
     _startedAt = DateTime.now().millisecondsSinceEpoch;
 
     switch (authMode) {
@@ -2373,6 +2408,7 @@ class _CliServer {
     if (expiry == null) return false;
     if (DateTime.now().millisecondsSinceEpoch > expiry) {
       _sessions.remove(token);
+      _sessionAccounts.remove(token); // #267
       return false;
     }
     return true;
@@ -2380,7 +2416,93 @@ class _CliServer {
 
   void _pruneExpiredSessions() {
     final now = DateTime.now().millisecondsSinceEpoch;
-    _sessions.removeWhere((_, expiry) => expiry < now);
+    _sessions.removeWhere((token, expiry) {
+      final expired = expiry < now;
+      if (expired) _sessionAccounts.remove(token); // #267
+      return expired;
+    });
+  }
+
+  // #267: セッションを1件発行する。account を渡すと passkey ログイン扱い。
+  String _createSession({String? account}) {
+    final token = _generateToken();
+    _pruneExpiredSessions();
+    if (_authMode == _AuthMode.noPin && _sessions.length >= _maxNoPinSessions) {
+      final oldest =
+          _sessions.entries.reduce((a, b) => a.value < b.value ? a : b);
+      _sessions.remove(oldest.key);
+      _sessionAccounts.remove(oldest.key);
+    }
+    _sessions[token] = DateTime.now().add(_sessionTtl).millisecondsSinceEpoch;
+    if (account != null) _sessionAccounts[token] = account;
+    return token;
+  }
+
+  String _sessionCookie(String token) =>
+      'localnode_session=$token; Path=/; HttpOnly; SameSite=Strict'
+      '${_httpsEnabled ? '; Secure' : ''}';
+
+  // #267: リクエストのセッション Cookie からアカウント名を取り出す（無ければ null=guest）。
+  String? _sessionAccountOf(Request req) {
+    final cookie = req.headers['cookie'] ?? '';
+    for (final c in cookie.split(';')) {
+      final t = c.trim();
+      if (t.startsWith('localnode_session=')) {
+        final token = t.substring(t.indexOf('=') + 1);
+        if (_isValidSession(token)) return _sessionAccounts[token];
+      }
+    }
+    return null;
+  }
+
+  // #267: passkey アカウントを YAML ファイルから読み込む（authorized_keys 相当）。
+  // 形式:  accounts:
+  //          - name: shiba
+  //            credential_id: <base64url>
+  //            public_key: <base64 SPKI DER>
+  // 読めなくても passkey が無効になるだけでサーバは起動を続ける。
+  void _loadAccounts(String path) {
+    final file = File(path);
+    if (!file.existsSync()) {
+      stderr.writeln(
+          'Warning: accounts file not found: $path (passkey login disabled)');
+      return;
+    }
+    try {
+      final doc = loadYaml(file.readAsStringSync());
+      final list = (doc is YamlMap) ? doc['accounts'] : null;
+      if (list is! YamlList) {
+        stderr.writeln('Error: accounts file must contain an "accounts:" list.');
+        return;
+      }
+      final acc = <_PasskeyAccount>[];
+      final seen = <String>{};
+      for (final e in list) {
+        if (e is! YamlMap) continue;
+        final name = e['name']?.toString();
+        final cid = e['credential_id']?.toString();
+        final pk = e['public_key']?.toString();
+        if (name == null || cid == null || pk == null) {
+          stderr.writeln('Warning: skipping incomplete account entry.');
+          continue;
+        }
+        if (!seen.add(cid)) {
+          stderr.writeln('Warning: duplicate credential_id for "$name", skipping.');
+          continue;
+        }
+        try {
+          acc.add(_PasskeyAccount(name, cid, base64.decode(pk)));
+        } catch (_) {
+          stderr.writeln('Warning: account "$name" has an invalid public_key.');
+        }
+      }
+      _accounts = acc;
+      if (_accounts.isNotEmpty) {
+        _log('[passkey] loaded ${_accounts.length} account(s) from $path');
+      }
+    } catch (e) {
+      stderr.writeln('Error reading accounts file: $e');
+    }
   }
 
   // #265: セッション Cookie または Bearer トークンが有効なリクエストか判定
@@ -2628,6 +2750,8 @@ class _CliServer {
           if (!path.startsWith('api/') ||
               path == 'api/info' ||
               path == 'api/auth' ||
+              path == 'api/webauthn/challenge' || // #267
+              path == 'api/webauthn/verify' ||    // #267
               path == 'api/health') {
             return inner(req);
           }
@@ -2691,16 +2815,10 @@ class _CliServer {
 
   Future<Response> _authHandler(Request req) async {
     if (_authMode == _AuthMode.noPin) {
-      final token = _generateToken();
-      _pruneExpiredSessions();
-      if (_sessions.length >= _maxNoPinSessions) {
-        final oldest = _sessions.entries.reduce((a, b) => a.value < b.value ? a : b);
-        _sessions.remove(oldest.key);
-      }
-      _sessions[token] = DateTime.now().add(_sessionTtl).millisecondsSinceEpoch;
+      final token = _createSession();
       return Response.ok(json.encode({'status': 'success'}), headers: {
         'Content-Type': 'application/json',
-        'Set-Cookie': 'localnode_session=$token; Path=/; HttpOnly; SameSite=Strict${_httpsEnabled ? '; Secure' : ''}',
+        'Set-Cookie': _sessionCookie(token),
       });
     }
 
@@ -2720,11 +2838,10 @@ class _CliServer {
       if (_pin != null && _constantTimeEquals(params['pin'] as String? ?? '', _pin!)) {
         _failedAttempts.remove(clientIp);
         _lockoutUntil.remove(clientIp);
-        final token = _generateToken();
-        _sessions[token] = DateTime.now().add(_sessionTtl).millisecondsSinceEpoch;
+        final token = _createSession();
         return Response.ok(json.encode({'status': 'success'}), headers: {
           'Content-Type': 'application/json',
-          'Set-Cookie': 'localnode_session=$token; Path=/; HttpOnly; SameSite=Strict${_httpsEnabled ? '; Secure' : ''}',
+          'Set-Cookie': _sessionCookie(token),
         });
       } else {
         final attempts = (_failedAttempts[clientIp] ?? 0) + 1;
@@ -2746,6 +2863,200 @@ class _CliServer {
         body: json.encode({'error': 'Invalid request body.'}),
         headers: {'Content-Type': 'application/json'},
       );
+    }
+  }
+
+  // === #267: passkey (WebAuthn) 認証 =========================================
+
+  // base64url（パディング有無どちらでも）→ bytes
+  Uint8List _b64urlDecode(String s) {
+    var t = s.replaceAll('-', '+').replaceAll('_', '/');
+    while (t.length % 4 != 0) {
+      t += '=';
+    }
+    return base64.decode(t);
+  }
+
+  String _b64urlNoPad(List<int> bytes) =>
+      base64Url.encode(bytes).replaceAll('=', '');
+
+  void _pruneWebauthnChallenges() {
+    final now = DateTime.now().millisecondsSinceEpoch;
+    _webauthnChallenges.removeWhere((_, exp) => exp < now);
+  }
+
+  // リクエストの Host からポートを除いたホスト名（= WebAuthn の rpId 候補）。
+  String? _rpIdForRequest(Request req) {
+    final host = req.headers['host'];
+    if (host == null) return null;
+    return host.replaceFirst(RegExp(r':\d+$'), '');
+  }
+
+  // clientData.origin が自サーバのものか（ホストが許可集合にある）を確認。
+  bool _isAllowedWebauthnOrigin(String origin) {
+    try {
+      final u = Uri.parse(origin);
+      if (u.host.isEmpty) return false;
+      return _allowedHosts.contains(u.host);
+    } catch (_) {
+      return false;
+    }
+  }
+
+  bool _bytesEqual(List<int> a, List<int> b) {
+    if (a.length != b.length) return false;
+    var r = 0;
+    for (var i = 0; i < a.length; i++) {
+      r |= a[i] ^ b[i];
+    }
+    return r == 0;
+  }
+
+  // POST /api/webauthn/challenge : ログイン用のチャレンジ(nonce)を発行する。
+  Response _webauthnChallengeHandler(Request req) {
+    if (_accounts.isEmpty) {
+      return Response.notFound(
+        json.encode({'error': 'Passkey login is not configured.'}),
+        headers: {'Content-Type': 'application/json'},
+      );
+    }
+    _pruneWebauthnChallenges();
+    final r = Random.secure();
+    final challenge =
+        _b64urlNoPad(List<int>.generate(32, (_) => r.nextInt(256)));
+    _webauthnChallenges[challenge] =
+        DateTime.now().add(_webauthnChallengeTtl).millisecondsSinceEpoch;
+    return Response.ok(
+      json.encode({
+        'challenge': challenge,
+        'rpId': _rpIdForRequest(req),
+        'timeout': 60000,
+      }),
+      headers: {'Content-Type': 'application/json'},
+    );
+  }
+
+  // POST /api/webauthn/verify : WebAuthn assertion を検証してセッションを発行する。
+  Future<Response> _webauthnVerifyHandler(Request req) async {
+    if (_accounts.isEmpty) {
+      return Response.forbidden(
+        json.encode({'error': 'Passkey login is not configured.'}),
+        headers: {'Content-Type': 'application/json'},
+      );
+    }
+    Response fail(int status, String msg) => Response(status,
+        body: json.encode({'error': msg}),
+        headers: {'Content-Type': 'application/json'});
+
+    final clientIp = _getClientIp(req);
+    final lockout = _lockoutUntil[clientIp];
+    if (lockout != null && DateTime.now().isBefore(lockout)) {
+      final rem = lockout.difference(DateTime.now()).inSeconds;
+      return fail(403, 'Locked out. Try again in $rem seconds.');
+    }
+
+    Map<String, dynamic> body;
+    try {
+      body = json.decode(await req.readAsString()) as Map<String, dynamic>;
+    } catch (_) {
+      return fail(400, 'Invalid request body.');
+    }
+    final credentialId = body['credentialId'] as String?;
+    final authDataB64 = body['authenticatorData'] as String?;
+    final clientDataB64 = body['clientDataJSON'] as String?;
+    final signatureB64 = body['signature'] as String?;
+    if (credentialId == null ||
+        authDataB64 == null ||
+        clientDataB64 == null ||
+        signatureB64 == null) {
+      return fail(400, 'Missing assertion fields.');
+    }
+
+    final account =
+        _accounts.firstWhereOrNullExt((a) => a.credentialId == credentialId);
+    if (account == null) return fail(401, 'Unknown credential.');
+
+    void recordFailure() {
+      final attempts = (_failedAttempts[clientIp] ?? 0) + 1;
+      _failedAttempts[clientIp] = attempts;
+      if (attempts >= _maxFailedAttempts) {
+        _lockoutUntil[clientIp] = DateTime.now().add(_lockoutDuration);
+        _failedAttempts.remove(clientIp);
+      }
+    }
+
+    try {
+      final authData = _b64urlDecode(authDataB64);
+      final clientData = _b64urlDecode(clientDataB64);
+      final signature = _b64urlDecode(signatureB64);
+
+      // 1) clientDataJSON の検証
+      final cd = json.decode(utf8.decode(clientData)) as Map<String, dynamic>;
+      if (cd['type'] != 'webauthn.get') {
+        recordFailure();
+        return fail(401, 'Bad clientData type.');
+      }
+      final challenge = cd['challenge'] as String?;
+      _pruneWebauthnChallenges();
+      // チャレンジは1回限り（消費してリプレイを防ぐ）
+      if (challenge == null || _webauthnChallenges.remove(challenge) == null) {
+        recordFailure();
+        return fail(401, 'Invalid or expired challenge.');
+      }
+      final origin = cd['origin'] as String?;
+      if (origin == null || !_isAllowedWebauthnOrigin(origin)) {
+        recordFailure();
+        return fail(401, 'Bad origin.');
+      }
+
+      // 2) authenticatorData の検証（rpIdHash / user-present フラグ）
+      if (authData.length < 37) {
+        recordFailure();
+        return fail(401, 'Bad authenticator data.');
+      }
+      final rpId = Uri.parse(origin).host;
+      final expectedRpHash =
+          CryptoUtils.getHashPlain(Uint8List.fromList(utf8.encode(rpId)));
+      if (!_bytesEqual(authData.sublist(0, 32), expectedRpHash)) {
+        recordFailure();
+        return fail(401, 'rpId mismatch.');
+      }
+      final flags = authData[32];
+      if ((flags & 0x01) == 0) {
+        recordFailure();
+        return fail(401, 'User presence flag not set.');
+      }
+
+      // 3) 署名検証: sig は (authData || SHA256(clientDataJSON)) に対する ES256
+      final clientDataHash =
+          CryptoUtils.getHashPlain(Uint8List.fromList(clientData));
+      final signedData =
+          Uint8List.fromList([...authData, ...clientDataHash]);
+      final pubKey = CryptoUtils.ecPublicKeyFromDerBytes(account.publicKeySpki);
+      final sig =
+          CryptoUtils.ecSignatureFromDerBytes(Uint8List.fromList(signature));
+      final ok = CryptoUtils.ecVerify(pubKey, signedData, sig,
+          algorithm: 'SHA-256/ECDSA');
+      if (!ok) {
+        recordFailure();
+        return fail(401, 'Signature verification failed.');
+      }
+
+      // 成功: アカウント付きセッションを発行
+      _failedAttempts.remove(clientIp);
+      _lockoutUntil.remove(clientIp);
+      final token = _createSession(account: account.name);
+      _log('[passkey] login ok: ${account.name} from $clientIp');
+      return Response.ok(
+        json.encode({'status': 'success', 'account': account.name}),
+        headers: {
+          'Content-Type': 'application/json',
+          'Set-Cookie': _sessionCookie(token),
+        },
+      );
+    } catch (e) {
+      recordFailure();
+      return fail(401, 'Assertion verification error.');
     }
   }
 
@@ -2789,6 +3100,10 @@ class _CliServer {
                 : 'randomPin',
         'requiresAuth': _authMode != _AuthMode.noPin,
         'clipboardEnabled': _clipboardEnabled,
+        // #267: passkey ログインが使えるか（accounts が1件以上）。Web UI がボタン表示に使う。
+        'passkeyEnabled': _accounts.isNotEmpty,
+        // #267: ログイン中のアカウント名（passkey セッションのみ。未ログイン/guest は null）
+        if (authed) 'account': _sessionAccountOf(req),
         // #265: deviceId は認証済みリクエストにのみ返す
         // federation heartbeat は Bearer トークン付きで /api/info を叩くため引き続き取得可能
         if (authed) 'deviceId': _deviceId,
@@ -3653,7 +3968,11 @@ class _CliServer {
           json.decode(await req.readAsString()) as Map<String, dynamic>;
       var text = (params['text'] as String?)?.trim();
       final rawTag = (params['tag'] as String?)?.trim();
-      final tag = (rawTag != null && rawTag.isNotEmpty) ? rawTag : null;
+      // #267: タグ未指定なら passkey ログイン中のアカウント名を既定タグにする
+      //       （誰が投稿したか分かる＝クリップボードが軽量な複数人チャットになる）。
+      final tag = (rawTag != null && rawTag.isNotEmpty)
+          ? rawTag
+          : _sessionAccountOf(req);
 
       if (text == null || text.isEmpty) {
         return Response.badRequest(

--- a/bin/localnode_cli.dart
+++ b/bin/localnode_cli.dart
@@ -26,7 +26,7 @@ import 'package:shelf_static/shelf_static.dart';
 import 'package:yaml/yaml.dart';
 
 // pubspec.yaml の version と一致させる
-const String _appVersion = '1.9.0';
+const String _appVersion = '1.10.0';
 
 // #174 + #220: 予約メンション名。ユーザーが `--mention-action <name>=...` で
 // 登録できない。

--- a/examples/accounts.example.yaml
+++ b/examples/accounts.example.yaml
@@ -1,0 +1,22 @@
+# LocalNode passkey accounts file (#267) — the "authorized_keys" for WebAuthn.
+#
+# Point the server at this file with:
+#   localnode-cli --accounts-file /etc/localnode/accounts.yaml
+# or `server.accounts-file` in config.yaml.
+#
+# Requirements:
+#   - Passkey login only works over HTTPS + a hostname (or http://localhost),
+#     NOT over a bare LAN IP. Keep the PIN for plain-IP LAN access.
+#   - Only ES256 (ECDSA P-256) passkeys are supported.
+#
+# To add an account: open the Web UI over the HTTPS hostname, click
+# "パスキーを登録", enter a name, create the passkey, then paste the YAML
+# snippet it shows here and restart the server. To revoke someone, delete
+# their entry and restart.
+
+accounts:
+  - name: shiba
+    # base64url of the credential id (shown by the register page)
+    credential_id: REPLACE_WITH_CREDENTIAL_ID
+    # base64 of the public key in SubjectPublicKeyInfo/DER form (shown by the page)
+    public_key: REPLACE_WITH_PUBLIC_KEY_SPKI

--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -1,33 +1,81 @@
+# =============================================================================
 # LocalNode CLI 設定ファイル例 (#185)
+# =============================================================================
 #
 # 使い方:
-#   localnode-cli --config /path/to/this/config.yaml
+#   localnode-cli --config /path/to/config.yaml
 #
-# 優先順位: CLI 引数 > config ファイル > 既定値
+# 優先順位: CLI 引数 > この config ファイル > 既定値
+#   （同じ設定を CLI 引数でも渡した場合は CLI 引数が勝つ）
+#
+# ここに書ける全キーは実際にパースされるものだけを載せている。
+# 各キーの「省略時」の挙動＝既定値をコメントに併記した。
+# systemd / launchd で常駐させる場合は、このファイルを
+# 例: /etc/localnode/config.yaml に置き、サービス定義から --config で指す
+# （examples/systemd/ · examples/launchd/ のテンプレート参照）。
 
-# サーバー設定 — 既存 CLI オプションに対応
+# =============================================================================
+# server — サーバー本体の設定（CLI オプションと 1:1 対応）
+# =============================================================================
 server:
-  port: 8080
-  ip: 192.168.1.100              # 省略可（自動選択）
-  name: home-server              # ブラウザタブに表示する名前
-  dir: /srv/share                # 共有フォルダ
-  cache-dir: /var/cache/localnode # キャッシュ/一時データ置き場 (#287)。省略時は OS の一時ディレクトリ
-  pin: "1234"                    # 固定 PIN（省略するとランダム生成）
-  mode: normal                   # normal / download-only
-  no-pin: false                  # PIN 認証を無効化（信頼ネットワーク用）
-  no-clipboard: false            # クリップボード共有を無効化
-  post-action-timeout: 300       # 各 post_action の実行タイムアウト秒 (#290)。0 で無制限
-  verbose: false                 # 詳細ログを有効化
+  # --- 基本 ---
+  port: 8080                     # 待受ポート（既定: 8080）
+  ip: 192.168.1.100              # 広告する IP。省略すると自動選択（複数 NIC 時に固定したいなら指定）
+  name: home-server              # ブラウザのタブ/タイトルに出すサーバー名（既定: LocalNode）
+  dir: /srv/share                # 共有フォルダ。省略するとカレントディレクトリ
+  cache-dir: /var/cache/localnode # キャッシュ/一時データ(サムネイル等)の置き場 (#287)。省略時は OS の一時ディレクトリ
+  mode: normal                   # normal / download-only（既定: normal）
+
+  # --- 認証: PIN ---
+  # PIN はブラウザアクセス時の認証。省略するとランダム生成され起動時に表示される。
+  pin: "12345678"                # 固定 PIN（省略でランダム）
+  pin-length: 8                  # ランダム PIN 生成時の桁数 8..16（既定: 8）
+  pin-charset: digits            # ランダム PIN の文字種: digits / alnum / alnum_symbols（既定: digits）
+  no-pin: false                  # true で PIN 認証を無効化（信頼ネットワーク専用。アップロードトークンも無効になる）
+
+  # --- 認証: アップロードトークン (Bearer) ---
+  # curl 等からのアップロード / クリップボード POST 用の固定トークン。省略でランダム生成。
+  token: change-me-upload-token  # 固定 Bearer トークン（省略でランダム）
+  no-token: false                # true でトークン認証を無効化
+
+  # --- HTTPS (任意) ---
+  # cert と key は両方指定するか、両方省略するか。片方だけはエラー。
   https-cert: /etc/letsencrypt/live/example.com/fullchain.pem
   https-key: /etc/letsencrypt/live/example.com/privkey.pem
-  token: mytoken-for-upload      # 固定 Bearer トークン
-  no-token: false                # トークン認証を無効化
 
-  # PIN 強化 (#206)
-  pin-length: 4                  # 4-8。ランダム PIN 生成時の文字数
-  pin-charset: digits            # digits / alnum / alnum_symbols
+  # --- DNS rebinding 対策で追加許可するホスト名 (#275) ---
+  # 既定では localhost / 127.0.0.1 / 広告 IP / 各 IPv4 NIC / 証明書のホスト名を許可。
+  # リバースプロキシ等でそれ以外のホスト名でアクセスさせる場合だけ列挙する（リスト）。
+  allowed-hosts:
+    - localnode.example.com
+    - myhost.tail-xxxx.ts.net
 
-# メンションアクション (alias 形式) — #185 + description は @list で表示 (#224)
+  # --- アップロード制限 ---
+  max-upload-size: 2G            # 直接アップロードの上限 (#262)。例: 100M, 2G。省略で無制限
+
+  # --- post-action の実行制御 ---
+  post-action-timeout: 300       # 各 post_action の実行タイムアウト秒 (#290)。0 で無制限（既定: 300）
+
+  # --- 運用向けファイル出力 (#208, daemon/systemd 連携) ---
+  # 起動後に生成した PIN / アップロードトークンをファイルに書き出す。
+  # 秘密情報なので配置先のパーミッションに注意（0600 で書かれる）。
+  pin-file: /run/localnode/pin       # 省略で書き出さない
+  token-file: /run/localnode/token   # 省略で書き出さない
+
+  # --- federation 用の永続 ID (#237) ---
+  # 親子連携で使う安定した device_id を保存する JSON ファイル。
+  # 省略時は XDG（POSIX: $XDG_STATE_HOME/localnode-cli/state.json）/ %LOCALAPPDATA%（Windows）。
+  state-file: /var/lib/localnode/state.json
+
+  # --- ログ ---
+  verbose: false                 # true で詳細リクエストログ（既定: false）
+  no-clipboard: false            # true でクリップボード共有をコンソール出力しない（既定: false）
+
+# =============================================================================
+# mention_actions — クリップボードの @run <alias> で起動するスクリプト (#185 / #224)
+# =============================================================================
+# 省略可。各エントリは alias と script が必須、description は任意（@list に表示）。
+# script は「実行可能ファイルのパスのみ」。引数のインライン指定は不可。
 mention_actions:
   - alias: backup
     script: /usr/local/bin/backup.sh
@@ -36,37 +84,44 @@ mention_actions:
     script: /usr/local/bin/notify.sh
     description: 通知を送る
 
-# post-action (アップロード後にパターン一致したファイルでスクリプト実行)
+# =============================================================================
+# post_actions — アップロード後にパターン一致したファイルでスクリプト実行
+# =============================================================================
+# 省略可。pattern はファイル名に対するグロブ（*.png, *.zip, * など）、script は必須。
+# 複数一致した場合は登録順に「逐次」実行される (#181)。各実行は post-action-timeout で
+# 打ち切られる (#290)。script にはアップロードされたファイルの絶対パスが第1引数で渡る。
 post_actions:
   - pattern: "*.png"
     script: /usr/local/bin/move-pic.sh
   - pattern: "*.zip"
     script: /usr/local/bin/unzip.sh
 
-# === 以下は 1.6.0 の federation / clipboard scalability で使用 ===
-# 現時点ではスキーマだけ予約。中身は対応 issue で反映される。
-
-# クリップボード共有のチューニング (#227 で実装)
+# =============================================================================
+# clipboard — クリップボード共有のチューニング (#227)
+# =============================================================================
+# 省略可。
 clipboard:
-  max_items: 1000                # デフォルト 10 → 1000
-  max_text_length: 10000
+  max_items: 1000                # 保持する最大件数（既定: 1000。範囲 1..100000）
+  max_text_length: 10000         # 1 件あたりの最大文字数（範囲 1..1000000）
 
-# 親子連携: 自分が「親」のとき子の一覧を書く (#218 で実装)
-# children は複数持てるので **リスト** (`- name: ...` で 1 エントリ)。
+# =============================================================================
+# federation — 親子連携 (#218)
+# =============================================================================
+# 省略可。連携する場合、両側とも HTTPS + 固定 token が前提。no-pin とは併用不可。
+
+# 自分が「親」のとき: 子の一覧。**リスト**（`- name:` で 1 エントリ）。
 children:
   - name: watcher-pi
     url: https://watcher-pi.tail-xxxx.ts.net:8080
-    token: <child-issued-token>
+    token: child-issued-token
     relation: friendly           # friendly / equally
-    max_upload_size: 100MB
+    max_upload_size: 100MB        # この子からのアップロード上限（任意）
 
-# 親子連携: 自分が「子」のとき親を書く (#218 で実装)
-# parent は 1 つだけ。**マッピング** (キー直書き) で、children と同じリスト形式
-# (`- name: ...`) で書くと "parent must be a mapping ... (got: YamlList)"
-# で起動エラーになる。
+# 自分が「子」のとき: 親を 1 つ。**マッピング**（キー直書き）。
+# ここをリスト（`- name:`）で書くと "parent must be a mapping" で起動エラーになる。
 parent:
   name: home-server
   url: https://home-server.tail-xxxx.ts.net:8080
-  token: <parent-issued-token>
+  token: parent-issued-token
   relation: friendly
-  trust: true                    # 親に転送したファイルを子側で保持しない
+  trust: true                    # true で親に転送したファイルを子側に残さない

--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -16,6 +16,7 @@ server:
   mode: normal                   # normal / download-only
   no-pin: false                  # PIN 認証を無効化（信頼ネットワーク用）
   no-clipboard: false            # クリップボード共有を無効化
+  post-action-timeout: 300       # 各 post_action の実行タイムアウト秒 (#290)。0 で無制限
   verbose: false                 # 詳細ログを有効化
   https-cert: /etc/letsencrypt/live/example.com/fullchain.pem
   https-key: /etc/letsencrypt/live/example.com/privkey.pem

--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -33,6 +33,12 @@ server:
   pin-charset: digits            # ランダム PIN の文字種: digits / alnum / alnum_symbols（既定: digits）
   no-pin: false                  # true で PIN 認証を無効化（信頼ネットワーク専用。アップロードトークンも無効になる）
 
+  # --- 認証: passkey (WebAuthn) アカウント (#267) ---
+  # 指定すると PIN と併存で「passkey ログイン」が有効になる（各自の passkey で
+  # ログイン・投稿の属性付与・個別失効）。HTTPS + ホスト名 or localhost が必須で、
+  # 素の LAN IP では動かない。詳細は examples/accounts.example.yaml。
+  accounts-file: /etc/localnode/accounts.yaml   # 省略で passkey ログイン無効
+
   # --- 認証: アップロードトークン (Bearer) ---
   # curl 等からのアップロード / クリップボード POST 用の固定トークン。省略でランダム生成。
   token: change-me-upload-token  # 固定 Bearer トークン（省略でランダム）

--- a/examples/launchd/com.ictglab.localnode.plist
+++ b/examples/launchd/com.ictglab.localnode.plist
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  LocalNode CLI as a launchd service (macOS)
+
+  IMPORTANT: the Mac App Store build is sandboxed and cannot run reliably as a
+  daemon writing to arbitrary paths (see #287). For an always-on macOS service,
+  use a self-built / non-App-Store binary:
+      dart compile exe bin/localnode_cli.dart -o localnode-cli
+  or point ProgramArguments at the app bundle's binary with --cli.
+
+  Install as a system LaunchDaemon (runs at boot, all users):
+    1. sudo cp localnode-cli /usr/local/bin/
+    2. sudo mkdir -p /etc/localnode /usr/local/var/localnode /usr/local/var/log
+       put your config at /etc/localnode/config.yaml (see examples/config.example.yaml)
+    3. sudo cp com.ictglab.localnode.plist /Library/LaunchDaemons/
+       sudo chown root:wheel /Library/LaunchDaemons/com.ictglab.localnode.plist
+    4. sudo launchctl load -w /Library/LaunchDaemons/com.ictglab.localnode.plist
+
+  Per-user LaunchAgent instead: put it in ~/Library/LaunchAgents/ and use
+  `launchctl load -w` without sudo (runs only while that user is logged in).
+
+  Logs:  tail -f /usr/local/var/log/localnode.log
+  Stop:  sudo launchctl unload -w /Library/LaunchDaemons/com.ictglab.localnode.plist
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.ictglab.localnode</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/local/bin/localnode-cli</string>
+        <string>--config</string>
+        <string>/etc/localnode/config.yaml</string>
+    </array>
+
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+
+    <!-- Restart back-off if it keeps failing -->
+    <key>ThrottleInterval</key>
+    <integer>5</integer>
+
+    <key>StandardOutPath</key>
+    <string>/usr/local/var/log/localnode.log</string>
+    <key>StandardErrorPath</key>
+    <string>/usr/local/var/log/localnode.log</string>
+
+    <!-- Optional: run as a dedicated non-root user for a LaunchDaemon -->
+    <!--
+    <key>UserName</key>
+    <string>localnode</string>
+    -->
+</dict>
+</plist>

--- a/examples/systemd/install-localnode.sh
+++ b/examples/systemd/install-localnode.sh
@@ -35,12 +35,16 @@ fi
 
 echo "== 3. create directories =="
 run mkdir -p /etc/localnode /var/lib/localnode /var/cache/localnode /srv/share /run/localnode
-run chown -R "$USER_NAME:$USER_NAME" /var/lib/localnode /var/cache/localnode /run/localnode
+# The service runs as $USER_NAME and must be able to write the shared dir and
+# its runtime/state/cache dirs.
+run chown -R "$USER_NAME:$USER_NAME" /var/lib/localnode /var/cache/localnode /run/localnode /srv/share
 
 echo "== 4. config =="
 if [[ ! -f /etc/localnode/config.yaml ]]; then
   if [[ -f "$SVC_DIR/../config.example.yaml" ]]; then
     run install -m 0640 "$SVC_DIR/../config.example.yaml" /etc/localnode/config.yaml
+    # Readable by the service user (group), not world-readable (may hold secrets).
+    run chown "root:$USER_NAME" /etc/localnode/config.yaml
     echo "  >> edit /etc/localnode/config.yaml before starting the service"
   else
     echo "  !! config.example.yaml not found; create /etc/localnode/config.yaml yourself"

--- a/examples/systemd/install-localnode.sh
+++ b/examples/systemd/install-localnode.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Transparent installer for the LocalNode systemd service (Linux).
+# It only runs the same steps documented in localnode.service — read it first.
+#
+# Usage:
+#   sudo ./install-localnode.sh /path/to/localnode-cli
+#
+# Re-running is safe: existing user/dirs/config are left as-is.
+set -euo pipefail
+
+BIN_SRC="${1:-}"
+if [[ -z "$BIN_SRC" || ! -x "$BIN_SRC" ]]; then
+  echo "usage: sudo $0 /path/to/localnode-cli" >&2
+  exit 1
+fi
+if [[ $EUID -ne 0 ]]; then
+  echo "error: run with sudo/root" >&2
+  exit 1
+fi
+
+SVC_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+USER_NAME=localnode
+
+run() { echo "+ $*"; "$@"; }
+
+echo "== 1. install binary =="
+run install -m 0755 "$BIN_SRC" /usr/local/bin/localnode-cli
+
+echo "== 2. create service user (if missing) =="
+if ! id -u "$USER_NAME" >/dev/null 2>&1; then
+  run useradd --system --home /var/lib/localnode --shell /usr/sbin/nologin "$USER_NAME"
+else
+  echo "  user '$USER_NAME' already exists, skipping"
+fi
+
+echo "== 3. create directories =="
+run mkdir -p /etc/localnode /var/lib/localnode /var/cache/localnode /srv/share /run/localnode
+run chown -R "$USER_NAME:$USER_NAME" /var/lib/localnode /var/cache/localnode /run/localnode
+
+echo "== 4. config =="
+if [[ ! -f /etc/localnode/config.yaml ]]; then
+  if [[ -f "$SVC_DIR/../config.example.yaml" ]]; then
+    run install -m 0640 "$SVC_DIR/../config.example.yaml" /etc/localnode/config.yaml
+    echo "  >> edit /etc/localnode/config.yaml before starting the service"
+  else
+    echo "  !! config.example.yaml not found; create /etc/localnode/config.yaml yourself"
+  fi
+else
+  echo "  /etc/localnode/config.yaml already exists, leaving it"
+fi
+
+echo "== 5. install unit =="
+run install -m 0644 "$SVC_DIR/localnode.service" /etc/systemd/system/localnode.service
+run systemctl daemon-reload
+
+echo
+echo "Done. Review /etc/localnode/config.yaml, then:"
+echo "  sudo systemctl enable --now localnode"
+echo "  journalctl -u localnode -f"

--- a/examples/systemd/localnode.service
+++ b/examples/systemd/localnode.service
@@ -1,0 +1,54 @@
+# LocalNode CLI as a systemd service (Linux)
+#
+# Install:
+#   1. Copy the standalone binary:   sudo cp localnode-cli /usr/local/bin/
+#   2. Create a low-privilege user:  sudo useradd --system --home /var/lib/localnode --shell /usr/sbin/nologin localnode
+#   3. Create dirs and set owner:
+#        sudo mkdir -p /etc/localnode /var/lib/localnode /var/cache/localnode /srv/share /run/localnode
+#        sudo chown -R localnode:localnode /var/lib/localnode /var/cache/localnode /run/localnode
+#   4. Put your config at /etc/localnode/config.yaml (see examples/config.example.yaml)
+#   5. Copy this file:               sudo cp localnode.service /etc/systemd/system/
+#   6. Enable + start:               sudo systemctl daemon-reload && sudo systemctl enable --now localnode
+#
+# Logs:   journalctl -u localnode -f
+# Stop:   sudo systemctl stop localnode        Disable: sudo systemctl disable localnode
+
+[Unit]
+Description=LocalNode file server (CLI)
+Documentation=https://github.com/koto2730/localnode
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/localnode-cli --config /etc/localnode/config.yaml
+Restart=on-failure
+RestartSec=5
+
+# Run as a dedicated non-root user (create it as above).
+User=localnode
+Group=localnode
+
+# Where the process is allowed to write. Adjust to match your config:
+#   - shared dir (server.dir)
+#   - cache dir  (server.cache-dir)
+#   - state file (server.state-file)
+#   - pin-file / token-file (if used)
+RuntimeDirectory=localnode
+StateDirectory=localnode
+CacheDirectory=localnode
+ReadWritePaths=/srv/share
+
+# Hardening (loosen only if something legitimately needs more access).
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+ProtectKernelTunables=true
+ProtectControlGroups=true
+RestrictSUIDSGID=true
+# Note: post-action / mention-action scripts run as this same user. Keep them
+# minimal and trusted; the hardening above also applies to them.
+
+[Install]
+WantedBy=multi-user.target

--- a/examples/systemd/localnode.service
+++ b/examples/systemd/localnode.service
@@ -3,10 +3,13 @@
 # Install:
 #   1. Copy the standalone binary:   sudo cp localnode-cli /usr/local/bin/
 #   2. Create a low-privilege user:  sudo useradd --system --home /var/lib/localnode --shell /usr/sbin/nologin localnode
-#   3. Create dirs and set owner:
+#   3. Create dirs and set owner (the service user must be able to write the
+#      shared dir and its runtime/state/cache dirs):
 #        sudo mkdir -p /etc/localnode /var/lib/localnode /var/cache/localnode /srv/share /run/localnode
-#        sudo chown -R localnode:localnode /var/lib/localnode /var/cache/localnode /run/localnode
+#        sudo chown -R localnode:localnode /var/lib/localnode /var/cache/localnode /run/localnode /srv/share
 #   4. Put your config at /etc/localnode/config.yaml (see examples/config.example.yaml)
+#      and make it readable by the service user without being world-readable:
+#        sudo chown root:localnode /etc/localnode/config.yaml && sudo chmod 0640 /etc/localnode/config.yaml
 #   5. Copy this file:               sudo cp localnode.service /etc/systemd/system/
 #   6. Enable + start:               sudo systemctl daemon-reload && sudo systemctl enable --now localnode
 #

--- a/lib/server_service.dart
+++ b/lib/server_service.dart
@@ -773,7 +773,7 @@ class ServerService {
       // AndroidでSAF URIが設定されている場合
       if (Platform.isAndroid && _safDirectoryUri != null) {
         // F1: SAF ツリー外のファイルへのアクセスを拒否
-        if (!decoded.startsWith(_safDirectoryUri!)) {
+        if (!_isWithinSafTree(decoded)) {
           return Response.forbidden('Access denied');
         }
         final fileUri = decoded;
@@ -1009,7 +1009,7 @@ class ServerService {
 
       if (Platform.isAndroid && _safDirectoryUri != null) {
         // F1: SAF ツリー外のファイルへのアクセスを拒否
-        if (!decoded.startsWith(_safDirectoryUri!)) {
+        if (!_isWithinSafTree(decoded)) {
           return Response.forbidden('Access denied');
         }
         imageBytes = await _safPlatform.invokeMethod('readFile', {'uri': decoded});
@@ -1177,7 +1177,7 @@ class ServerService {
 
       // パストラバーサル検証 (Copilot #199 review)
       if (Platform.isAndroid && _safDirectoryUri != null) {
-        if (!decoded.startsWith(_safDirectoryUri!)) {
+        if (!_isWithinSafTree(decoded)) {
           return Response.forbidden('Access denied');
         }
       } else {
@@ -1337,7 +1337,7 @@ class ServerService {
       // AndroidでSAF URIが設定されている場合
       if (Platform.isAndroid && _safDirectoryUri != null) {
         // F1: SAF ツリー外のファイルへのアクセスを拒否
-        if (!decoded.startsWith(_safDirectoryUri!)) {
+        if (!_isWithinSafTree(decoded)) {
           return Response.forbidden('Access denied');
         }
         final fileUri = decoded;
@@ -1406,7 +1406,7 @@ class ServerService {
       for (final raw in ids) {
         try {
           final fileUri = utf8.decode(base64Url.decode(raw as String));
-          if (!fileUri.startsWith(_safDirectoryUri!)) {
+          if (!_isWithinSafTree(fileUri)) {
             skipped.add(raw);
             continue;
           }
@@ -1742,6 +1742,17 @@ class ServerService {
   //   (b) 生の UTF-8 バイト列 -> latin1 として読まれ文字化けするので、
   //       latin1 に戻してから UTF-8 として解釈し直す
   // どちらでも正しく読めるように両方試す。
+  // #291(L2): SAF ツリー URI の配下かを境界付きで判定する。
+  // 単純な startsWith だと tree=".../Shared" のとき ".../SharedEvil" も通って
+  // しまうため、完全一致か直後が '/' で続く場合のみ許可する。
+  // （SAF の document URI は <treeUri>/document/... の形なので子は必ず '/' が続く。
+  //   実際のアクセスは Android のパーミッションでも守られるが、多層防御として。）
+  bool _isWithinSafTree(String uri) {
+    final tree = _safDirectoryUri;
+    if (tree == null) return false;
+    return uri == tree || uri.startsWith('$tree/');
+  }
+
   String? _decodeHeader(String? raw) {
     if (raw == null) return null;
     var s = raw;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.9.0+1
+version: 1.10.0+1
 
 environment:
   sdk: '>=3.4.3 <4.0.0'


### PR DESCRIPTION
## Summary

Passkey account login (#267) plus self-hosting/packaging polish and the hardening items from the v1.9.0 security review. **No breaking changes** — passkey is opt-in and coexists with the PIN; federation stays backward-compatible (1.9.x ⇄ 1.10.0 parent/child still works).

## #267 — Passkey (WebAuthn) account login (standalone CLI)

Per-user passkey login in the SSH `authorized_keys` model. Multiple accounts live in a YAML file; each is one labeled credential.

- `--accounts-file` / `server.accounts-file` loads `{name, credential_id (base64url), public_key (base64 SPKI)}`.
- `POST /api/webauthn/challenge` — one-time nonce (2-min TTL, consumed on use to block replay, 4096-entry cap).
- `POST /api/webauthn/verify` — validates clientDataJSON (type/challenge/origin), authenticatorData (rpIdHash vs `SHA-256(host)`, user-present flag), and the ES256 signature over `authData || SHA-256(clientDataJSON)` via `basic_utils` (no new dependency). Failures feed the same per-IP lockout as the PIN.
- Sessions now carry an optional **account identity**; PIN / no-pin sessions are anonymous "guest". `/api/info` advertises `passkeyEnabled` + the logged-in `account`. Clipboard posts auto-tag with the account name when none is given (lightweight multi-person-chat attribution; remove one file line to revoke one person).
- **Web UI**: PIN screen gains a "🔑 パスキーでログイン" button (only when `passkeyEnabled` + a secure context) and a "パスキーを登録" dialog that runs `navigator.credentials.create()`, extracts the credentialId + SPKI public key, and shows a ready-to-paste YAML snippet.

**Requirement:** WebAuthn needs a secure context with a hostname (HTTPS / Tailscale Funnel, or `localhost`) — it does **not** work over a bare LAN IP, so the PIN remains for LAN use. Only ES256 (ECDSA P-256) passkeys.

**Scope:** standalone `localnode-cli` (Windows/Linux) only. GUI server / macOS `localnode --cli` not covered yet.

## Other

- **#290** `--post-action-timeout` (default 300s, 0 = unlimited) — each post-action script is killed if it exceeds the timeout, so one hung script can't block the whole queue
- **#291** Android SAF: cap `readFileRange` length; SAF tree-URI check requires a path boundary (`.../Shared` no longer matches `.../SharedEvil`)
- **#292** service templates under `examples/` (systemd unit + transparent installer, launchd plist) + README "Running as a service"
- **#293** `examples/config.example.yaml` rewritten as a complete annotated reference (every parsed key + defaults; added several previously-undocumented keys), `examples/accounts.example.yaml` added

## Verification

`flutter analyze` clean; standalone CLI verified **end-to-end against the real server code** with a test P-256 key: valid login → 200 + account, tampered signature → 401, challenge replay → 401. Full browser/authenticator passkey flow and the systemd/launchd services need device/manual testing (see `work/1.10.0_check.md`). Pre-release security review in `work/1.10.0_security_report.md` (one DoS-hardening finding fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)