### PR TITLE
docs(service): install the whole release bundle, not just localnode-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,9 +219,12 @@ localnode-cli --config /mnt/usb/localnode.yaml --state-file /mnt/usb/state.json
 
 To run the CLI as a background service that starts on boot and restarts on failure, use the templates under [`examples/`](examples/):
 
-- **Linux (systemd):** [`examples/systemd/localnode.service`](examples/systemd/localnode.service) — a unit that runs `localnode-cli --config /etc/localnode/config.yaml` as a dedicated non-root user with filesystem hardening. The header comments list the exact install steps, or use the transparent helper:
+> **Note:** `localnode-cli` reads its Web UI assets (`data/flutter_assets/…`) from disk next to the executable. Install the **whole extracted release directory** (e.g. to `/opt/localnode`) and run the binary from inside it — not just the single binary, or the server falls back to a minimal HTML page.
+
+- **Linux (systemd):** [`examples/systemd/localnode.service`](examples/systemd/localnode.service) — a unit that runs `/opt/localnode/localnode-cli --config /etc/localnode/config.yaml` as a dedicated non-root user with filesystem hardening. The header comments list the exact install steps, or use the transparent helper:
   ```bash
-  sudo examples/systemd/install-localnode.sh /path/to/localnode-cli
+  tar xzf localnode-linux-x64-v*.tar.gz -C /tmp/localnode-dist
+  sudo examples/systemd/install-localnode.sh /tmp/localnode-dist
   # then edit /etc/localnode/config.yaml and:
   sudo systemctl enable --now localnode
   journalctl -u localnode -f

--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -22,6 +22,12 @@ server:
   port: 8080                     # 待受ポート（既定: 8080）
   ip: 192.168.1.100              # 広告する IP。省略すると自動選択（複数 NIC 時に固定したいなら指定）
   name: home-server              # ブラウザのタブ/タイトルに出すサーバー名（既定: LocalNode）
+  # 書き込み先パス（dir / cache-dir / state-file / pin-file / token-file）について:
+  #   同梱の systemd ユニットで動かす場合、ProtectSystem=strict で `/` は基本
+  #   読み取り専用。書き込み先は systemd 管理dir（/var/lib/localnode,
+  #   /var/cache/localnode, /run/localnode）に入れると ReadWritePaths 無しで動く。
+  #   下の /srv/share のように“管理dirの外”を使うなら、ユニットに
+  #   `ReadWritePaths=/srv/share` を足して chown が必要（examples/systemd/ 参照）。
   dir: /srv/share                # 共有フォルダ。省略するとカレントディレクトリ
   cache-dir: /var/cache/localnode # キャッシュ/一時データ(サムネイル等)の置き場 (#287)。省略時は OS の一時ディレクトリ
   mode: normal                   # normal / download-only（既定: normal）

--- a/examples/launchd/com.ictglab.localnode.plist
+++ b/examples/launchd/com.ictglab.localnode.plist
@@ -8,9 +8,14 @@
       dart compile exe bin/localnode_cli.dart -o localnode-cli
   or point ProgramArguments at the app bundle's binary with --cli.
 
+  NOTE: `localnode-cli` reads its web assets (data/flutter_assets/…) from disk
+  next to the executable, so install the WHOLE extracted release directory, not
+  just the binary, and run the binary from inside it. (On a self-built binary,
+  keep it beside the project's assets/ or the built bundle's data/ folder.)
+
   Install as a system LaunchDaemon (runs at boot, all users):
-    1. sudo cp localnode-cli /usr/local/bin/
-    2. sudo mkdir -p /etc/localnode /usr/local/var/localnode /usr/local/var/log
+    1. sudo mkdir -p /opt/localnode && sudo cp -a /path/to/extracted-release/. /opt/localnode/
+    2. sudo mkdir -p /etc/localnode /usr/local/var/log
        put your config at /etc/localnode/config.yaml (see examples/config.example.yaml)
     3. sudo cp com.ictglab.localnode.plist /Library/LaunchDaemons/
        sudo chown root:wheel /Library/LaunchDaemons/com.ictglab.localnode.plist
@@ -30,7 +35,7 @@
 
     <key>ProgramArguments</key>
     <array>
-        <string>/usr/local/bin/localnode-cli</string>
+        <string>/opt/localnode/localnode-cli</string>
         <string>--config</string>
         <string>/etc/localnode/config.yaml</string>
     </array>

--- a/examples/systemd/install-localnode.sh
+++ b/examples/systemd/install-localnode.sh
@@ -44,22 +44,36 @@ else
   echo "  user '$USER_NAME' already exists, skipping"
 fi
 
-echo "== 3. create directories =="
-run mkdir -p /etc/localnode /var/lib/localnode /var/cache/localnode /srv/share /run/localnode
-# The service runs as $USER_NAME and must be able to write the shared dir and
-# its runtime/state/cache dirs.
-run chown -R "$USER_NAME:$USER_NAME" /var/lib/localnode /var/cache/localnode /run/localnode /srv/share
+echo "== 3. create config directory =="
+# /var/lib, /var/cache, /run/localnode are created and owned automatically by
+# the unit's StateDirectory=/CacheDirectory=/RuntimeDirectory= at start, so we
+# only need the config dir here.
+run mkdir -p /etc/localnode
 
 echo "== 4. config =="
+# Write a MINIMAL working default whose writable paths all live under the
+# systemd-managed dirs, so it starts with the shipped unit as-is (no
+# ReadWritePaths / manual chown needed). config.example.yaml is the full
+# annotated reference — do NOT install it verbatim (it enables HTTPS /
+# federation pointing at paths/hosts that won't exist and would fail to start).
 if [[ ! -f /etc/localnode/config.yaml ]]; then
-  if [[ -f "$SVC_DIR/../config.example.yaml" ]]; then
-    run install -m 0640 "$SVC_DIR/../config.example.yaml" /etc/localnode/config.yaml
-    # Readable by the service user (group), not world-readable (may hold secrets).
-    run chown "root:$USER_NAME" /etc/localnode/config.yaml
-    echo "  >> edit /etc/localnode/config.yaml before starting the service"
-  else
-    echo "  !! config.example.yaml not found; create /etc/localnode/config.yaml yourself"
-  fi
+  cat > /etc/localnode/config.yaml <<'YAML'
+# LocalNode service config — minimal defaults for the systemd unit.
+# All writable paths are under the systemd-managed dirs, so this works with the
+# shipped unit as-is. See /opt/localnode or the repo examples/config.example.yaml
+# for every available option (HTTPS, passkey accounts, federation, etc.).
+server:
+  port: 8080
+  dir: /var/lib/localnode/share          # shared folder (inside StateDirectory)
+  cache-dir: /var/cache/localnode
+  state-file: /var/lib/localnode/state.json
+  # pin: omitted -> a random PIN is generated and printed to the journal at start
+  #   (find it with: journalctl -u localnode | grep -i pin)
+YAML
+  # Readable by the service user (group), not world-readable (may hold secrets).
+  run chown "root:$USER_NAME" /etc/localnode/config.yaml
+  run chmod 0640 /etc/localnode/config.yaml
+  echo "  wrote a minimal /etc/localnode/config.yaml (edit to taste)"
 else
   echo "  /etc/localnode/config.yaml already exists, leaving it"
 fi
@@ -69,6 +83,11 @@ run install -m 0644 "$SVC_DIR/localnode.service" /etc/systemd/system/localnode.s
 run systemctl daemon-reload
 
 echo
-echo "Done. Review /etc/localnode/config.yaml, then:"
+echo "Done. The default config works out of the box. Start it with:"
 echo "  sudo systemctl enable --now localnode"
-echo "  journalctl -u localnode -f"
+echo "  journalctl -u localnode -f      # note the PIN printed on start"
+echo
+echo "To serve files from a path OUTSIDE the managed dirs (e.g. /srv/share or an"
+echo "external disk), set server.dir to it in /etc/localnode/config.yaml AND add"
+echo "  ReadWritePaths=<that path>   to the unit (systemctl edit --full localnode),"
+echo "then: sudo mkdir -p <path> && sudo chown -R $USER_NAME:$USER_NAME <path>"

--- a/examples/systemd/install-localnode.sh
+++ b/examples/systemd/install-localnode.sh
@@ -2,15 +2,21 @@
 # Transparent installer for the LocalNode systemd service (Linux).
 # It only runs the same steps documented in localnode.service — read it first.
 #
-# Usage:
-#   sudo ./install-localnode.sh /path/to/localnode-cli
+# `localnode-cli` needs its web assets (data/flutter_assets/…) next to it, so
+# this installs the WHOLE extracted release directory to /opt/localnode, not
+# just the binary.
 #
-# Re-running is safe: existing user/dirs/config are left as-is.
+# Usage:
+#   tar xzf localnode-linux-x64-v*.tar.gz -C /tmp/localnode-dist
+#   sudo ./install-localnode.sh /tmp/localnode-dist
+#
+# Re-running is safe: existing user/dirs/config are left as-is; /opt/localnode
+# is refreshed from the given directory.
 set -euo pipefail
 
-BIN_SRC="${1:-}"
-if [[ -z "$BIN_SRC" || ! -x "$BIN_SRC" ]]; then
-  echo "usage: sudo $0 /path/to/localnode-cli" >&2
+DIST_SRC="${1:-}"
+if [[ -z "$DIST_SRC" || ! -d "$DIST_SRC" || ! -x "$DIST_SRC/localnode-cli" ]]; then
+  echo "usage: sudo $0 /path/to/extracted-release-dir  (must contain localnode-cli + data/)" >&2
   exit 1
 fi
 if [[ $EUID -ne 0 ]]; then
@@ -20,11 +26,16 @@ fi
 
 SVC_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 USER_NAME=localnode
+INSTALL_DIR=/opt/localnode
 
 run() { echo "+ $*"; "$@"; }
 
-echo "== 1. install binary =="
-run install -m 0755 "$BIN_SRC" /usr/local/bin/localnode-cli
+echo "== 1. install the release bundle to $INSTALL_DIR =="
+run mkdir -p "$INSTALL_DIR"
+# Copy the whole directory (binary + data/flutter_assets + libs). root-owned,
+# read-only for the service user is fine — the CLI only reads its assets.
+run cp -a "$DIST_SRC/." "$INSTALL_DIR/"
+run chmod 0755 "$INSTALL_DIR/localnode-cli"
 
 echo "== 2. create service user (if missing) =="
 if ! id -u "$USER_NAME" >/dev/null 2>&1; then

--- a/examples/systemd/localnode.service
+++ b/examples/systemd/localnode.service
@@ -7,6 +7,8 @@
 # run the binary from inside it. Otherwise the server falls back to a minimal
 # HTML page ("Web assets not found").
 #
+# The install-localnode.sh helper does all of the below; these are the manual steps.
+#
 # Install:
 #   1. Extract the release archive and install the whole directory:
 #        tar xzf localnode-linux-x64-v*.tar.gz -C /tmp/localnode-dist
@@ -14,13 +16,14 @@
 #        sudo cp -a /tmp/localnode-dist/. /opt/localnode/     # localnode-cli + data/ + lib/
 #      (the service user only needs to READ /opt/localnode; keep it root-owned)
 #   2. Create a low-privilege user:  sudo useradd --system --home /var/lib/localnode --shell /usr/sbin/nologin localnode
-#   3. Create dirs and set owner (the service user must be able to write the
-#      shared dir and its runtime/state/cache dirs):
-#        sudo mkdir -p /etc/localnode /var/lib/localnode /var/cache/localnode /srv/share /run/localnode
-#        sudo chown -R localnode:localnode /var/lib/localnode /var/cache/localnode /run/localnode /srv/share
-#   4. Put your config at /etc/localnode/config.yaml (see examples/config.example.yaml)
-#      and make it readable by the service user without being world-readable:
+#   3. Create the config dir:        sudo mkdir -p /etc/localnode
+#      (/var/lib, /var/cache, /run/localnode are created + owned automatically by
+#       the StateDirectory=/CacheDirectory=/RuntimeDirectory= lines below.)
+#   4. Put your config at /etc/localnode/config.yaml, readable by the service user:
 #        sudo chown root:localnode /etc/localnode/config.yaml && sudo chmod 0640 /etc/localnode/config.yaml
+#      Keep server.dir / cache-dir / state-file / pin-file / token-file INSIDE the
+#      managed dirs (/var/lib/localnode, /var/cache/localnode, /run/localnode) and
+#      this unit works as-is. (See the "Writable paths" note below.)
 #   5. Copy this file:               sudo cp localnode.service /etc/systemd/system/
 #   6. Enable + start:               sudo systemctl daemon-reload && sudo systemctl enable --now localnode
 #
@@ -45,15 +48,22 @@ RestartSec=5
 User=localnode
 Group=localnode
 
-# Where the process is allowed to write. Adjust to match your config:
-#   - shared dir (server.dir)
-#   - cache dir  (server.cache-dir)
-#   - state file (server.state-file)
-#   - pin-file / token-file (if used)
+# Writable paths.
+# ProtectSystem=strict makes the filesystem read-only EXCEPT these. The three
+# *Directory= lines create AND own (as the service user) /run/localnode,
+# /var/lib/localnode and /var/cache/localnode. So if your config.yaml keeps its
+# writable paths inside those (the shipped default does):
+#     dir: /var/lib/localnode/share   cache-dir: /var/cache/localnode
+#     state-file: /var/lib/localnode/state.json   pin-file/token-file: /run/localnode/...
+# the unit works as-is and no ReadWritePaths / chown is needed.
+#
+# To serve files from a path OUTSIDE those (e.g. /srv/share or an external disk),
+# set that same path as `server.dir` in config.yaml, uncomment the matching
+# ReadWritePaths below, and `chown -R localnode:localnode` it once.
 RuntimeDirectory=localnode
 StateDirectory=localnode
 CacheDirectory=localnode
-ReadWritePaths=/srv/share
+#ReadWritePaths=/srv/share
 
 # Hardening (loosen only if something legitimately needs more access).
 NoNewPrivileges=true

--- a/examples/systemd/localnode.service
+++ b/examples/systemd/localnode.service
@@ -1,7 +1,18 @@
 # LocalNode CLI as a systemd service (Linux)
 #
+# IMPORTANT: `localnode-cli` is NOT a single self-contained file for serving the
+# Web UI — it reads assets/web/index.html from disk, next to the executable
+# (the release archive ships them at data/flutter_assets/assets/web/...). So do
+# NOT copy just the binary; install the WHOLE extracted release directory and
+# run the binary from inside it. Otherwise the server falls back to a minimal
+# HTML page ("Web assets not found").
+#
 # Install:
-#   1. Copy the standalone binary:   sudo cp localnode-cli /usr/local/bin/
+#   1. Extract the release archive and install the whole directory:
+#        tar xzf localnode-linux-x64-v*.tar.gz -C /tmp/localnode-dist
+#        sudo mkdir -p /opt/localnode
+#        sudo cp -a /tmp/localnode-dist/. /opt/localnode/     # localnode-cli + data/ + lib/
+#      (the service user only needs to READ /opt/localnode; keep it root-owned)
 #   2. Create a low-privilege user:  sudo useradd --system --home /var/lib/localnode --shell /usr/sbin/nologin localnode
 #   3. Create dirs and set owner (the service user must be able to write the
 #      shared dir and its runtime/state/cache dirs):
@@ -24,7 +35,9 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-ExecStart=/usr/local/bin/localnode-cli --config /etc/localnode/config.yaml
+# Run the binary from inside the extracted release dir so it finds its web
+# assets (data/flutter_assets/…) next to itself.
+ExecStart=/opt/localnode/localnode-cli --config /etc/localnode/config.yaml
 Restart=on-failure
 RestartSec=5
 


### PR DESCRIPTION
## Problem

`localnode-cli` is a self-contained Dart executable, but it is **not** a single file for serving the Web UI: it reads `assets/web/index.html` from disk relative to the executable's directory (the release archive ships it at `data/flutter_assets/assets/web/index.html`). The service templates said to `cp localnode-cli /usr/local/bin/` — copying only the binary drops the assets, so the server falls back to a minimal HTML page ("Web assets not found").

## Fix (docs/examples only — no binary changes)

Install the **whole extracted release directory** to `/opt/localnode` and run `/opt/localnode/localnode-cli` from there, so it finds `data/flutter_assets/…` next to itself.

- `examples/systemd/localnode.service` — header + `ExecStart=/opt/localnode/localnode-cli`
- `examples/systemd/install-localnode.sh` — now takes the extracted release dir (with `localnode-cli` + `data/`) and copies it to `/opt/localnode`, instead of a bare binary path
- `examples/launchd/com.ictglab.localnode.plist` — same
- README "Running as a service" — note explaining the asset dependency + updated commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)