### PR TITLE
Web UI: default clipboard sender tag to the passkey account name (#267)

### DIFF
--- a/assets/web/index.html
+++ b/assets/web/index.html
@@ -1300,6 +1300,12 @@
                 document.title = name;
                 document.querySelector('#main-content h1').textContent = name;
                 fetchFiles();
+                // #267: passkey アカウントでログインしているときは、送信元タグの
+                // 既定をアカウント名にする（誰の投稿か分かる＝チャット化）。
+                // 未ログイン/guest はデバイスの OS 名の既定のまま。
+                if (serverInfo.account) {
+                    clipboardTagInput.value = serverInfo.account;
+                }
                 if (serverInfo.clipboardEnabled !== false) startClipboardPolling();
                 applyModeRestrictions();
                 if (serverInfo.version) {


### PR DESCRIPTION
Follow-up to the #267 passkey work, for inclusion in the (not-yet-published) v1.10.0.

The clipboard tag input defaults to the device OS name (Windows/Android/…) and is what the browser always sends, so the server-side "tag defaults to the account name" fallback (#267) never fired for browser posts. Now, when logged in with a passkey account, `showMainContent()` pre-fills the tag input with the account name (`serverInfo.account`) — so a passkey user's clipboard posts are attributed to them by default (the point of the multi-account chat). PIN / guest sessions keep the OS-name default; the field stays editable; clearing it still falls back to the account name server-side.

Web UI only (assets/web/index.html) — needs a rebuild to take effect in the release binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)